### PR TITLE
Mark type, slug, name fields on Attribute non nullable in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### GraphQL API
 - Gift cards support as payment method within Transaction API (read more in the [docs](https://docs.saleor.io/developer/gift-cards#using-gift-cards-in-checkout)).
+- `Attribute` fields `name`, `slug` and `type` are now non-nullable in schema.
 
 ### Webhooks
 

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -293,9 +293,9 @@ class Attribute(ChannelContextType[models.Attribute]):
         ),
     )
 
-    name = graphene.String(description=AttributeDescriptions.NAME)
-    slug = graphene.String(description=AttributeDescriptions.SLUG)
-    type = AttributeTypeEnum(description=AttributeDescriptions.TYPE)
+    name = graphene.String(description=AttributeDescriptions.NAME, required=True)
+    slug = graphene.String(description=AttributeDescriptions.SLUG, required=True)
+    type = AttributeTypeEnum(description=AttributeDescriptions.TYPE, required=True)
     unit = MeasurementUnitsEnum(description=AttributeDescriptions.UNIT)
     choices = FilterConnectionField(
         AttributeValueCountableConnection,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5894,13 +5894,13 @@ type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes")
   ): [ReferenceType!]
 
   """Name of an attribute displayed in the interface."""
-  name: String
+  name: String!
 
   """Internal representation of an attribute name."""
-  slug: String
+  slug: String!
 
   """The attribute type."""
-  type: AttributeTypeEnum
+  type: AttributeTypeEnum!
 
   """The unit of attribute values."""
   unit: MeasurementUnitsEnum


### PR DESCRIPTION
These fields are optional in schema, but required in DB, meaning that it's safe to mark them non-nullable in API