### PR TITLE
Replace redis with valkey and run tests with valkey service

### DIFF
--- a/.devcontainer/backend.env
+++ b/.devcontainer/backend.env
@@ -1,7 +1,8 @@
 DATABASE_URL=postgres://saleor:saleor@db/saleor
 DASHBOARD_URL=http://localhost:9000/
 DEFAULT_FROM_EMAIL=noreply@example.com
-CELERY_BROKER_URL=redis://redis:6379/1
+CACHE_URL=redis://cache:6379/0
+CELERY_BROKER_URL=redis://cache:6379/1
 SECRET_KEY=changeme
 # Mailpit
 EMAIL_URL=smtp://mailpit:1025

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
     8000,
     "dashboard:9000",
     "mailpit:8025",
-    "db:5432"
+    "db:5432",
+    "cache:6379"
   ],
   "portsAttributes": {
     "8000": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   saleor:
     image: saleor
@@ -12,7 +10,7 @@ services:
       - backend.env
     depends_on:
       - db
-      - redis
+      - cache
     volumes:
       - ..:/app
 
@@ -25,7 +23,7 @@ services:
   db:
     image: library/postgres:15-alpine
     ports:
-     - 5432:5432
+      - 5432:5432
     restart: unless-stopped
     volumes:
       - saleor-db:/var/lib/postgresql/data
@@ -33,11 +31,11 @@ services:
       - POSTGRES_USER=saleor
       - POSTGRES_PASSWORD=saleor
 
-  redis:
-    image: library/redis:7.0-alpine
+  cache:
+    image: valkey/valkey:8.1-alpine
     restart: unless-stopped
     volumes:
-      - saleor-redis:/data
+      - saleor-cache:/data
     ports:
       - 6379:6379
 
@@ -51,5 +49,5 @@ services:
 volumes:
   saleor-db:
     driver: local
-  saleor-redis:
+  saleor-cache:
     driver: local

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+CACHE_URL=redis://localhost:6379/0
 CELERY_BROKER_URL=redis://localhost:6379/1
 DEFAULT_FROM_EMAIL=noreply@example.com
 EMAIL_URL=smtp://localhost:1025

--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -24,6 +24,7 @@ on:
 
 env:
   BENCH_PATH: ./queries-results.json
+  CACHE_URL: "redis://cache:6379/0"
   DATABASE_URL: "postgres://saleor:saleor@postgres:5432/saleor"
   SECRET_KEY: ci-test
 
@@ -47,6 +48,13 @@ jobs:
           POSTGRES_USER: saleor
         options: >-
           --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      cache:
+        image: valkey/valkey:8.1-alpine
+        options: >-
+          --health-cmd "valkey-cli ping | grep PONG"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Clone this [repository](https://github.com/saleor/saleor) and setup database and
 
 ```shell
 cd .devcontainer
-docker compose up db dashboard redis mailpit
+docker compose up db dashboard cache mailpit
 ```
 
 To create virtualenv and install dependencies run in root of the repository:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ exclude_lines =
     @overload
 
 [tool:pytest]
-addopts = -n auto --record-mode=none --ds=saleor.tests.settings --disable-socket --allow-unix-socket --pdbcls=IPython.terminal.debugger:TerminalPdb
+addopts = -n auto --record-mode=none --ds=saleor.tests.settings --disable-socket --allow-hosts 127.0.0.1,::1,cache --allow-unix-socket --pdbcls=IPython.terminal.debugger:TerminalPdb
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = fixture
 testpaths = saleor


### PR DESCRIPTION
We want to switch the default cache backend to Valkey because cloud providers (such as AWS and GCP) no longer support latest Redis versions due to AGPLv3 license. Valkey is also a more performant engine which should benefit users. (see: https://aws.amazon.com/elasticache/what-is-valkey/)

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
