### PR TITLE
Replace redis with valkey and run tests with valkey service

### DIFF
--- a/.devcontainer/backend.env
+++ b/.devcontainer/backend.env
@@ -1,7 +1,8 @@
 DATABASE_URL=postgres://saleor:saleor@db/saleor
 DASHBOARD_URL=http://localhost:9000/
 DEFAULT_FROM_EMAIL=noreply@example.com
-CELERY_BROKER_URL=redis://redis:6379/1
+CACHE_URL=redis://cache:6379/0
+CELERY_BROKER_URL=redis://cache:6379/1
 SECRET_KEY=changeme
 # Mailpit
 EMAIL_URL=smtp://mailpit:1025

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
   "forwardPorts": [
     8000,
     "dashboard:9000",
-    "mailpit:8025"
+    "mailpit:8025",
+    "db:5432",
+    "cache:6379"
   ],
   "portsAttributes": {
     "8000": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   saleor:
     image: saleor
@@ -12,7 +10,7 @@ services:
       - backend.env
     depends_on:
       - db
-      - redis
+      - cache
     volumes:
       - ..:/app
 
@@ -23,7 +21,9 @@ services:
       - 9000:80
 
   db:
-    image: library/postgres:13-alpine
+    image: library/postgres:15-alpine
+    ports:
+      - 5432:5432
     restart: unless-stopped
     volumes:
       - saleor-db:/var/lib/postgresql/data
@@ -31,11 +31,13 @@ services:
       - POSTGRES_USER=saleor
       - POSTGRES_PASSWORD=saleor
 
-  redis:
-    image: library/redis:7.0-alpine
+  cache:
+    image: valkey/valkey:8.1-alpine
     restart: unless-stopped
     volumes:
-      - saleor-redis:/data
+      - saleor-cache:/data
+    ports:
+      - 6379:6379
 
   mailpit:
     image: axllent/mailpit
@@ -47,5 +49,5 @@ services:
 volumes:
   saleor-db:
     driver: local
-  saleor-redis:
+  saleor-cache:
     driver: local

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,6 +24,7 @@ on:
 
 env:
   BENCH_PATH: ./queries-results.json
+  CACHE_URL: "redis://cache:6379/0"
   DATABASE_URL: "postgres://saleor:saleor@postgres:5432/saleor"
   SECRET_KEY: ci-test
 
@@ -40,6 +41,13 @@ jobs:
           POSTGRES_USER: saleor
         options: >-
           --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      cache:
+        image: valkey/valkey:8.1-alpine
+        options: >-
+          --health-cmd "valkey-cli ping | grep PONG"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ exclude_lines =
     @overload
 
 [tool:pytest]
-addopts = -n auto --record-mode=none --ds=saleor.tests.settings --disable-socket --allow-unix-socket
+addopts = -n auto --record-mode=none --ds=saleor.tests.settings --disable-socket --allow-hosts 127.0.0.1,::1,cache --allow-unix-socket
 asyncio_mode = auto
 testpaths = saleor
 filterwarnings =


### PR DESCRIPTION
Port of #18500 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
