### PR TITLE
Release 3.22.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.31",
+  "version": "3.22.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.31",
+      "version": "3.22.32",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.31",
+  "version": "3.22.32",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,4 +294,4 @@ target-version = "py312"
     known-first-party = [ "saleor" ]
 
 [tool.poetry]
-version = "3.22.31"
+version = "3.22.32"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.31"
+__version__ = "3.22.32"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.22.32 (0987fc629c)
* Bump Django to 5.2.11 (#18751) (3dba02802a)
* Revert "Add tags and last 4 chars to gift card search vector (#18737)" (#18749) (1c405b1312)
* Add tags and last 4 chars to gift card search vector (#18737) (e4e0aefbe9)
