### PR TITLE
Do not update `last_change` in checkout prices recalculations

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -460,7 +460,6 @@ def _fetch_checkout_prices_if_expired(
                     "discount_amount",
                     "discount_name",
                     "currency",
-                    "last_change",
                     "price_expiration",
                     "discount_expiration",
                     "tax_error",

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -1377,13 +1377,15 @@ def test_fetch_checkout_data_checkout_updated_during_price_recalculation(
         "lines": lines_info,
     }
     expected_email = "new_email@example.com"
+    freeze_time_str = "2024-01-01T12:00:00+00:00"
 
     # when
     def modify_checkout(*args, **kwargs):
-        checkout_to_modify = Checkout.objects.get(pk=checkout.pk)
-        checkout_to_modify.lines.update(quantity=F("quantity") + 1)
-        checkout_to_modify.email = expected_email
-        checkout_to_modify.save(update_fields=["email", "last_change"])
+        with freeze_time(freeze_time_str):
+            checkout_to_modify = Checkout.objects.get(pk=checkout.pk)
+            checkout_to_modify.lines.update(quantity=F("quantity") + 1)
+            checkout_to_modify.email = expected_email
+            checkout_to_modify.save(update_fields=["email", "last_change"])
 
     with race_condition.RunAfter(
         "saleor.checkout.calculations._calculate_and_add_tax", modify_checkout
@@ -1404,7 +1406,8 @@ def test_fetch_checkout_data_checkout_updated_during_price_recalculation(
 
     # Check if database contains updated checkout by other requests.
     checkout.refresh_from_db()
-    assert checkout.last_change > last_change_before_recalculation
+    assert checkout.last_change != last_change_before_recalculation
+    assert checkout.last_change.isoformat() == freeze_time_str
     assert checkout.email == expected_email
     for old_line, new_line in zip(lines, checkout.lines.all(), strict=True):
         assert old_line.quantity + 1 == new_line.quantity

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -11,6 +11,7 @@ from django.test import override_settings
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django_countries.fields import Country
+from freezegun import freeze_time
 from measurement.measures import Weight
 from prices import Money
 
@@ -2949,14 +2950,16 @@ def test_checkout_prices_with_checkout_updated_during_price_recalculation(
     }
     total_before_recalculation = checkout.total
     lines_before_recalculation = list(checkout.lines.all())
+    freeze_time_str = "2024-01-01T12:00:00+00:00"
 
     # when
     def modify_checkout(*args, **kwargs):
-        with allow_writer():
-            checkout_to_modify = Checkout.objects.get(pk=checkout.pk)
-            checkout_to_modify.lines.update(quantity=F("quantity") + 1)
-            checkout_to_modify.email = expected_email
-            checkout_to_modify.save(update_fields=["email", "last_change"])
+        with freeze_time(freeze_time_str):
+            with allow_writer():
+                checkout_to_modify = Checkout.objects.get(pk=checkout.pk)
+                checkout_to_modify.lines.update(quantity=F("quantity") + 1)
+                checkout_to_modify.email = expected_email
+                checkout_to_modify.save(update_fields=["email", "last_change"])
 
     with race_condition.RunBefore(
         "saleor.checkout.calculations._calculate_and_add_tax", modify_checkout
@@ -2976,6 +2979,7 @@ def test_checkout_prices_with_checkout_updated_during_price_recalculation(
 
     checkout.refresh_from_db()
     assert checkout.email == expected_email
+    assert checkout.last_change.isoformat() == freeze_time_str
 
     # Confirm that total price hasn't changed in database due to recalculation
     assert checkout.total == total_before_recalculation


### PR DESCRIPTION
Do not update `last_change` in checkout prices recalculations, as it should reflect the change made by user. Currently prices are recalculated when checkout is fetched which is misleading.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
