### PR TITLE
Feature admin email cred customization populatedb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,6 @@ All notable, unreleased changes to this project will be documented in this file.
 
 - Fix send order confirmation email to staff - #18342 by @Shaokun-X
 
+- Add possability to customize email and password using --superuser_email --superuser_password flags when populating database with example data - #18467
+
 ### Deprecations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,7 @@ uv run poe populatedb
 
 > [!NOTE]
 > `populatedb` populates database with example data and creates an admin account for `admin@example.com` with the password set to `admin`.*
+> You can customize email and password using --superuser_email --superuser_password flags
 
 To build `schema.graphql` file:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ populatedb.help = """
 Populates database with sample data and creates admin user with credentials:
 - email: admin@example.com
 - password: admin
+With --superuser_email and --superuser_password arguments you can customize admin user credentials.
 """
 
 test.cmd="pytest --reuse-db"

--- a/saleor/core/management/commands/populatedb.py
+++ b/saleor/core/management/commands/populatedb.py
@@ -45,6 +45,7 @@ class Command(BaseCommand):
         )
         parser.add_argument("--user_password", type=str, default="password")
         parser.add_argument("--staff_password", type=str, default="password")
+        parser.add_argument("--superuser_email", type=str, default="admin@example.com")
         parser.add_argument("--superuser_password", type=str, default="admin")
         parser.add_argument(
             "--withoutimages",
@@ -82,6 +83,7 @@ class Command(BaseCommand):
         # example database
         user_password = options["user_password"]
         staff_password = options["staff_password"]
+        superuser_email = options["superuser_email"]
         superuser_password = options["superuser_password"]
 
         create_images = not options["withoutimages"]
@@ -124,7 +126,7 @@ class Command(BaseCommand):
 
         if options["createsuperuser"]:
             credentials = {
-                "email": "admin@example.com",
+                "email": superuser_email,
                 "password": superuser_password,
             }
             msg = create_superuser(credentials)


### PR DESCRIPTION
User would like to customize the email address when setting up the initial database poopulation using:

`python3 manage.py populatedb --createsuperuser`

I want to merge this change because currently there is no way of setting up admin email via flags when using populatedb.py.

User should be able to customize the email and password with using --superuser_email --superuser_password flags.

Relevant issue numbers: #18467
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [x] user can customize admin email when using populatedb.py

# Docs
See commit changes

- [ ] Link to documentation: see commit changes

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
