### PR TITLE
Adjust app extension filters to new fields

### DIFF
--- a/saleor/graphql/app/filters.py
+++ b/saleor/graphql/app/filters.py
@@ -2,7 +2,7 @@ import django_filters
 
 from ...app import models
 from ...app.types import AppExtensionTarget, AppType
-from ..core.descriptions import DEPRECATED_IN_3X_INPUT
+from ..core.descriptions import ADDED_IN_322, DEPRECATED_IN_3X_INPUT
 from ..core.filters import EnumFilter, ListObjectTypeFilter
 from .enums import AppExtensionMountEnum, AppExtensionTargetEnum, AppTypeEnum
 
@@ -66,11 +66,11 @@ class AppExtensionFilter(django_filters.FilterSet):
     )
     mountName = django_filters.CharFilter(
         method=filter_app_extension_mount_name,
-        help_text="Plain-text mount name (case insensitive)",
+        help_text="Plain-text mount name (case insensitive)" + ADDED_IN_322,
     )
     targetName = django_filters.CharFilter(
         method=filter_app_extension_target_name,
-        help_text="Plain-text target name (case insensitive)",
+        help_text="Plain-text target name (case insensitive)" + ADDED_IN_322,
     )
 
     class Meta:

--- a/saleor/graphql/app/tests/queries/test_app_extensions.py
+++ b/saleor/graphql/app/tests/queries/test_app_extensions.py
@@ -285,7 +285,7 @@ def test_app_extensions_with_name_filter(
     filter, expected_count, staff_api_client, app, permission_manage_products
 ):
     # given
-    app_extensions = AppExtension.objects.bulk_create(
+    AppExtension.objects.bulk_create(
         [
             AppExtension(
                 app=app,
@@ -315,7 +315,6 @@ def test_app_extensions_with_name_filter(
             ),
         ]
     )
-    app_extensions[0].permissions.add(permission_manage_products)
     variables = {"filter": filter}
 
     # when

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14849,10 +14849,18 @@ input AppExtensionFilterInput @doc(category: "Apps") {
   """DEPRECATED: Use `targetName` instead."""
   target: AppExtensionTargetEnum @deprecated
 
-  """Plain-text mount name (case insensitive)"""
+  """
+  Plain-text mount name (case insensitive)
+  
+  Added in Saleor 3.22.
+  """
   mountName: String
 
-  """Plain-text target name (case insensitive)"""
+  """
+  Plain-text target name (case insensitive)
+  
+  Added in Saleor 3.22.
+  """
   targetName: String
 }
 


### PR DESCRIPTION
Updates appExtensions input for filtering to match newly added fields. They work with backwards compatible manner which made me to use case-insensitive approach (on the migration phase).

In main/3.23 enums will be NOT stored anymore, values will be uppercase strings in DB (or any strings actually) and filter can be case-sensitive again

https://github.com/saleor/saleor/pull/18480