### PR TITLE
INFRA-786 - switch publish-containers.yml to shared workflow

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -85,7 +85,7 @@ jobs:
 
   notify:
     if: ${{ failure() }}
-    needs: build-push
+    needs: [prepare-variables, build-push]
     runs-on: ubuntu-24.04
 
     permissions:


### PR DESCRIPTION
I have temporarily added
```
on:
  workflow_dispatch:
```

and tested the workflow as such:
```
gh workflow run publish-containers.yml --ref INFRA-786 -f ref=refs/heads/main
```


Workflow run:
https://github.com/saleor/saleor/actions/runs/21395948743


It successfully published new `main` GHCR package: https://github.com/saleor/saleor/pkgs/container/saleor/658929195?tag=main ( sha256:e521a601a06b476e05917d62e98d1f384f0e78a4620e8f4f3a9278a14de11304 ) (now deleted)
<img width="961" height="597" alt="obraz" src="https://github.com/user-attachments/assets/00071cb1-6559-46ca-b87b-464fe3cf7d0d" />
