### PR TITLE
Provide better message for transactionAPI

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -423,7 +423,7 @@ class TransactionEventReport(DeprecatedModelMutation):
                 error_code = TransactionEventReportErrorCode.ALREADY_EXISTS.value
                 error_msg = (
                     "Event with `AUTHORIZATION_SUCCESS` already "
-                    "reported for the transaction. Use "
+                    f"reported for the transaction: {transaction.pk}. Use "
                     "`AUTHORIZATION_ADJUSTMENT` to change the "
                     "authorization amount."
                 )

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -410,6 +410,7 @@ class TransactionEventReport(DeprecatedModelMutation):
                 error_msg = (
                     "The transaction with provided `pspReference` and "
                     "`type` already exists with different amount."
+                    f"Existing value: {existing_event.amount}, New value: {transaction_event.amount}"
                 )
                 error_field = "pspReference"
             elif existing_event:


### PR DESCRIPTION
### Description
I want to merge this change because it improves the clarity of error messages in the Transaction API, providing users with more detailed information about conflicting transaction amounts and helping developers debug issues more effectively.

### Issues: 
- https://github.com/saleor/saleor/issues/13951

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
