### PR TITLE
Refactor currency handling in checkout model

### DIFF
--- a/saleor/checkout/models.py
+++ b/saleor/checkout/models.py
@@ -446,9 +446,6 @@ class CheckoutLine(ModelWithMetadata):
         blank=True,
         null=True,
     )
-    currency = models.CharField(
-        max_length=settings.DEFAULT_CURRENCY_CODE_LENGTH,
-    )
 
     undiscounted_unit_price_amount = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
@@ -458,7 +455,7 @@ class CheckoutLine(ModelWithMetadata):
 
     undiscounted_unit_price = MoneyField(
         amount_field="undiscounted_unit_price_amount",
-        currency_field="currency",
+        currency_field="checkout_currency",
     )
 
     prior_unit_price_amount = models.DecimalField(
@@ -469,7 +466,7 @@ class CheckoutLine(ModelWithMetadata):
     )
 
     prior_unit_price = MoneyField(
-        amount_field="prior_unit_price_amount", currency_field="currency"
+        amount_field="prior_unit_price_amount", currency_field="checkout_currency"
     )
 
     total_price_net_amount = models.DecimalField(
@@ -519,7 +516,10 @@ class CheckoutLine(ModelWithMetadata):
     def is_shipping_required(self) -> bool:
         """Return `True` if the related product variant requires shipping."""
         return self.variant.is_shipping_required()
-
+        
+    @property
+    def checkout_currency(self):
+        return self.checkout.currency
 
 # Checkout metadata is moved to separate model so it can be used when checkout model is
 # locked by select_for_update during complete_checkout.


### PR DESCRIPTION
Removed currency field and updated MoneyField references to use checkout_currency. Added checkout_currency property to retrieve the currency.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
