### PR TITLE
Add custom scheduler for automatic checkout completion

### DIFF
--- a/saleor/core/schedules.py
+++ b/saleor/core/schedules.py
@@ -3,6 +3,7 @@ from typing import NamedTuple, cast
 
 from celery.utils.time import maybe_timedelta, remaining
 from django.db.models import F, Q
+from django.utils import timezone
 
 from ..schedulers.customschedule import CustomSchedule
 
@@ -125,4 +126,105 @@ class promotion_webhook_schedule(CustomSchedule):
         return schedstate(is_due, self.next_run.total_seconds())
 
 
+class TimeBaseSchedule(CustomSchedule):
+    """Base schedule for time-based periodic tasks.
+
+    Arguments:
+        import_path (str): Import path of the schedule.
+        initial_timedelta (float, ~datetime.timedelta):
+            Initial time interval in seconds.
+        nowfun (Callable): Function returning the current date and time
+            (:class:`~datetime.datetime`).
+        app (Celery): Celery app instance.
+
+    """
+
+    class Meta:
+        abstract = True
+
+    def __init__(self, import_path: str, initial_timedelta, nowfun=None, app=None):
+        self.initial_timedelta: datetime.timedelta = cast(
+            datetime.timedelta, maybe_timedelta(initial_timedelta)
+        )
+        self.next_run: datetime.timedelta = self.initial_timedelta
+        super().__init__(
+            schedule=self,
+            nowfun=nowfun,
+            app=app,
+            import_path=import_path,
+        )
+
+    def are_dirty(self) -> bool:
+        raise NotImplementedError
+
+    def remaining_estimate(self, last_run_at):
+        """Estimate of next run time.
+
+        Returns when the periodic task should run next as a timedelta.
+        """
+        return remaining(
+            self.maybe_make_aware(last_run_at),
+            self.next_run,
+            self.maybe_make_aware(self.now()),
+        )
+
+    def is_due(self, last_run_at):
+        """Return tuple of ``(is_due, next_time_to_run)``.
+
+        Note:
+            Next time to run is in seconds.
+
+        """
+        last_run_at = self.maybe_make_aware(last_run_at)
+        rem_delta = self.remaining_estimate(last_run_at)
+        remaining_s = max(rem_delta.total_seconds(), 0)
+        if remaining_s == 0:
+            remaining_s = self.initial_timedelta.total_seconds()
+
+        are_marked_as_dirty = self.are_dirty()
+        return schedstate(is_due=are_marked_as_dirty, next=remaining_s)
+
+
+class checkout_automatic_completion_schedule(TimeBaseSchedule):
+    def __init__(self, initial_timedelta=60, nowfun=None, app=None):
+        # initial_timedelta defaults to 60 seconds, as referencing settings.py variables
+        # would require rebuilding the schedule. settings depends on this class instance,
+        # leading to a circular import if accessed directly.
+        import_path = (
+            "saleor.core.schedules.initiated_checkout_automatic_completion_schedule"
+        )
+        super().__init__(import_path, initial_timedelta, nowfun, app)
+
+    def are_dirty(self) -> bool:
+        from django.conf import settings
+
+        from ..channel.models import Channel
+        from ..checkout import CheckoutAuthorizeStatus
+        from ..checkout.models import Checkout
+
+        channels = Channel.objects.filter(
+            automatically_complete_fully_paid_checkouts=True
+        )
+        for channel in channels:
+            # calculate threshold time for automatic completion for given channel
+            delay_minutes = channel.automatic_completion_delay or 0
+            threshold_time = timezone.now() - datetime.timedelta(
+                minutes=float(delay_minutes)
+            )
+            if (
+                Checkout.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+                .filter(
+                    authorize_status=CheckoutAuthorizeStatus.FULL,
+                    channel_id=channel.pk,
+                    last_change__lt=threshold_time,
+                )
+                .exists()
+            ):
+                return True
+        return False
+
+
 initiated_promotion_webhook_schedule = promotion_webhook_schedule()
+initiated_checkout_automatic_completion_schedule = (
+    checkout_automatic_completion_schedule()
+)

--- a/saleor/core/tests/test_schedules.py
+++ b/saleor/core/tests/test_schedules.py
@@ -5,8 +5,13 @@ from django.utils import timezone
 from django.utils.module_loading import import_string
 from freezegun import freeze_time
 
+from ...checkout import CheckoutAuthorizeStatus
+from ...checkout.models import Checkout
 from ...discount.models import Promotion
-from ..schedules import promotion_webhook_schedule
+from ..schedules import (
+    checkout_automatic_completion_schedule,
+    promotion_webhook_schedule,
+)
 
 
 @freeze_time("2020-10-10 12:00:00")
@@ -226,3 +231,52 @@ def test_promotion_webhook_schedule_import_path():
 
     # then
     assert isinstance(scheduler_instance, BaseSchedule)
+
+
+@freeze_time("2020-10-10 12:00:00")
+def test_automatic_completion_update_schedule_remaining_estimate_initial_state():
+    # given
+    schedule = checkout_automatic_completion_schedule()
+
+    # when
+    remaining = schedule.remaining_estimate(last_run_at=timezone.now())
+
+    # then
+    assert remaining == schedule.initial_timedelta
+
+
+@freeze_time("2020-10-10 12:00:00")
+def test_automatic_completion_schedule_remaining_estimate():
+    # given
+    schedule = checkout_automatic_completion_schedule()
+    time_delta = datetime.timedelta(seconds=30)
+
+    # when
+    remaining = schedule.remaining_estimate(last_run_at=timezone.now() - time_delta)
+
+    # then
+    assert remaining == schedule.initial_timedelta - time_delta
+
+
+def test_automatic_completion_schedule_are_dirty(checkout_with_prices, channel_USD):
+    # given
+    schedule = checkout_automatic_completion_schedule()
+    channel_USD.automatically_complete_fully_paid_checkouts = True
+    channel_USD.automatic_completion_delay = 5
+    channel_USD.save(
+        update_fields=[
+            "automatically_complete_fully_paid_checkouts",
+            "automatic_completion_delay",
+        ]
+    )
+    Checkout.objects.update(
+        authorize_status=CheckoutAuthorizeStatus.FULL,
+        last_change=timezone.now() - datetime.timedelta(minutes=7),
+    )
+
+    # when
+    is_due, next_run = schedule.is_due(timezone.now() - datetime.timedelta(minutes=1))
+
+    # then
+    assert is_due is True
+    assert next_run == schedule.initial_timedelta.total_seconds()


### PR DESCRIPTION
Add custom scheduler for automatic checkout completion to not run the task in case there is no need.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
