### PR TITLE
Make `id` a required argument for `mediaById` and `imageById`

### DIFF
--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -1000,12 +1000,16 @@ class Product(ChannelContextType[models.Product]):
     )
     media_by_id = graphene.Field(
         lambda: ProductMedia,
-        id=graphene.Argument(graphene.ID, description="ID of a product media."),
+        id=graphene.Argument(
+            graphene.ID, description="ID of a product media.", required=True
+        ),
         description="Get a single product media by ID.",
     )
     image_by_id = graphene.Field(
         lambda: ProductImage,
-        id=graphene.Argument(graphene.ID, description="ID of a product image."),
+        id=graphene.Argument(
+            graphene.ID, description="ID of a product image.", required=True
+        ),
         description="Get a single product image by ID.",
         deprecation_reason="Use the `mediaById` field instead.",
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5697,13 +5697,13 @@ type Product implements Node & ObjectWithMetadata & ObjectWithAttributes @doc(ca
   """Get a single product media by ID."""
   mediaById(
     """ID of a product media."""
-    id: ID
+    id: ID!
   ): ProductMedia
 
   """Get a single product image by ID."""
   imageById(
     """ID of a product image."""
-    id: ID
+    id: ID!
   ): ProductImage @deprecated(reason: "Use the `mediaById` field instead.")
 
   """Get a single variant by SKU or ID."""


### PR DESCRIPTION
It's a bug that they can be called without explicitly passing an ID and it causes Saleor to crash.

Port of #18575 

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
