### PR TITLE
Fix flaky test in `product_vatiant_update`

### DIFF
--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -3564,11 +3564,11 @@ def test_update_product_variant_with_existing_metadata_and_event_when_write_diff
     staff_api_client,
     product,
     permission_manage_products,
+    site_settings,
 ):
     # Given
     # - Metadata in variant is already existing
     # - mutation writes the same metadata key but different value
-
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
@@ -3579,6 +3579,9 @@ def test_update_product_variant_with_existing_metadata_and_event_when_write_diff
     variant.metadata = {metadata_key: metadata_value}
     variant.private_metadata = {metadata_key: metadata_value}
     variant.save()
+
+    site_settings.use_legacy_update_webhook_emission = False
+    site_settings.save(update_fields=["use_legacy_update_webhook_emission"])
 
     # When
     # - Metadata is updated with the same values


### PR DESCRIPTION
Fix flaky `test_update_product_variant_with_existing_metadata_and_event_when_write_different_value` test

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
