### PR TITLE
Add circuit breaker event count metric

### DIFF
--- a/saleor/core/telemetry/saleor_attributes.py
+++ b/saleor/core/telemetry/saleor_attributes.py
@@ -26,3 +26,6 @@ SALEOR_APP_NAME: Final = "saleor.app.name"
 SALEOR_WEBHOOK_EXECUTION_MODE: Final = "saleor.webhook.execution_mode"
 SALEOR_WEBHOOK_EVENT_TYPE: Final = "saleor.webhook.event_type"
 SALEOR_WEBHOOK_PAYLOAD_SIZE: Final = "saleor.webhook.payload.size"
+
+# Circuit Breaker
+SALEOR_CIRCUIT_BREAKER_STATE: Final = "saleor.circuit_breaker.state"

--- a/saleor/core/telemetry/utils.py
+++ b/saleor/core/telemetry/utils.py
@@ -35,6 +35,7 @@ class Unit(Enum):
     REQUEST = "{request}"
     BYTE = "By"
     COST = "{cost}"
+    EVENT = "{event}"
 
 
 UNIT_CONVERSIONS: dict[tuple[Unit, Unit], float] = {


### PR DESCRIPTION
I want to merge this change because we want better monitoring of circuit breaker.
Currently it reports only logs which are gone after couple of days due to relatively short retention period.

I decided to create a new metric because:
- it is persistent
- it's easy to use in Datadog dashboards and monitors

Unlike log-based metrics it also:
- can be shared with customers
- has compatible attributes with other webhook metrics

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
