### PR TITLE
Release 3.22.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.9",
+  "version": "3.22.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.9",
+      "version": "3.22.10",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.9",
+  "version": "3.22.10",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,4 +292,4 @@ target-version = "py312"
     known-first-party = [ "saleor" ]
 
 [tool.poetry]
-version = "3.22.9"
+version = "3.22.10"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.9"
+__version__ = "3.22.10"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.22.10 (cc4cc86fd8)
* Fix missing external shipping metadata on the order  (#18474) (f9752f7b72)
* Unify webhooks metrics and attributes (#18470) (#18481) (332edc0fd6)
* Fix flaky test for discount recalculation (#18477) (5e4d7c88ef)
