### PR TITLE
Enable test aggregation grouped by the 'xdist_group' mark

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ exclude_lines =
     @overload
 
 [tool:pytest]
-addopts = -n auto --record-mode=none --ds=saleor.tests.settings --disable-socket --allow-hosts 127.0.0.1,::1,cache --allow-unix-socket --pdbcls=IPython.terminal.debugger:TerminalPdb
+addopts = -n auto --record-mode=none --ds=saleor.tests.settings --disable-socket --allow-hosts 127.0.0.1,::1,cache --allow-unix-socket --pdbcls=IPython.terminal.debugger:TerminalPdb --dist loadgroup
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = fixture
 testpaths = saleor


### PR DESCRIPTION
I want to merge this change to enable test aggregation grouped by the 'xdist_group' marker, to avoid a race condition in the garbage collection tests. 

`--dist loadgroup` is added to `pytest` to prevent test Interference. [Docs. ](https://pytest-xdist.readthedocs.io/en/stable/distribution.html)

> `--dist loadgroup`: Tests are grouped by the xdist_group mark. Groups are distributed to available workers as whole units. This guarantees that all tests with same xdist_group name run in the same worker.

Port #18533 

It's implemented in 3.20: https://github.com/saleor/saleor/blob/3.20/setup.cfg#L19

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
