### PR TITLE
Release 3.22.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.11",
+  "version": "3.22.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.11",
+      "version": "3.22.12",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.11",
+  "version": "3.22.12",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,4 +292,4 @@ target-version = "py312"
     known-first-party = [ "saleor" ]
 
 [tool.poetry]
-version = "3.22.11"
+version = "3.22.12"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.11"
+__version__ = "3.22.12"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.22.12 (434c0b03a7)
* Fix bug with mountName filter (#18509) (bda2d2ef62)
* Replace redis with valkey and run tests with valkey service (#18501) (099d642440)
