### PR TITLE
Deactivate single use voucher when completing draft order

### DIFF
--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from unittest.mock import ANY, call, patch
 
 import graphene
+import pytest
 from django.db.models import Sum
 from django.test import override_settings
 from django.utils import timezone
@@ -1882,3 +1883,55 @@ def test_draft_order_complete_clear_line_draft_base_price_expire_at_field(
 
     for line in order.lines.all():
         assert line.draft_base_price_expire_at is None
+
+
+@pytest.mark.parametrize("include_draft_order_in_voucher_usage", [True, False])
+@pytest.mark.parametrize("code_is_active", [True, False])
+def test_draft_order_complete_with_single_use_voucher(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    voucher,
+    channel_USD,
+    include_draft_order_in_voucher_usage,
+    code_is_active,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = draft_order
+
+    channel_USD.include_draft_order_in_voucher_usage = (
+        include_draft_order_in_voucher_usage
+    )
+    channel_USD.save(update_fields=["include_draft_order_in_voucher_usage"])
+
+    voucher.single_use = True
+    voucher.save(update_fields=["single_use"])
+
+    code_instance = voucher.codes.first()
+    code_instance.is_active = code_is_active
+    code_instance.save(update_fields=["is_active"])
+
+    order.voucher = voucher
+    order.voucher_code = code_instance.code
+    order.should_refresh_prices = True
+    order.save(update_fields=["voucher", "voucher_code", "should_refresh_prices"])
+    create_or_update_voucher_discount_objects_for_order(order)
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+
+    # when
+    response = staff_api_client.post_graphql(DRAFT_ORDER_COMPLETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderComplete"]["order"]
+    order.refresh_from_db()
+
+    assert data["status"] == order.status.upper()
+    assert data["voucherCode"] == code_instance.code
+    assert data["voucher"]["code"] == voucher.code
+
+    code_instance.refresh_from_db()
+    assert not code_instance.is_active


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/18690

Always deactivate single use voucher when completing draft order. We should discuss if the usage should increase for all kind of vouchers - will be discussed in `eng-1207`. For now it's a partial solution needed for now.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
