### PR TITLE
Upgrade Django due to security release

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1113,14 +1113,14 @@ files = [
 
 [[package]]
 name = "django"
-version = "4.2.26"
+version = "4.2.28"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "django-4.2.26-py3-none-any.whl", hash = "sha256:c96e64fc3c359d051a6306871bd26243db1bd02317472a62ffdbe6c3cae14280"},
-    {file = "django-4.2.26.tar.gz", hash = "sha256:9398e487bcb55e3f142cb56d19fbd9a83e15bb03a97edc31f408361ee76d9d7a"},
+    {file = "django-4.2.28-py3-none-any.whl", hash = "sha256:49a23c1b83ef31525f8d71a57b040f91d34660edb3f086280a8519855655ed3c"},
+    {file = "django-4.2.28.tar.gz", hash = "sha256:a4b9cd881991add394cafa8bb3b11ad1742d1e1470ba99c3ef53dc540316ccfe"},
 ]
 
 [package.dependencies]
@@ -6112,4 +6112,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12"
-content-hash = "62aa84eeace66d5bcb8e2eab67b1cf208cdb70b91cd0ddbcd92903b63b6d6ff8"
+content-hash = "e5b32b5c07309c32391eae409bb8f9b3c3e08a786df52b6a3493f0aff092beb5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ package-mode = false
     version = "^5.5.4"
 
     [tool.poetry.dependencies.django]
-    version = "^4.2.26"
+    version = "^4.2.28"
     extras = [ "bcrypt" ]
 
     [tool.poetry.dependencies.uvicorn]


### PR DESCRIPTION
I want to merge this change because it bumps Django version due to a security release: https://www.djangoproject.com/weblog/2026/feb/03/security-releases/

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
