### PR TITLE
Release 3.22.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.17",
+  "version": "3.22.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.17",
+      "version": "3.22.18",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.17",
+  "version": "3.22.18",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,4 +292,4 @@ target-version = "py312"
     known-first-party = [ "saleor" ]
 
 [tool.poetry]
-version = "3.22.17"
+version = "3.22.18"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.17"
+__version__ = "3.22.18"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Adjust customer events generation (#18570) (1270e9940f)
* Fix automatic checkout completion for empty lines (#18588) (120ef10b98)
* Add explicit typing to dynamically constructed enums (#18577) (b1be552b55)
* Make `id` a required argument for `mediaById` and `imageById` (#18575) (1c69e05c28)
