### PR TITLE
Do not update `last_change` in checkout prices recalculations

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -465,7 +465,6 @@ def _fetch_checkout_prices_if_expired(
                     "discount_amount",
                     "discount_name",
                     "currency",
-                    "last_change",
                     "price_expiration",
                     "discount_expiration",
                     "tax_error",


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/18536

Do not update `last_change` in checkout prices recalculations, as it should reflect the change made by user. Currently prices are recalculated when checkout is fetched which is misleading.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
