### PR TITLE
Do not return installed/created app token when not needed

### DIFF
--- a/saleor/app/management/commands/install_app.py
+++ b/saleor/app/management/commands/install_app.py
@@ -23,6 +23,12 @@ class Command(BaseCommand):
             dest="activate",
             help="Activates the app after installation",
         )
+        parser.add_argument(
+            "--quiet",
+            action="store_true",
+            dest="quiet",
+            help="Hide auth token output after installation",
+        )
 
     def validate_manifest_url(self, manifest_url: str):
         url_validator = AppURLValidator()
@@ -35,6 +41,7 @@ class Command(BaseCommand):
 
     def handle(self, *args: Any, **options: Any) -> str | None:
         activate = options["activate"]
+        quiet = options["quiet"]
         manifest_url = options["manifest-url"]
 
         self.validate_manifest_url(manifest_url)
@@ -57,4 +64,5 @@ class Command(BaseCommand):
             app_job.status = JobStatus.FAILED
             app_job.save(update_fields=["status"])
             raise e
-        return json.dumps({"auth_token": token})
+
+        return json.dumps({"auth_token": token}) if not quiet else None


### PR DESCRIPTION
I want to merge this change because currently manage.py commands may leak app token to logs when used in production environments.