### PR TITLE
Add warning to dataloader.__init__

### DIFF
--- a/saleor/graphql/core/dataloaders.py
+++ b/saleor/graphql/core/dataloaders.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from collections.abc import Iterable
 from typing import TypeVar
@@ -14,6 +15,8 @@ from .context import get_database_connection_name
 
 K = TypeVar("K")
 R = TypeVar("R")
+
+logger = logging.getLogger(__name__)
 
 
 class DataLoader[K, R](BaseLoader):
@@ -34,7 +37,15 @@ class DataLoader[K, R](BaseLoader):
         return loader
 
     def __init__(self, context: SaleorContext) -> None:
-        if getattr(self, "context", None) != context:
+        current_context: SaleorContext | None = getattr(self, "context", None)
+        if current_context != context:
+            if current_context is not None:
+                logger.warning(
+                    "Dataloader for key %s is being initialized with "
+                    "a different context. This leads to overwriting the "
+                    "previous context and may cause unexpected behavior.",
+                    self.context_key,
+                )
             self.context = context
             self.database_connection_name = get_database_connection_name(context)
             super().__init__()


### PR DESCRIPTION
I want to merge this change because it adds a warning in case of providing different context to dataloader. When recieving different context, Dataloader will throw away previous cached data.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
