### PR TITLE
Fix incorrect usage of use-old-id

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -2047,10 +2047,14 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
                 user, address = data
 
             requester = get_user_or_app_from_context(info.context)
-            if order.use_old_id is False or is_owner_or_has_one_of_perms(
+
+            if order.use_old_id is False:
+                return address
+            if user and is_owner_or_has_one_of_perms(
                 requester, user, OrderPermissions.MANAGE_ORDERS
             ):
                 return address
+
             return obfuscate_address(address)
 
         if not order.billing_address_id:
@@ -2078,7 +2082,9 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             else:
                 user, address = data
             requester = get_user_or_app_from_context(info.context)
-            if order.use_old_id is False or is_owner_or_has_one_of_perms(
+            if order.use_old_id is False:
+                return address
+            if user and is_owner_or_has_one_of_perms(
                 requester, user, OrderPermissions.MANAGE_ORDERS
             ):
                 return address
@@ -2530,10 +2536,13 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             elif user:
                 email_to_return = user.email
 
-            if order.use_old_id is False or is_owner_or_has_one_of_perms(
+            if order.use_old_id is False:
+                return email_to_return
+            if user and is_owner_or_has_one_of_perms(
                 requester, user, OrderPermissions.MANAGE_ORDERS
             ):
                 return email_to_return
+
             return obfuscate_email(email_to_return)
 
         if not order.user_id:
@@ -2732,11 +2741,14 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
     def resolve_invoices(root: SyncWebhookControlContext[models.Order], info):
         order = root.node
         requester = get_user_or_app_from_context(info.context)
-        if order.use_old_id is True:
+        if order.use_old_id is False:
+            return InvoicesByOrderIdLoader(info.context).load(order.id)
+        if order.user_id:
             check_is_owner_or_has_one_of_perms(
                 requester, order.user, OrderPermissions.MANAGE_ORDERS
             )
-        return InvoicesByOrderIdLoader(info.context).load(order.id)
+            return InvoicesByOrderIdLoader(info.context).load(order.id)
+        return []
 
     @staticmethod
     def resolve_is_shipping_required(


### PR DESCRIPTION
I want to merge this change because it fixes incorrect usage of use_old_id

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
