### PR TITLE
Fix gift promotion calculation

### DIFF
--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
@@ -18,7 +18,7 @@ from ....product.models import (
     VariantChannelListingPromotionRule,
 )
 from ....tests import race_condition
-from ... import DiscountType, RewardType, RewardValueType
+from ... import DiscountType, DiscountValueType, RewardType, RewardValueType
 from ...models import CheckoutDiscount, CheckoutLineDiscount, PromotionRule
 from ...utils.checkout import (
     create_checkout_discount_objects_for_order_promotions,
@@ -2123,6 +2123,47 @@ def test_create_discount_objects_for_order_promotions_race_condition(
     discounts = list(checkout_info.checkout.discounts.all())
     assert len(discounts) == 1
     assert discounts[0].amount_value == reward_value
+
+
+def test_create_discount_objects_for_order_promotions_missing_rule_on_discount_object(
+    checkout_info,
+    checkout_lines_info,
+    gift_promotion_rule,
+):
+    # given
+    rule = gift_promotion_rule
+    checkout = checkout_info.checkout
+    channel = checkout_info.channel
+
+    gift_promotion_rule.channels.add(channel)
+    variant = gift_promotion_rule.gifts.first()
+    gift_promotion_rule.gifts.exclude(pk=variant.pk).delete()
+    gift_line = checkout.lines.create(
+        checkout=checkout,
+        variant=variant,
+        quantity=1,
+        is_gift=True,
+        undiscounted_unit_price_amount=10,
+    )
+    # create a discount object without promotion rule set
+    line_discount = CheckoutLineDiscount.objects.create(
+        promotion_rule=None,
+        line=gift_line,
+        type=DiscountType.ORDER_PROMOTION,
+        value_type=DiscountValueType.FIXED,
+        value=Decimal("5"),
+        amount_value=Decimal("5"),
+        currency=channel.currency_code,
+    )
+
+    # when
+    create_checkout_discount_objects_for_order_promotions(
+        checkout_info, checkout_lines_info
+    )
+
+    # then
+    line_discount.refresh_from_db()
+    assert line_discount.promotion_rule_id == rule.id
 
 
 def test_create_or_update_order_discount_race_condition(

--- a/saleor/discount/utils/promotion.py
+++ b/saleor/discount/utils/promotion.py
@@ -828,7 +828,7 @@ def _handle_gift_reward(
         if line_discount.line_id != line.id:
             line_discount.line = line
             fields_to_update.append("line_id")
-        promotion_rule = cast(PromotionRule, line_discount.promotion_rule)
+        promotion_rule = cast(PromotionRule, line_discount_data.promotion_rule)
         update_promotion_discount(
             promotion_rule,
             rule_info,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -1324,7 +1324,7 @@ def test_add_checkout_lines_gift_discount_applies(
 
     # when
     user_api_client.ensure_access_token()
-    with django_assert_num_queries(132):
+    with django_assert_num_queries(131):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
 
     # then


### PR DESCRIPTION
Prevent failing checkout calculations because of missing promotion rule on `CheckoutLineDisocunt`, that might be the result of removing the promotion rule

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
