### PR TITLE
Fix flaky `test_set_password` tests

### DIFF
--- a/saleor/graphql/account/tests/mutations/authentication/test_set_password.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_set_password.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 
 from ......account import events as account_events
 from ......account.error_codes import AccountErrorCode
+from ......account.models import User
 from ......core.tokens import token_generator
 from .....core.utils import str_to_enum
 from .....tests.utils import get_graphql_content
@@ -32,7 +33,10 @@ SET_PASSWORD_MUTATION = """
 
 
 @freeze_time("2018-05-31 12:00:01")
-def test_set_password(user_api_client, customer_user):
+def test_set_password(user_api_client):
+    customer_user = User.objects.create_user(
+        email="testSetPassword1@example.com", password="old-password"
+    )
     token = token_generator.make_token(customer_user)
     password = "spanish-inquisition"
 
@@ -56,11 +60,14 @@ def test_set_password(user_api_client, customer_user):
     "saleor.graphql.account.mutations.authentication.set_password.match_orders_with_new_user"
 )
 def test_set_password_confirm_user_and_match_orders(
-    match_orders_with_new_user_mock, user_api_client, customer_user
+    match_orders_with_new_user_mock, user_api_client
 ):
     # given
-    customer_user.is_confirmed = False
-    customer_user.save(update_fields=["is_confirmed"])
+    customer_user = User.objects.create_user(
+        email="testSetPassword2@example.com",
+        password="old-password",
+        is_confirmed=False,
+    )
 
     token = token_generator.make_token(customer_user)
     password = "spanish-inquisition"


### PR DESCRIPTION
Those two tests are failing randomly in CI (Cannot reproduce locally). My suspicious is that some other test modified the `last_change` of the `customer_user` and that's why it's failing from time to time.  
I'm not sure if it will help for 100%.

Port of https://github.com/saleor/saleor/pull/18648

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
