### PR TITLE
Release 3.22.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.8",
+  "version": "3.22.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.8",
+      "version": "3.22.9",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.8",
+  "version": "3.22.9",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,4 +292,4 @@ target-version = "py312"
     known-first-party = [ "saleor" ]
 
 [tool.poetry]
-version = "3.22.8"
+version = "3.22.9"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.8"
+__version__ = "3.22.9"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Fix negative unit price on gift line in case promotion gift reward changes (#18462) (8588a72c2e)
* Do not trigger order_charged webhooks for draft orders (#18456) (fdabcdb0ee)
* Fix a bug with refund reason required for non-refund action (#18449) (0dc310c9f5)
