### PR TITLE
Disable pre-commit on release workflow 

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -2,7 +2,8 @@
   "git": {
     "commit": true,
     "tag": false,
-    "push": false
+    "push": false,
+    "commitArgs": ["-n"]
   },
   "github": {
     "release": false


### PR DESCRIPTION
Disabled pre-commit on release workflow (using relase-it). Precommit is not needed - release contains only metadata updates. At the same time it executes mypy which fails to execute. This requires developers to directly remove precommit logic (clean repo) to actually make a release (!) or do other workarounds

This can be reverted once we update mypy to 1.18 which should fix several known issues

Port of https://github.com/saleor/saleor/pull/18510