### PR TITLE
Do not call .get on Promise, while building promise subscription

### DIFF
--- a/saleor/graphql/webhook/dataloaders/pregenerated_payload_for_checkout_tax.py
+++ b/saleor/graphql/webhook/dataloaders/pregenerated_payload_for_checkout_tax.py
@@ -104,7 +104,6 @@ class PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(DataLoader):
                                     app=app,
                                 )
                             )
-                            promises.append(promise_payload)
 
                             def store_payload(
                                 payload,
@@ -117,7 +116,7 @@ class PregeneratedCheckoutTaxPayloadsByCheckoutTokenLoader(DataLoader):
                                         payload
                                     )
 
-                            promise_payload.then(store_payload)
+                            promises.append(promise_payload.then(store_payload))
 
             def return_payloads(_payloads):
                 return [results[str(checkout_token)] for checkout_token in keys]

--- a/saleor/graphql/webhook/dataloaders/pregenerated_payloads_for_checkout_filter_shipping_methods.py
+++ b/saleor/graphql/webhook/dataloaders/pregenerated_payloads_for_checkout_filter_shipping_methods.py
@@ -95,7 +95,6 @@ class PregeneratedCheckoutFilterShippingMethodPayloadsByCheckoutTokenLoader(Data
                             request=request_context,
                             app=app,
                         )
-                        promises.append(promise_payload)
 
                         def store_payload(
                             payload,
@@ -106,7 +105,7 @@ class PregeneratedCheckoutFilterShippingMethodPayloadsByCheckoutTokenLoader(Data
                             if payload:
                                 results[checkout_token][app_id][query_hash] = payload
 
-                        promise_payload.then(store_payload)
+                        promises.append(promise_payload.then(store_payload))
 
                 def return_payloads(_payloads):
                     return [


### PR DESCRIPTION
I want to merge this change because it adds separate handler to process the promise payload. Previously we were calling `Promise.get()`, this could cause that the Promise loop would be interrupted

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
