### PR TITLE
Add workflow for checking if celery conf is updated in case of new migration tasks

### DIFF
--- a/.github/workflows/check-migration-tasks.yml
+++ b/.github/workflows/check-migration-tasks.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   check-migration-tasks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip celery check') }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Since adding new migration tasks requires updating the Celery configuration, and this step can be easily missed, I propose introducing a workflow that fails whenever a new file is added to any `migration/tasks` directory but the Celery configuration is not updated accordingly.

Check can be skipped by adding `skip celery check` label to the PR.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
