### PR TITLE
Prevent raising `DatabaseError` in `CheckoutComplete`

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -390,12 +390,16 @@ def _fetch_checkout_prices_if_expired(
         checkout_info, database_connection_name
     )
 
-    recalculate_discounts(
-        checkout_info,
-        lines,
-        database_connection_name=database_connection_name,
-        force_update=force_update,
-    )
+    try:
+        recalculate_discounts(
+            checkout_info,
+            lines,
+            database_connection_name=database_connection_name,
+            force_update=force_update,
+        )
+    except Checkout.DoesNotExist:
+        # Checkout was removed or converted to a order. Return data without saving.
+        return checkout_info, lines
 
     checkout.tax_error = None
 
@@ -530,9 +534,8 @@ def recalculate_discounts(
     else:
         checkout.discount_expiration = timezone.now() + settings.CHECKOUT_PRICES_TTL
 
-    checkout.save(
+    checkout.safe_update(
         update_fields=["discount_expiration"],
-        using=settings.DATABASE_CONNECTION_DEFAULT_NAME,
     )
 
     return checkout_info, lines

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -1493,3 +1493,38 @@ def test_fetch_checkout_data_checkout_updated_during_price_recalculation(
     assert checkout.email == expected_email
     for old_line, new_line in zip(lines, checkout.lines.all(), strict=True):
         assert old_line.quantity + 1 == new_line.quantity
+
+
+def test_fetch_checkout_data_checkout_deleted_during_discount_recalculation(
+    checkout_with_item_and_order_discount,
+):
+    # given
+    checkout = checkout_with_item_and_order_discount
+    checkout.price_expiration = timezone.now()
+    checkout.save(update_fields=["price_expiration"])
+
+    manager = get_plugins_manager(allow_replica=False)
+    lines_info, _ = fetch_checkout_lines(checkout)
+    fetch_kwargs = {
+        "checkout_info": fetch_checkout_info(checkout, lines_info, manager),
+        "manager": manager,
+        "lines": lines_info,
+    }
+
+    # when
+    def delete_checkout(*args, **kwargs):
+        Checkout.objects.filter(pk=checkout.pk).delete()
+
+    with patch(
+        "saleor.checkout.calculations.recalculate_discounts",
+        side_effect=delete_checkout,
+    ):
+        result_checkout_info, result_lines_info = fetch_checkout_data(**fetch_kwargs)
+
+    # then
+    # Check if checkout was deleted.
+    with pytest.raises(Checkout.DoesNotExist):
+        checkout.refresh_from_db()
+
+    assert result_checkout_info.checkout.total is not None
+    assert result_lines_info

--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -7,7 +7,7 @@ from django.test import override_settings
 from prices import Money, TaxedMoney
 
 from ...channel import MarkAsPaidStrategy
-from ...checkout.models import Checkout, CheckoutLine
+from ...checkout.models import CheckoutLine
 from ...core.exceptions import InsufficientStock
 from ...core.prices import quantize_price
 from ...core.taxes import (
@@ -836,41 +836,6 @@ def test_note_in_created_order_checkout_line_deleted_in_the_meantime(
 
     # then
     assert order
-
-
-def test_note_in_created_order_checkout_deleted_in_the_meantime(
-    checkout_with_item, address, shipping_method, app, voucher_percentage
-):
-    # given
-    checkout_with_item.voucher_code = voucher_percentage.code
-    checkout_with_item.shipping_address = address
-    checkout_with_item.billing_address = address
-    checkout_with_item.shipping_method = shipping_method
-    checkout_with_item.tracking_code = "tracking_code"
-    checkout_with_item.redirect_url = "https://www.example.com"
-    checkout_with_item.save()
-    manager = get_plugins_manager(allow_replica=False)
-
-    checkout_lines, _ = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, checkout_lines, manager)
-
-    def delete_checkout(*args, **kwargs):
-        Checkout.objects.get(pk=checkout_with_item.pk).delete()
-
-    # when
-    with race_condition.RunAfter(
-        "saleor.checkout.complete_checkout._increase_voucher_code_usage_value",
-        delete_checkout,
-    ):
-        order = create_order_from_checkout(
-            checkout_info=checkout_info,
-            manager=manager,
-            user=None,
-            app=app,
-        )
-
-    # then
-    assert order is None
 
 
 @mock.patch("saleor.checkout.calculations.checkout_line_total")

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -1062,7 +1062,7 @@ def clear_delivery_method(
     if updated_fields:
         updated_fields.append("last_change")
         if save:
-            checkout.save(update_fields=updated_fields)
+            checkout.safe_update(updated_fields)
 
     return updated_fields
 

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -422,7 +422,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(87):
+    with django_assert_num_queries(90):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -440,7 +440,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(87):
+    with django_assert_num_queries(90):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -572,7 +572,7 @@ def test_create_checkout_with_order_promotion(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(93):
+    with django_assert_num_queries(96):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
 
     # then
@@ -828,7 +828,7 @@ def test_update_checkout_lines_with_reservations(
     )
 
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(109):
+    with django_assert_num_queries(112):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -842,7 +842,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(109):
+    with django_assert_num_queries(112):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -1103,7 +1103,7 @@ def test_add_checkout_lines_with_reservations(
 
     user_api_client.ensure_access_token()
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(106):
+    with django_assert_num_queries(109):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -1116,7 +1116,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(106):
+    with django_assert_num_queries(109):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,
@@ -1167,7 +1167,7 @@ def test_add_checkout_lines_catalogue_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(97):
+    with django_assert_num_queries(100):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1253,7 +1253,7 @@ def test_add_checkout_lines_multiple_catalogue_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(97):
+    with django_assert_num_queries(100):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1289,7 +1289,7 @@ def test_add_checkout_lines_order_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(103):
+    with django_assert_num_queries(106):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then
@@ -1324,7 +1324,7 @@ def test_add_checkout_lines_gift_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(135):
+    with django_assert_num_queries(138):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -661,3 +661,93 @@ def test_checkout_complete_existing_user_address_save_address_options_off(
 
     assert order.draft_save_billing_address is None
     assert order.draft_save_shipping_address is None
+
+
+@mock.patch(
+    "saleor.graphql.checkout.mutations.checkout_complete.CheckoutComplete.validate_checkout_addresses"
+)
+def test_checkout_complete_validate_checkout_addresses_raises_does_not_exist_error(
+    validate_addresses_mock,
+    user_api_client,
+    checkout_with_item,
+    shipping_method,
+    address,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.billing_address = address
+    checkout.shipping_address = address
+    checkout.save_shipping_address = False
+    checkout.save_billing_address = False
+    checkout.shipping_method = shipping_method
+    checkout.save(
+        update_fields=[
+            "billing_address",
+            "shipping_address",
+            "save_shipping_address",
+            "save_billing_address",
+            "shipping_method",
+        ]
+    )
+    validate_addresses_mock.side_effect = Checkout.DoesNotExist()
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": "https://www.example.com",
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["code"] == CheckoutErrorCode.NOT_FOUND.name
+
+
+@mock.patch(
+    "saleor.graphql.checkout.mutations.checkout_complete.CheckoutComplete.validate_checkout_addresses"
+)
+def test_checkout_complete_validate_checkout_addresses_raises_does_not_exist_error_order_returned(
+    validate_addresses_mock,
+    user_api_client,
+    checkout_with_item,
+    order,
+    shipping_method,
+    address,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.billing_address = address
+    checkout.shipping_address = address
+    checkout.save_shipping_address = False
+    checkout.save_billing_address = False
+    checkout.shipping_method = shipping_method
+    checkout.save(
+        update_fields=[
+            "billing_address",
+            "shipping_address",
+            "save_shipping_address",
+            "save_billing_address",
+            "shipping_method",
+        ]
+    )
+    validate_addresses_mock.side_effect = Checkout.DoesNotExist()
+    order.checkout_token = checkout.pk
+    order.save(update_fields=["checkout_token"])
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": "https://www.example.com",
+    }
+
+    # when
+
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+    assert data["order"]


### PR DESCRIPTION
Prevent raising `DatabaseError` in case save is called with `update_fields` on non existing instance.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
