### PR TITLE
Fix draft order update emit events test

### DIFF
--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -3477,7 +3477,7 @@ def test_draft_order_update_emit_events(
     order.draft_save_billing_address = True
     order.draft_save_shipping_address = True
     order.voucher = voucher
-    order.voucher_code = voucher.codes.first().code
+    order.voucher_code = "OLD_CODE"
     order.customer_note = "some note"
     order.redirect_url = "http://localhost:8000/redirect"
     order.external_reference = "some_reference_string"
@@ -3520,12 +3520,12 @@ def test_draft_order_update_emit_events(
     assert graphql_address_data["lastName"] != order.billing_address.last_name
 
     input = {
+        "voucherCode": voucher.codes.last().code,
         "billingAddress": graphql_address_data,
         "shippingAddress": graphql_address_data,
         "shippingMethod": new_shipping_method_id,
         "user": user_id,
         "userEmail": "new_" + order.user_email,
-        "voucherCode": voucher.codes.last().code,
         "customerNote": order.customer_note + "_new",
         "redirectUrl": "https://www.example.com",
         "externalReference": order.external_reference + "_new",


### PR DESCRIPTION
Fix failing `test_draft_order_update_emit_events` test

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
