### PR TITLE
fix(devcontainer): different mypy version shadowing project's mypy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,5 +26,5 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-install-project --no-editable
 
 # Removes the default 'mypy' installed by the base image as it clashes with the
-# version in poetry.lock
+# version in uv.lock
 RUN pipx uninstall mypy


### PR DESCRIPTION
This fixes the devcontainers' pre-installed `mypy` shadowing the one that Saleor installs through `uv` which leads to unexpected errors (can lead to crashes, and to having new typing errors that aren't present for people who are not using devcontainers.)

Before:

```shell
~/Saleor/core/.devcontainer$ docker exec -ti devcontainer-saleor-1 which mypy
/usr/local/py-utils/bin/mypy

~/Saleor/core/.devcontainer$ docker exec -ti devcontainer-saleor-1 mypy --version
mypy 1.19.1 (compiled: yes)
```

After:

```shell
~/Saleor/core/.devcontainer$ docker-compose up --build -d
[…]

~/Saleor/core/.devcontainer$ docker exec -ti devcontainer-saleor-1 which mypy
/usr/local/bin/mypy

~/Saleor/core/.devcontainer$ docker exec -ti devcontainer-saleor-1 mypy --version
mypy 1.17.1 (compiled: yes)
```

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
