### PR TITLE
drop legacy raw_response field from adyen plugin

### DIFF
--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -472,8 +472,6 @@ class AdyenGatewayPlugin(BasePlugin):
             currency=payment_information.currency,
             transaction_id=result.message.get("pspReference", ""),
             error=error_message,
-            # @deprecated
-            raw_response=result.message,
             action_required_data=action,
             payment_method_info=payment_method_info,
             psp_reference=psp_reference,
@@ -556,8 +554,6 @@ class AdyenGatewayPlugin(BasePlugin):
             currency=payment_information.currency,
             transaction_id=result.message.get("pspReference", ""),
             error=result.message.get("refusalReason"),
-            # @deprecated
-            raw_response=result.message,
             psp_reference=result.message.get("pspReference", ""),
             payment_method_info=payment_method_info,
             legacy_adyen_plugin_payment_method=self._normalize_response_field(
@@ -619,10 +615,6 @@ class AdyenGatewayPlugin(BasePlugin):
         result_code_temporary_field = transaction.legacy_adyen_plugin_result_code
         payment_method_temporary_field = transaction.legacy_adyen_plugin_payment_method
 
-        if (not result_code_temporary_field) and (not payment_method_temporary_field):
-            # Track legacy reads, so we keep grace period in case of enqueued messages
-            logger.warning("Reading deprecated raw_response from Adyen plugin.")
-
         if result_code_temporary_field:
             result_code = result_code_temporary_field
         else:
@@ -676,8 +668,6 @@ class AdyenGatewayPlugin(BasePlugin):
             currency=payment_information.currency,
             transaction_id=token,
             error=None,
-            # @deprecated
-            raw_response={},
             transaction_already_processed=bool(transaction_already_processed),
             psp_reference=token,
         )
@@ -745,8 +735,6 @@ class AdyenGatewayPlugin(BasePlugin):
             currency=currency,
             transaction_id=result.message.get("pspReference", ""),
             error="",
-            # @deprecated
-            raw_response=result.message,
             psp_reference=result.message.get("pspReference", ""),
             legacy_adyen_plugin_payment_method=self._normalize_response_field(
                 result.message.get("paymentMethod", "")
@@ -782,8 +770,6 @@ class AdyenGatewayPlugin(BasePlugin):
             currency=payment_information.currency,
             transaction_id=result.message.get("pspReference", ""),
             error="",
-            # @deprecated
-            raw_response=result.message,
             payment_method_info=payment_method_info,
             psp_reference=result.message.get("pspReference", ""),
             legacy_adyen_plugin_payment_method=self._normalize_response_field(
@@ -820,8 +806,6 @@ class AdyenGatewayPlugin(BasePlugin):
             currency=payment_information.currency,
             transaction_id=result.message.get("pspReference", ""),
             error="",
-            # @deprecated
-            raw_response=result.message,
             psp_reference=result.message.get("pspReference", ""),
             legacy_adyen_plugin_payment_method=self._normalize_response_field(
                 result.message.get("paymentMethod", "")

--- a/saleor/payment/gateways/adyen/tests/test_plugin.py
+++ b/saleor/payment/gateways/adyen/tests/test_plugin.py
@@ -44,7 +44,6 @@ def test_process_additional_action(
         currency=dummy_payment_data.currency,
         transaction_id="ref-id",
         error=None,
-        raw_response=expected_message,
         psp_reference="ref-id",
         payment_method_info=PaymentMethodInfo(),
         legacy_adyen_plugin_result_code=expected_message.get("resultCode"),
@@ -351,7 +350,6 @@ def test_confirm_payment(payment_adyen_for_order, adyen_plugin):
         amount=payment_info.amount,
         currency=payment_info.currency,
         error="",
-        raw_response={},
     )
 
     action_transaction = create_transaction(
@@ -382,7 +380,7 @@ def test_confirm_payment_pending_order(payment_adyen_for_checkout, adyen_plugin)
         amount=payment_info.amount,
         currency=payment_info.currency,
         error="",
-        raw_response={"pspReference": "882595494831959A", "resultCode": "Pending"},
+        legacy_adyen_plugin_result_code="pending",
     )
     action_transaction = create_transaction(
         payment=payment_adyen_for_checkout,
@@ -412,7 +410,6 @@ def test_confirm_already_processed_payment(payment_adyen_for_order, adyen_plugin
         amount=payment_info.amount,
         currency=payment_info.currency,
         error="",
-        raw_response={},
     )
     create_transaction(
         payment=payment_adyen_for_order,
@@ -451,7 +448,6 @@ def test_confirm_payment_with_adyen_auto_capture(payment_adyen_for_order, adyen_
         amount=payment_info.amount,
         currency=payment_info.currency,
         error="",
-        raw_response={},
     )
 
     auth_transaction = create_transaction(
@@ -519,7 +515,6 @@ def test_refund_payment(payment_adyen_for_order, order_with_lines, adyen_plugin)
         amount=payment_info.amount,
         currency=payment_info.currency,
         error="",
-        raw_response={},
     )
 
     create_transaction(
@@ -554,7 +549,6 @@ def test_void_payment(
         amount=payment_info.amount,
         currency=payment_info.currency,
         error="",
-        raw_response={},
     )
 
     create_transaction(
@@ -589,7 +583,6 @@ def test_capture_payment(
         amount=payment_info.amount,
         currency=payment_info.currency,
         error="",
-        raw_response={},
     )
 
     create_transaction(

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -151,7 +151,6 @@ def create_new_transaction(notification, payment, kind):
         amount=amount,
         currency=currency,
         error="",
-        raw_response=notification,
         psp_reference=transaction_id,
         legacy_adyen_plugin_payment_method=notification.get("paymentMethod", "")
         .strip()
@@ -1171,7 +1170,6 @@ def handle_api_response(
         currency=payment_data.currency,
         transaction_id=response.message.get("pspReference", ""),
         error=error_message,
-        raw_response=response.message,
         action_required_data=response.message.get("action"),
         psp_reference=response.message.get("pspReference", ""),
         legacy_adyen_plugin_payment_method=response.message.get("paymentMethod", "")

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -316,7 +316,7 @@ class GatewayResponse:
     error: str | None
     customer_id: str | None = None
     payment_method_info: PaymentMethodInfo | None = None
-    # @deprecated
+    # @deprecated instead of storing entire response, pick only needed fields
     raw_response: dict[str, str] | None = None
     action_required_data: JSONType | None = None
     # Some gateway can process transaction asynchronously. This value define if we


### PR DESCRIPTION
This is follow up of https://github.com/saleor/saleor/pull/17952

Previously (3.20, 3.21, 3.22) I extracted specific fields (only used) from raw response and assigned them. Now, when data is migrated and use new fields, I want to stop saving raw_response. Then, I want migration that will prune this db column

`raw_response` field in case of adyen contains sensitive data which plugin does not need, yet it increases risk of exposing sensitive data