### PR TITLE
Add missing celery conf for `fix_shared_address_instances_task`

### DIFF
--- a/saleor/celeryconf.py
+++ b/saleor/celeryconf.py
@@ -51,6 +51,12 @@ app.autodiscover_tasks(
 app.autodiscover_tasks(
     packages=[
         "saleor.checkout.migrations.tasks",
+    ],
+    related_name="saleor3_21",
+)
+app.autodiscover_tasks(
+    packages=[
+        "saleor.checkout.migrations.tasks",
         "saleor.order.migrations.tasks",
     ],
     related_name="saleor3_20",


### PR DESCRIPTION
Update celery conf to recognise `saleor.checkout.migrations.tasks.saleor3_21.fix_shared_address_instances_task` 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
