### PR TITLE
Prevent race condition between TransactionEventReport and checkout completion

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -478,7 +478,9 @@ class TransactionEventReport(DeprecatedModelMutation):
 
         app_identifier = app_identifier or transaction.app_identifier
 
-        source_object = Checkout.objects.filter(pk=transaction.checkout_id).first()
+        source_object: Checkout | order_models.Order | None = None
+        if transaction.checkout_id:
+            source_object = Checkout.objects.filter(pk=transaction.checkout_id).first()
         if not source_object:
             # Prevent race condition between TransactionEventReport and checkout completion
             source_object = order_models.Order.objects.filter(


### PR DESCRIPTION
The transactionEventReport mutation does not lock the checkout so it's possible for transaction.checkout to raise an exception where the fetched Transaction instance has a checkout_id but the Checkout object no longer exists.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
