### PR TITLE
Fix empty country code in AddressInput.

### DIFF
--- a/saleor/core/utils/country.py
+++ b/saleor/core/utils/country.py
@@ -24,7 +24,7 @@ def get_active_country(
 
     To get country code from address data from mutation input use address_data parameter
     """
-    if address_data is not None:
+    if address_data is not None and address_data.country:
         return address_data.country
 
     if shipping_address:

--- a/saleor/tax/tests/test_utils.py
+++ b/saleor/tax/tests/test_utils.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from unittest.mock import Mock
 
 import pytest
 
@@ -116,6 +117,34 @@ def test_get_tax_country_fallbacks_to_channel_country(channel_USD):
 
     # when
     country = get_active_country(channel_USD, shipping_address, billing_address)
+
+    # then
+    assert country == channel_USD.default_country.code
+
+
+def test_get_tax_country_use_address_data(
+    channel_USD,
+):
+    # given
+    address_data = Mock()
+    address_data.country = "PL"
+
+    # when
+    country = get_active_country(channel_USD, address_data=address_data)
+
+    # then
+    assert country == "PL"
+
+
+def test_get_tax_country_fallbacks_to_channel_country_address_data_with_empty_country(
+    channel_USD,
+):
+    # given
+    address_data = Mock()
+    address_data.country = None
+
+    # when
+    country = get_active_country(channel_USD, address_data=address_data)
 
     # then
     assert country == channel_USD.default_country.code


### PR DESCRIPTION
I want to merge this change because it fixes the empty country code in AddressInput.

Example query:
```graphql
query Produ($first: Int, $channel: String!, $country: CountryCode){
  products(first: $first,  channel: $channel) {
    edges {
      node {
        defaultVariant{
          pricing(address: {country: $country}){
            price{
              gross{
                amount
              }
            }
          }
        }
        pricing(address: {country: $country}) {
          priceRange {
            start {
              gross {
                amount
              }
            }
          }
        }
      }
    }
  }
}
```

Example variables:
``` json
{
  "first": 1,
  "channel": "default-channel"
}
```
⚠️ 
The country should be set to an empty value. 


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
