### PR TITLE
Add new delivery related problems

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -242,6 +242,30 @@ def _resolve_line_problem_type(
     return None
 
 
+class CheckoutProblemDeliveryMethodStale(
+    SyncWebhookControlContextObjectType[problems.CheckoutProblemDeliveryMethodStale]
+):
+    delivery = graphene.Field("saleor.graphql.checkout.types.Delivery", required=True)
+
+    class Meta:
+        default_resolver = SyncWebhookControlContextObjectType.resolver_with_context
+        description = "Indicates that the delivery methods are stale." + ADDED_IN_323
+        doc_category = DOC_CATEGORY_CHECKOUT
+
+
+class CheckoutProblemDeliveryMethodInvalid(
+    SyncWebhookControlContextObjectType[problems.CheckoutProblemDeliveryMethodInvalid]
+):
+    delivery = graphene.Field("saleor.graphql.checkout.types.Delivery", required=True)
+
+    class Meta:
+        default_resolver = SyncWebhookControlContextObjectType.resolver_with_context
+        description = (
+            "Indicates that the selected delivery method is invalid." + ADDED_IN_323
+        )
+        doc_category = DOC_CATEGORY_CHECKOUT
+
+
 class CheckoutLineProblem(graphene.Union):
     class Meta:
         types = (
@@ -265,7 +289,10 @@ class CheckoutLineProblem(graphene.Union):
 
 class CheckoutProblem(graphene.Union):
     class Meta:
-        types = [] + list(CheckoutLineProblem._meta.types)
+        types = [
+            CheckoutProblemDeliveryMethodStale,
+            CheckoutProblemDeliveryMethodInvalid,
+        ] + list(CheckoutLineProblem._meta.types)
         description = "Represents an problem in the checkout."
         doc_category = DOC_CATEGORY_CHECKOUT
 
@@ -278,6 +305,13 @@ class CheckoutProblem(graphene.Union):
         line_problem_type = _resolve_line_problem_type(instance)
         if line_problem_type:
             return line_problem_type
+
+        problem_instance = instance.node
+        if isinstance(problem_instance, problems.CheckoutProblemDeliveryMethodStale):
+            return CheckoutProblemDeliveryMethodStale
+        if isinstance(problem_instance, problems.CheckoutProblemDeliveryMethodInvalid):
+            return CheckoutProblemDeliveryMethodInvalid
+
         return super().resolve_type(instance.node, info)
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12746,7 +12746,25 @@ enum TokenizedPaymentFlowEnum @doc(category: "Payments") {
 }
 
 """Represents an problem in the checkout."""
-union CheckoutProblem = CheckoutLineProblemInsufficientStock | CheckoutLineProblemVariantNotAvailable
+union CheckoutProblem = CheckoutProblemDeliveryMethodStale | CheckoutProblemDeliveryMethodInvalid | CheckoutLineProblemInsufficientStock | CheckoutLineProblemVariantNotAvailable
+
+"""
+Indicates that the delivery methods are stale.
+
+Added in Saleor 3.23.
+"""
+type CheckoutProblemDeliveryMethodStale @doc(category: "Checkout") {
+  delivery: Delivery!
+}
+
+"""
+Indicates that the selected delivery method is invalid.
+
+Added in Saleor 3.23.
+"""
+type CheckoutProblemDeliveryMethodInvalid @doc(category: "Checkout") {
+  delivery: Delivery!
+}
 
 type CheckoutCountableConnection @doc(category: "Checkout") {
   """Pagination data for this connection."""


### PR DESCRIPTION
I want to merge this change because it adds new CheckoutProblem objects:
- `CheckoutProblemDeliveryMethodStale` - present when assigned shipping method is stale, and refresh is required
- `CheckoutProblemDeliveryMethodInvalid` - present when delivery method is marked as invalid, and new one needs to be picked up"

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
