### PR TITLE
Rename shipping_methods_stale_at to delivery_methods_stale_at

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -762,10 +762,10 @@ def fetch_shipping_methods_for_checkout(
 
         assigned_delivery = checkout.assigned_delivery
 
-        checkout.shipping_methods_stale_at = (
+        checkout.delivery_methods_stale_at = (
             timezone.now() + settings.CHECKOUT_SHIPPING_OPTIONS_TTL
         )
-        checkout.save(update_fields=["shipping_methods_stale_at"])
+        checkout.save(update_fields=["delivery_methods_stale_at"])
 
         _refresh_checkout_deliveries(
             checkout=locked_checkout,
@@ -810,8 +810,8 @@ def get_or_fetch_checkout_deliveries(
     """
     checkout = checkout_info.checkout
     if (
-        checkout.shipping_methods_stale_at is None
-        or checkout.shipping_methods_stale_at <= timezone.now()
+        checkout.delivery_methods_stale_at is None
+        or checkout.delivery_methods_stale_at <= timezone.now()
     ):
         return fetch_shipping_methods_for_checkout(checkout_info)
     return list(

--- a/saleor/checkout/migrations/0083_checkout_shipping_methods_stale_at_checkoutdelivery_and_more.py
+++ b/saleor/checkout/migrations/0083_checkout_shipping_methods_stale_at_checkoutdelivery_and_more.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name="checkout",
-            name="shipping_methods_stale_at",
+            name="delivery_methods_stale_at",
             field=models.DateTimeField(blank=True, null=True),
         ),
         migrations.CreateModel(

--- a/saleor/checkout/models.py
+++ b/saleor/checkout/models.py
@@ -266,7 +266,7 @@ class Checkout(models.Model):
         db_index=True,
     )
 
-    shipping_methods_stale_at = models.DateTimeField(null=True, blank=True)
+    delivery_methods_stale_at = models.DateTimeField(null=True, blank=True)
     price_expiration = models.DateTimeField(default=timezone.now)
     # Expiration time of the applied discounts.
     # Decides if the discounts are updated before tax recalculation.

--- a/saleor/checkout/tests/test_fetch.py
+++ b/saleor/checkout/tests/test_fetch.py
@@ -412,7 +412,7 @@ def _assert_built_in_shipping_method(
 
     checkout.refresh_from_db()
     assert (
-        checkout.shipping_methods_stale_at
+        checkout.delivery_methods_stale_at
         == timezone.now() + settings.CHECKOUT_SHIPPING_OPTIONS_TTL
     )
 
@@ -479,14 +479,14 @@ def test_fetch_shipping_methods_for_checkout_updates_existing_built_in_shipping_
     # given
     checkout = checkout_with_item
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = (
+    checkout.delivery_methods_stale_at = (
         timezone.now() - settings.CHECKOUT_SHIPPING_OPTIONS_TTL
     )
     checkout.assigned_delivery_id = None
     checkout.save(
         update_fields=[
             "shipping_address",
-            "shipping_methods_stale_at",
+            "delivery_methods_stale_at",
             "assigned_delivery_id",
         ]
     )
@@ -560,10 +560,10 @@ def test_fetch_shipping_methods_for_checkout_removes_non_applicable_built_in_shi
     # given
     checkout = checkout_with_item
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = (
+    checkout.delivery_methods_stale_at = (
         timezone.now() + settings.CHECKOUT_SHIPPING_OPTIONS_TTL
     )
-    checkout.save(update_fields=["shipping_address", "shipping_methods_stale_at"])
+    checkout.save(update_fields=["shipping_address", "delivery_methods_stale_at"])
 
     available_shipping_method = ShippingMethod.objects.get()
 
@@ -603,10 +603,10 @@ def test_fetch_shipping_methods_for_checkout_non_applicable_assigned_built_in_sh
     # given
     checkout = checkout_with_item
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = (
+    checkout.delivery_methods_stale_at = (
         timezone.now() + settings.CHECKOUT_SHIPPING_OPTIONS_TTL
     )
-    checkout.save(update_fields=["shipping_address", "shipping_methods_stale_at"])
+    checkout.save(update_fields=["shipping_address", "delivery_methods_stale_at"])
 
     available_shipping_method = ShippingMethod.objects.get()
 
@@ -818,7 +818,7 @@ def _assert_external_shipping_method(
     assert checkout_delivery.is_external is True
     checkout.refresh_from_db()
     assert (
-        checkout.shipping_methods_stale_at
+        checkout.delivery_methods_stale_at
         == timezone.now() + settings.CHECKOUT_SHIPPING_OPTIONS_TTL
     )
 
@@ -911,8 +911,8 @@ def test_fetch_shipping_methods_for_checkout_updates_existing_external_shipping_
         currency="USD",
     )
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = timezone.now()
-    checkout.save(update_fields=["shipping_address", "shipping_methods_stale_at"])
+    checkout.delivery_methods_stale_at = timezone.now()
+    checkout.save(update_fields=["shipping_address", "delivery_methods_stale_at"])
 
     ShippingMethod.objects.all().delete()
 
@@ -973,8 +973,8 @@ def test_fetch_shipping_methods_for_checkout_removes_non_applicable_external_shi
         currency="USD",
     )
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = timezone.now()
-    checkout.save(update_fields=["shipping_address", "shipping_methods_stale_at"])
+    checkout.delivery_methods_stale_at = timezone.now()
+    checkout.save(update_fields=["shipping_address", "delivery_methods_stale_at"])
 
     ShippingMethod.objects.all().delete()
 
@@ -1034,7 +1034,7 @@ def test_fetch_shipping_methods_for_checkout_non_applicable_assigned_external_sh
         currency="USD",
     )
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = timezone.now()
+    checkout.delivery_methods_stale_at = timezone.now()
     checkout.assigned_delivery = assigned_delivery
     checkout.save()
 
@@ -1167,7 +1167,7 @@ def test_fetch_shipping_methods_for_checkout_with_changed_price_of_external_ship
     )
     checkout.assigned_delivery = assigned_delivery
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = timezone.now()
+    checkout.delivery_methods_stale_at = timezone.now()
     checkout.save()
 
     ShippingMethod.objects.all().delete()

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -72,8 +72,8 @@ def mark_checkout_deliveries_as_stale_if_needed(
 ) -> list[str]:
     if not is_shipping_required(lines):
         return []
-    checkout.shipping_methods_stale_at = timezone.now()
-    return ["shipping_methods_stale_at"]
+    checkout.delivery_methods_stale_at = timezone.now()
+    return ["delivery_methods_stale_at"]
 
 
 def get_variants_and_total_quantities(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -1075,7 +1075,7 @@ def test_checkout_add_promo_code_marks_shipping_methods_as_stale(
     assert shipping_method_id not in data["checkout"]["availableShippingMethods"]
     assert checkout.assigned_delivery
     assert (
-        checkout.shipping_methods_stale_at
+        checkout.delivery_methods_stale_at
         == new_time + settings.CHECKOUT_SHIPPING_OPTIONS_TTL
     )
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -865,12 +865,12 @@ def test_checkout_billing_address_do_not_mark_shipping_as_stale(
     checkout = checkout_with_item
     checkout.assigned_delivery = checkout_delivery(checkout)
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = expected_stale_time
+    checkout.delivery_methods_stale_at = expected_stale_time
     checkout.save(
         update_fields=[
             "assigned_delivery",
             "shipping_address",
-            "shipping_methods_stale_at",
+            "delivery_methods_stale_at",
         ]
     )
 
@@ -892,4 +892,4 @@ def test_checkout_billing_address_do_not_mark_shipping_as_stale(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    assert checkout.shipping_methods_stale_at == expected_stale_time
+    assert checkout.delivery_methods_stale_at == expected_stale_time

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -6252,7 +6252,7 @@ def test_complete_refreshes_shipping_methods_when_stale(
 ):
     # given
     checkout = checkout_ready_to_complete
-    checkout.shipping_methods_stale_at = timezone.now()
+    checkout.delivery_methods_stale_at = timezone.now()
     checkout.save()
 
     checkout.gift_cards.all().delete()
@@ -6299,7 +6299,7 @@ def test_complete_do_not_refresh_shipping_methods_when_not_stale(
 ):
     # given
     checkout = checkout_ready_to_complete
-    checkout.shipping_methods_stale_at = timezone.now() + datetime.timedelta(hours=1)
+    checkout.delivery_methods_stale_at = timezone.now() + datetime.timedelta(hours=1)
     checkout.save()
 
     checkout.gift_cards.all().delete()
@@ -6348,7 +6348,7 @@ def test_complete_refreshes_shipping_methods_when_stale_and_invalid(
     # given
 
     checkout = checkout_ready_to_complete
-    checkout.shipping_methods_stale_at = timezone.now()
+    checkout.delivery_methods_stale_at = timezone.now()
     checkout.save()
     checkout.gift_cards.all().delete()
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -5771,8 +5771,8 @@ def test_complete_refreshes_shipping_methods_when_stale(
 ):
     # given
     checkout = checkout_ready_to_complete
-    checkout.shipping_methods_stale_at = timezone.now()
-    checkout.save(update_fields=["shipping_methods_stale_at"])
+    checkout.delivery_methods_stale_at = timezone.now()
+    checkout.save(update_fields=["delivery_methods_stale_at"])
     checkout.gift_cards.all().delete()
 
     manager = get_plugins_manager(allow_replica=False)
@@ -5819,8 +5819,8 @@ def test_complete_do_not_refresh_shipping_methods_when_not_stale(
 ):
     # given
     checkout = checkout_ready_to_complete
-    checkout.shipping_methods_stale_at = timezone.now() + datetime.timedelta(hours=1)
-    checkout.save(update_fields=["shipping_methods_stale_at"])
+    checkout.delivery_methods_stale_at = timezone.now() + datetime.timedelta(hours=1)
+    checkout.save(update_fields=["delivery_methods_stale_at"])
     checkout.gift_cards.all().delete()
 
     manager = get_plugins_manager(allow_replica=False)
@@ -5868,8 +5868,8 @@ def test_complete_refreshes_shipping_methods_when_stale_and_invalid(
 ):
     # given
     checkout = checkout_ready_to_complete
-    checkout.shipping_methods_stale_at = timezone.now()
-    checkout.save(update_fields=["shipping_methods_stale_at"])
+    checkout.delivery_methods_stale_at = timezone.now()
+    checkout.save(update_fields=["delivery_methods_stale_at"])
     checkout.gift_cards.all().delete()
 
     # Shipping is not available anymore

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -390,12 +390,12 @@ def test_checkout_customer_attach_do_not_mark_shipping_as_stale(
     checkout.email = "old@email.com"
     checkout.assigned_delivery = checkout_delivery(checkout)
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = expected_stale_time
+    checkout.delivery_methods_stale_at = expected_stale_time
     checkout.save(
         update_fields=[
             "assigned_delivery",
             "shipping_address",
-            "shipping_methods_stale_at",
+            "delivery_methods_stale_at",
         ]
     )
 
@@ -417,4 +417,4 @@ def test_checkout_customer_attach_do_not_mark_shipping_as_stale(
     assert not data["errors"]
     assert data["checkout"]["email"] == customer_user2.email
     checkout.refresh_from_db()
-    assert checkout.shipping_methods_stale_at == expected_stale_time
+    assert checkout.delivery_methods_stale_at == expected_stale_time

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
@@ -253,12 +253,12 @@ def test_checkout_customer_detach_do_not_mark_shipping_as_stale(
     checkout.user = customer_user
     checkout.assigned_delivery = checkout_delivery(checkout)
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = expected_stale_time
+    checkout.delivery_methods_stale_at = expected_stale_time
     checkout.save(
         update_fields=[
             "assigned_delivery",
             "shipping_address",
-            "shipping_methods_stale_at",
+            "delivery_methods_stale_at",
         ]
     )
 
@@ -276,4 +276,4 @@ def test_checkout_customer_detach_do_not_mark_shipping_as_stale(
     data = content["data"]["checkoutCustomerDetach"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    assert checkout.shipping_methods_stale_at == expected_stale_time
+    assert checkout.delivery_methods_stale_at == expected_stale_time

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_note_update.py
@@ -213,12 +213,12 @@ def test_checkout_customer_note_update_do_not_mark_shipping_as_stale(
     checkout = checkout_with_item
     checkout.assigned_delivery = checkout_delivery(checkout)
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = expected_stale_time
+    checkout.delivery_methods_stale_at = expected_stale_time
     checkout.save(
         update_fields=[
             "assigned_delivery",
             "shipping_address",
-            "shipping_methods_stale_at",
+            "delivery_methods_stale_at",
         ]
     )
 
@@ -237,4 +237,4 @@ def test_checkout_customer_note_update_do_not_mark_shipping_as_stale(
     data = content["data"]["checkoutCustomerNoteUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    assert checkout.shipping_methods_stale_at == expected_stale_time
+    assert checkout.delivery_methods_stale_at == expected_stale_time

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -247,12 +247,12 @@ def test_checkout_email_update_do_not_mark_shipping_as_stale(
     checkout = checkout_with_item
     checkout.assigned_delivery = checkout_delivery(checkout)
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = expected_stale_time
+    checkout.delivery_methods_stale_at = expected_stale_time
     checkout.save(
         update_fields=[
             "assigned_delivery",
             "shipping_address",
-            "shipping_methods_stale_at",
+            "delivery_methods_stale_at",
         ]
     )
 
@@ -273,4 +273,4 @@ def test_checkout_email_update_do_not_mark_shipping_as_stale(
     assert not data["errors"]
     assert data["checkout"]["email"] == email
     checkout.refresh_from_db()
-    assert checkout.shipping_methods_stale_at == expected_stale_time
+    assert checkout.delivery_methods_stale_at == expected_stale_time

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
@@ -206,12 +206,12 @@ def test_checkout_update_language_code_do_not_mark_shipping_as_stale(
     checkout = checkout_with_item
     checkout.assigned_delivery = checkout_delivery(checkout)
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = expected_stale_time
+    checkout.delivery_methods_stale_at = expected_stale_time
     checkout.save(
         update_fields=[
             "assigned_delivery",
             "shipping_address",
-            "shipping_methods_stale_at",
+            "delivery_methods_stale_at",
         ]
     )
 
@@ -231,4 +231,4 @@ def test_checkout_update_language_code_do_not_mark_shipping_as_stale(
 
     assert data["checkout"]["languageCode"] == language_code
     checkout.refresh_from_db()
-    assert checkout.shipping_methods_stale_at == expected_stale_time
+    assert checkout.delivery_methods_stale_at == expected_stale_time

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -291,7 +291,7 @@ def test_checkout_line_marks_shipping_as_stale_if_removed_product_with_shipping(
     checkout.refresh_from_db()
     assert checkout.lines.count() == 1
     assert checkout.assigned_delivery
-    assert checkout.shipping_methods_stale_at == timezone.now()
+    assert checkout.delivery_methods_stale_at == timezone.now()
 
 
 def test_with_active_problems_flow(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -1399,7 +1399,7 @@ def test_checkout_lines_marks_shipping_methods_as_stale(
     # then
     checkout.refresh_from_db()
     assert checkout.assigned_delivery
-    assert checkout.shipping_methods_stale_at == timezone.now()
+    assert checkout.delivery_methods_stale_at == timezone.now()
     content = get_graphql_content(response)
     data = content["data"]["checkoutLinesAdd"]
     assert not data["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1434,7 +1434,7 @@ def test_checkout_lines_update_marks_shipping_as_stale(
     lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 1
     assert checkout.assigned_delivery
-    assert checkout.shipping_methods_stale_at == timezone.now()
+    assert checkout.delivery_methods_stale_at == timezone.now()
 
 
 @freeze_time("2022-04-12 12:00:00")
@@ -1477,7 +1477,7 @@ def test_checkout_lines_update_do_not_remove_shipping_if_removed_product_with_sh
     checkout.refresh_from_db()
     assert checkout.lines.count() == 1
     assert checkout.assigned_delivery
-    assert checkout.shipping_methods_stale_at == timezone.now()
+    assert checkout.delivery_methods_stale_at == timezone.now()
 
 
 def test_with_active_problems_flow(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -956,12 +956,12 @@ def test_checkout_remove_voucher_code_marks_shipping_as_stale(
     checkout = checkout_with_voucher
     checkout.assigned_delivery = checkout_delivery(checkout)
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = previous_stale_time
+    checkout.delivery_methods_stale_at = previous_stale_time
     checkout.save(
         update_fields=[
             "assigned_delivery",
             "shipping_address",
-            "shipping_methods_stale_at",
+            "delivery_methods_stale_at",
         ]
     )
 
@@ -981,4 +981,4 @@ def test_checkout_remove_voucher_code_marks_shipping_as_stale(
     assert data["checkout"]["token"] == str(checkout_with_voucher.token)
     assert data["checkout"]["voucherCode"] is None
     checkout.refresh_from_db()
-    assert checkout.shipping_methods_stale_at == expected_stale_time
+    assert checkout.delivery_methods_stale_at == expected_stale_time

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -1373,12 +1373,12 @@ def test_checkout_shipping_address_marks_shipping_as_stale(
     checkout = checkout_with_item
     checkout.assigned_delivery = checkout_delivery(checkout)
     checkout.shipping_address = address
-    checkout.shipping_methods_stale_at = expected_stale_time
+    checkout.delivery_methods_stale_at = expected_stale_time
     checkout.save(
         update_fields=[
             "assigned_delivery",
             "shipping_address",
-            "shipping_methods_stale_at",
+            "delivery_methods_stale_at",
         ]
     )
 
@@ -1400,4 +1400,4 @@ def test_checkout_shipping_address_marks_shipping_as_stale(
     data = content["data"]["checkoutShippingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    assert checkout.shipping_methods_stale_at == new_now
+    assert checkout.delivery_methods_stale_at == new_now

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -122,8 +122,8 @@ def test_checkout_shipping_method_update_not_valid_shipping_method(
 ):
     # given
     checkout = checkout_with_item_and_shipping_method
-    checkout.shipping_methods_stale_at = timezone.now() + timedelta(minutes=10)
-    checkout.save(update_fields=["shipping_methods_stale_at"])
+    checkout.delivery_methods_stale_at = timezone.now() + timedelta(minutes=10)
+    checkout.save(update_fields=["delivery_methods_stale_at"])
 
     old_shipping_method = checkout.assigned_delivery
     previous_last_change = checkout.last_change

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -2899,8 +2899,8 @@ def test_order_from_checkout_refreshes_shipping_methods_when_stale(
 ):
     # given
     checkout = checkout_ready_to_complete
-    checkout.shipping_methods_stale_at = timezone.now()
-    checkout.save(update_fields=["shipping_methods_stale_at"])
+    checkout.delivery_methods_stale_at = timezone.now()
+    checkout.save(update_fields=["delivery_methods_stale_at"])
 
     variables = {"id": graphene.Node.to_global_id("Checkout", checkout.pk)}
 
@@ -2936,8 +2936,8 @@ def test_order_from_checkout_do_not_refresh_shipping_methods_when_not_stale(
 ):
     # given
     checkout = checkout_ready_to_complete
-    checkout.shipping_methods_stale_at = timezone.now() + datetime.timedelta(hours=1)
-    checkout.save(update_fields=["shipping_methods_stale_at"])
+    checkout.delivery_methods_stale_at = timezone.now() + datetime.timedelta(hours=1)
+    checkout.save(update_fields=["delivery_methods_stale_at"])
 
     variables = {"id": graphene.Node.to_global_id("Checkout", checkout.pk)}
 
@@ -2975,8 +2975,8 @@ def test_order_from_checkout_refreshes_shipping_methods_when_stale_and_invalid(
 ):
     # given
     checkout = checkout_ready_to_complete
-    checkout.shipping_methods_stale_at = timezone.now()
-    checkout.save(update_fields=["shipping_methods_stale_at"])
+    checkout.delivery_methods_stale_at = timezone.now()
+    checkout.save(update_fields=["delivery_methods_stale_at"])
 
     # Shipping is not available anymore
     ShippingMethod.objects.all().delete()

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -396,7 +396,7 @@ def test_checkout_available_shipping_methods(
 
     checkout_with_item.shipping_address = address
     checkout_with_item.assigned_delivery = checkout_delivery(checkout_with_item)
-    checkout_with_item.shipping_methods_stale_at = timezone.now()
+    checkout_with_item.delivery_methods_stale_at = timezone.now()
     checkout_with_item.save()
 
     # when
@@ -4917,7 +4917,7 @@ def test_query_checkout_delivery_method_invalidates_taxes_when_delivery_price_is
     checkout.assigned_delivery = checkout_delivery(checkout, shipping_method)
 
     checkout.price_expiration = timezone.now() + datetime.timedelta(minutes=5)
-    checkout.shipping_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
+    checkout.delivery_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
     checkout.save()
 
     current_checkout_delivery_price = checkout.assigned_delivery.price_amount
@@ -4971,7 +4971,7 @@ def test_query_checkout_delivery_method_invalidates_taxes_when_delivery_tax_clas
     checkout = checkout_with_item
     checkout.shipping_address = address
     checkout.assigned_delivery = checkout_delivery(checkout, shipping_method)
-    checkout.shipping_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
+    checkout.delivery_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
     checkout.price_expiration = timezone.now() + datetime.timedelta(minutes=5)
     checkout.save()
 
@@ -5025,7 +5025,7 @@ def test_query_checkout_delivery_method_dont_invalidate_taxes_when_nothing_chang
     checkout = checkout_with_item
     checkout.shipping_address = address
     checkout.assigned_delivery = checkout_delivery(checkout, shipping_method)
-    checkout.shipping_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
+    checkout.delivery_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
     checkout.price_expiration = expected_price_expiration
     checkout.save()
 
@@ -5070,7 +5070,7 @@ def test_query_checkout_shipping_method_invalidates_taxes_when_shipping_price_is
     checkout.assigned_delivery = checkout_delivery(checkout, shipping_method)
 
     checkout.price_expiration = timezone.now() + datetime.timedelta(minutes=5)
-    checkout.shipping_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
+    checkout.delivery_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
     checkout.save()
 
     current_checkout_delivery_price = checkout.assigned_delivery.price_amount
@@ -5122,7 +5122,7 @@ def test_query_checkout_shipping_method_invalidates_taxes_when_shipping_tax_clas
     checkout = checkout_with_item
     checkout.shipping_address = address
     checkout.assigned_delivery = checkout_delivery(checkout, shipping_method)
-    checkout.shipping_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
+    checkout.delivery_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
     checkout.price_expiration = timezone.now() + datetime.timedelta(minutes=5)
     checkout.save()
 
@@ -5174,7 +5174,7 @@ def test_query_checkout_shipping_method_dont_invalidate_taxes_when_nothing_chang
     checkout = checkout_with_item
     checkout.shipping_address = address
     checkout.assigned_delivery = checkout_delivery(checkout, shipping_method)
-    checkout.shipping_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
+    checkout.delivery_methods_stale_at = timezone.now() - datetime.timedelta(minutes=5)
     checkout.price_expiration = expected_price_expiration
     checkout.save()
 

--- a/saleor/graphql/checkout/tests/test_checkouts_query.py
+++ b/saleor/graphql/checkout/tests/test_checkouts_query.py
@@ -85,7 +85,7 @@ def test_query_checkouts_do_not_trigger_external_shipping_webhook_with_flat_rate
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     checkout = checkout_with_delivery_method_for_external_shipping
     checkout.price_expiration = timezone.now()
-    checkout.shipping_methods_stale_at = timezone.now()
+    checkout.delivery_methods_stale_at = timezone.now()
     checkout.undiscounted_base_shipping_price_amount = Decimal(100)
     checkout.save()
 
@@ -144,7 +144,7 @@ def test_query_checkouts_do_not_trigger_external_shipping_webhook_with_tax_app(
     checkout.price_expiration = timezone.now()
 
     checkout.undiscounted_base_shipping_price_amount = Decimal(100)
-    checkout.shipping_methods_stale_at = timezone.now()
+    checkout.delivery_methods_stale_at = timezone.now()
     checkout.save()
 
     checkout_delivery = checkout.shipping_methods.get()
@@ -200,7 +200,7 @@ def test_query_checkouts_do_not_trigger_exclude_shipping_webhooks_with_flat_rate
     checkout = checkout_with_delivery_method_for_external_shipping
     checkout.price_expiration = timezone.now()
     checkout.undiscounted_base_shipping_price_amount = Decimal(100)
-    checkout.shipping_methods_stale_at = timezone.now()
+    checkout.delivery_methods_stale_at = timezone.now()
     checkout.save()
 
     checkout_delivery = checkout.shipping_methods.get()
@@ -256,7 +256,7 @@ def test_query_checkouts_do_not_trigger_exclude_shipping_webhooks_with_tax_app(
     checkout = checkout_with_delivery_method_for_external_shipping
     checkout.price_expiration = timezone.now()
     checkout.undiscounted_base_shipping_price_amount = Decimal(100)
-    checkout.shipping_methods_stale_at = timezone.now()
+    checkout.delivery_methods_stale_at = timezone.now()
     checkout.save()
 
     checkout_delivery = checkout.shipping_methods.get()

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -630,8 +630,8 @@ def _should_load_denormalized_checkout_deliveries(
     checkout_context: SyncWebhookControlContext[models.Checkout],
 ):
     return not checkout_context.allow_sync_webhooks or (
-        checkout_context.node.shipping_methods_stale_at
-        and checkout_context.node.shipping_methods_stale_at > timezone.now()
+        checkout_context.node.delivery_methods_stale_at
+        and checkout_context.node.delivery_methods_stale_at > timezone.now()
     )
 
 
@@ -663,8 +663,8 @@ def _resolve_checkout_deliveries(
         )
         checkout_info.allow_sync_webhooks = root.allow_sync_webhooks
         shipping_methods = fetch_shipping_methods_for_checkout(checkout_info)
-        checkout.shipping_methods_stale_at = (
-            checkout_info.checkout.shipping_methods_stale_at
+        checkout.delivery_methods_stale_at = (
+            checkout_info.checkout.delivery_methods_stale_at
         )
         CheckoutDeliveriesOnlyValidByCheckoutIdLoader(info.context).prime(
             checkout.pk, shipping_methods
@@ -704,8 +704,8 @@ def _resolve_checkout_delivery(
         return None
 
     if (
-        checkout.shipping_methods_stale_at
-        and checkout.shipping_methods_stale_at > timezone.now()
+        checkout.delivery_methods_stale_at
+        and checkout.delivery_methods_stale_at > timezone.now()
     ) or not root.allow_sync_webhooks:
         return (
             CheckoutDeliveryByIdLoader(info.context)
@@ -726,8 +726,8 @@ def _resolve_checkout_delivery(
         )
         checkout_info.allow_sync_webhooks = root.allow_sync_webhooks
         shipping_methods = fetch_shipping_methods_for_checkout(checkout_info)
-        root.node.shipping_methods_stale_at = (
-            checkout_info.checkout.shipping_methods_stale_at
+        root.node.delivery_methods_stale_at = (
+            checkout_info.checkout.delivery_methods_stale_at
         )
         CheckoutDeliveriesOnlyValidByCheckoutIdLoader(info.context).prime(
             checkout.pk, shipping_methods


### PR DESCRIPTION
I want to merge this change because it renames the flag name from `shipping_methods_stale_at` to `deliver_methods_stale_at`, as the name is more universal.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
