### PR TITLE
INFRA-857  - Improve test-envs CICD - better logging and get rid of rlespinasse/github-slug-action

### DIFF
--- a/.github/workflows/test-env-cleanup-cron.yml
+++ b/.github/workflows/test-env-cleanup-cron.yml
@@ -66,13 +66,14 @@ jobs:
       - name: Print lambda outputs
         if: ${{ always() && steps.lambda.conclusion != 'skipped' }}
         env:
+          RESPONSE: ${{ steps.lambda.outputs.response }}
           INVOCATION_STATUS_CODE: ${{ fromJSON(steps.lambda.outputs.response).StatusCode }}
           LOG_RESULT_BASE64: ${{ fromJSON(steps.lambda.outputs.response).LogResult }}
           FUNCTION_ERROR: ${{ fromJSON(steps.lambda.outputs.response).FunctionError }}
           PAYLOAD: ${{ fromJSON(steps.lambda.outputs.response).Payload }}
         run: |
           # If there is no response (e.g. invoke step failed before calling Lambda), bail out gracefully
-          if [ -z "${{ steps.lambda.outputs.response }}" ]; then
+          if [ -z "${RESPONSE}" ]; then
             echo "No lambda response available (invoke step may have failed before receiving output)."
             exit 0
           fi

--- a/.github/workflows/test-env-cleanup.yml
+++ b/.github/workflows/test-env-cleanup.yml
@@ -58,13 +58,14 @@ jobs:
       - name: Print lambda outputs
         if: ${{ always() && steps.lambda.conclusion != 'skipped' }}
         env:
+          RESPONSE: ${{ steps.lambda.outputs.response }}
           INVOCATION_STATUS_CODE: ${{ fromJSON(steps.lambda.outputs.response).StatusCode }}
           LOG_RESULT_BASE64: ${{ fromJSON(steps.lambda.outputs.response).LogResult }}
           FUNCTION_ERROR: ${{ fromJSON(steps.lambda.outputs.response).FunctionError }}
           PAYLOAD: ${{ fromJSON(steps.lambda.outputs.response).Payload }}
         run: |
           # If there is no response (e.g. invoke step failed before calling Lambda), bail out gracefully
-          if [ -z "${{ steps.lambda.outputs.response }}" ]; then
+          if [ -z "${RESPONSE}" ]; then
             echo "No lambda response available (invoke step may have failed before receiving output)."
             exit 0
           fi

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -85,13 +85,14 @@ jobs:
       - name: Print lambda outputs
         if: ${{ always() && steps.lambda.conclusion != 'skipped' }}
         env:
+          RESPONSE: ${{ steps.lambda.outputs.response }}
           INVOCATION_STATUS_CODE: ${{ fromJSON(steps.lambda.outputs.response).StatusCode }}
           LOG_RESULT_BASE64: ${{ fromJSON(steps.lambda.outputs.response).LogResult }}
           FUNCTION_ERROR: ${{ fromJSON(steps.lambda.outputs.response).FunctionError }}
           PAYLOAD: ${{ fromJSON(steps.lambda.outputs.response).Payload }}
         run: |
           # If there is no response (e.g. invoke step failed before calling Lambda), bail out gracefully
-          if [ -z "${{ steps.lambda.outputs.response }}" ]; then
+          if [ -z "${RESPONSE}" ]; then
             echo "No lambda response available (invoke step may have failed before receiving output)."
             exit 0
           fi


### PR DESCRIPTION
This covers step 3 from Linear: `Improve the CICD`

I tested that it still works for both deploy and cleanup, I couldn't test cron-cleanup (I can only run it from main, not from this branch or otherwise we lack IAM permissions) but it should be okay :) 


Example logs (they will be enriched with timestamps soon, for better QOL):

Deploy:
<img width="2259" height="937" alt="image" src="https://github.com/user-attachments/assets/811bdbcf-20fd-41e6-90fd-fc5a626d491a" />

Cleanup:
<img width="2846" height="960" alt="image" src="https://github.com/user-attachments/assets/04b3887b-fae2-4aa8-b888-a8b0cfe7ed8f" />
