### PR TITLE
Fix migration 0052 compatibility with PostgreSQL 18

### DIFF
--- a/saleor/discount/migrations/0052_drop_sales_constraints.py
+++ b/saleor/discount/migrations/0052_drop_sales_constraints.py
@@ -27,9 +27,13 @@ begin
          from information_schema.table_constraints
          where table_name=tab
       ) loop
-         execute concat(
-            'ALTER TABLE '||tab||' DROP CONSTRAINT IF EXISTS "'||r.constraint_name||'"'
-         );
+         begin
+            execute concat(
+               'ALTER TABLE '||tab||' DROP CONSTRAINT IF EXISTS "'||r.constraint_name||'"'
+            );
+         exception when others then
+            raise notice 'Skipping constraint % on %: %', r.constraint_name, tab, sqlerrm;
+         end;
       end loop;
    end loop;
 end;


### PR DESCRIPTION
## Problem

Migration `0052_drop_sales_constraints` fails on PostgreSQL 18 with:

```
psycopg.errors.InvalidTableDefinition: column "id" is in a primary key
CONTEXT: SQL statement "ALTER TABLE discount_sale_collections DROP CONSTRAINT IF EXISTS "discount_sale_collections_id_not_null""
```

PostgreSQL 18 raises an error when attempting to drop NOT NULL constraints on columns that are part of a primary key. The migration iterates over ALL constraints (including implicit NOT NULL from PK) and tries to drop them, which fails on PG 18.

## Fix

Added BEGIN/EXCEPTION block inside the PL/pgSQL loop to gracefully skip constraints that cannot be dropped, while still removing all other constraints as intended.

## Tested on

- PostgreSQL 18
- Saleor 3.22.32
- Fresh database (clean migration from scratch)