### PR TITLE
Release 3.22.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.13",
+  "version": "3.22.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.13",
+      "version": "3.22.14",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.13",
+  "version": "3.22.14",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,4 +292,4 @@ target-version = "py312"
     known-first-party = [ "saleor" ]
 
 [tool.poetry]
-version = "3.22.13"
+version = "3.22.14"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.13"
+__version__ = "3.22.14"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Fix automatic checkout completion (#18528) (95cc8d4234)
* Prevent raising `DatabaseError` in `CheckoutComplete` (#18527) (f1e4db0ac0)
* Do not update last_change in checkout prices recalculations (#18537) (790c27ddda)
* Fix reference cycles in ASGIHandler (#18416) (cba995b458)
* Enable test aggregation grouped by the 'xdist_group' mark (#18534) (dc4494f609)
