### PR TITLE
Improve email indexing in search vector - include both full email and domain

### DIFF
--- a/saleor/graphql/account/tests/queries/test_customers_filtering.py
+++ b/saleor/graphql/account/tests/queries/test_customers_filtering.py
@@ -42,6 +42,7 @@ def query_customer_with_filter():
         ({"search": "kowalski alice"}, 1),
         ({"search": "John doe"}, 1),
         ({"search": "Alice Doe"}, 0),
+        ({"search": "mirumee.com"}, 2),
     ],
 )
 def test_query_customer_members_with_filter_search(

--- a/saleor/graphql/account/tests/queries/test_staff_users_filtering.py
+++ b/saleor/graphql/account/tests/queries/test_staff_users_filtering.py
@@ -92,6 +92,7 @@ def test_query_staff_members_with_filter_by_ids(
         ({"search": "Kowalski Alice"}, 1),
         ({"search": "John Doe"}, 1),
         ({"search": "Alice Doe"}, 0),
+        ({"search": "mirumee.com"}, 2),
     ],
 )
 def test_query_staff_members_with_filter_search(


### PR DESCRIPTION
Allow searching the emails by both email and domain.

💡 
I'm not adding a migration as we already have a migration on 3.23 for search regeneration that is not released yet.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
