### PR TITLE
test-env-cleanup-cron workflow now uses slugified branch names as input for test-env-manager lambda

### DIFF
--- a/.github/workflows/test-env-cleanup-cron.yml
+++ b/.github/workflows/test-env-cleanup-cron.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_TESTENVS_ACCOUNT_ID }}:role/${{ secrets.AWS_TESTENVS_CICD_ROLE_NAME }}
           aws-region: ${{ vars.AWS_TESTENVS_REGION }}
@@ -38,8 +38,17 @@ jobs:
               .filter(pr => pr.labels.some(label => label.name === 'test deployment'))
               .map(pr => pr.head.ref);
 
-            // Deduplicate (in case there are multiple PRs with the same source branch)
-            return [...new Set(branches)];
+            // Deduplicate (in case there are multiple PRs with the same source branch) and then slugify the branch names
+            // using the same logic as https://github.com/marketplace/actions/github-slug-action#overview (this GHA is used 
+            // to slugify branch names in the https://github.com/saleor/saleor/actions/workflows/test-env-deploy.yml workflow,
+            // which this workflow cleans up after).
+            return [...new Set(branches)].map(ref =>
+              ref.toLowerCase()
+                .replace(/[^a-z0-9._]/g, '-')    // replace any character except [0-9, a-z, .,_] with dash
+                .replace(/^-+/, '')              // remove leading -
+                .slice(0, 63)                    // limit to 63
+                .replace(/-+$/, '')              // remove trailing -
+            );
 
       - name: Invoke test-env-manager lambda
         uses: gagoar/invoke-aws-lambda@2ea0b5791eba7a9513ddf0fb7f91aa8f098b6458 # v3.4.0


### PR DESCRIPTION
This fixes issue reported in the linear ticket: https://linear.app/saleor/issue/ENG-805/bug-test-env-cleanup-cron-removes-active-env