### PR TITLE
fix: handle None/invalid values in WeightScalar parsing

### DIFF
--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -1,10 +1,12 @@
 from unittest import mock
 
 import pytest
+from measurement.measures import Weight
 
 from ....order.models import Order
 from ....payment.interface import PaymentGatewayData
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
+from ..scalars import WeightScalar
 from ..utils import to_global_id_or_none
 
 QUERY_CHECKOUT = """
@@ -419,3 +421,37 @@ def test_correct_date_time_as_input(
 
     # then
     get_graphql_content(response)
+
+
+# WeightScalar tests
+
+
+def test_weight_scalar_parse_value_valid_dict():
+    value = {"unit": "KG", "value": 10.5}
+    result = WeightScalar.parse_value(value)
+    assert isinstance(result, Weight)
+    assert result.kg == 10.5
+
+
+def test_weight_scalar_parse_value_none_unit():
+    value = {"unit": None, "value": 10.5}
+    result = WeightScalar.parse_value(value)
+    assert result is None
+
+
+def test_weight_scalar_parse_value_none_value():
+    value = {"unit": "KG", "value": None}
+    result = WeightScalar.parse_value(value)
+    assert result is None
+
+
+def test_weight_scalar_parse_value_invalid_unit():
+    value = {"unit": "INVALID", "value": 10.5}
+    result = WeightScalar.parse_value(value)
+    assert result is None
+
+
+def test_weight_scalar_parse_value_invalid_value():
+    value = {"unit": "KG", "value": "invalid"}
+    result = WeightScalar.parse_value(value)
+    assert result is None


### PR DESCRIPTION
Prevent a runtime crash when GraphQL weight inputs contain null or invalid values (e.g., {"unit":"KG","value":null}) by validating unit and value, safely converting value to Decimal, and catching errors from measurement.Weight construction.

What it does:
- Validates presence of unit and value for dict inputs to WeightScalar.
- Safely converts value to Decimal and handles decimal.DecimalException.
- Catches TypeError, ValueError, and AttributeError from measurement.Weight and returns None for invalid inputs.

Fixes: [#18680](https://github.com/saleor/saleor/issues/18680)


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
