### PR TITLE
Deprecate export mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ Validation is now performed on the frontend (Dashboard). This change increases v
 
 ### Deprecations
 - Deprecate the `hasVariants` field on `ProductType`.
+- Deprecate export mutations (`exportProducts`, `exportGiftCards`, `exportVoucherCodes`). All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -17,6 +17,11 @@ ADDED_IN_321 = "\n\nAdded in Saleor 3.21."
 ADDED_IN_322 = "\n\nAdded in Saleor 3.22."
 ADDED_IN_323 = "\n\nAdded in Saleor 3.23."
 
+DEPRECATED_EXPORT_MUTATIONS = (
+    "Export functionality is deprecated and will be removed. "
+    "All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools."
+)
+
 
 PREVIEW_FEATURE = (
     "\n\nNote: this API is currently in Feature Preview and can be subject to "

--- a/saleor/graphql/csv/mutations/export_voucher_codes.py
+++ b/saleor/graphql/csv/mutations/export_voucher_codes.py
@@ -9,7 +9,9 @@ from ....permission.enums import DiscountPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_318, PREVIEW_FEATURE
+from ...core.descriptions import (
+    ADDED_IN_318,
+)
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.types import BaseInputObjectType, ExportError, NonNullList
 from ...core.utils import WebhookEventInfo, raise_validation_error
@@ -44,9 +46,7 @@ class ExportVoucherCodes(BaseExportMutation):
         )
 
     class Meta:
-        description = (
-            "Export voucher codes to csv/xlsx file." + ADDED_IN_318 + PREVIEW_FEATURE
-        )
+        description = "Export voucher codes to csv/xlsx file." + ADDED_IN_318
         doc_category = DOC_CATEGORY_DISCOUNTS
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
         error_type_class = ExportError

--- a/saleor/graphql/csv/schema.py
+++ b/saleor/graphql/csv/schema.py
@@ -3,6 +3,7 @@ import graphene
 from ...permission.enums import ProductPermissions
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
+from ..core.descriptions import DEPRECATED_EXPORT_MUTATIONS
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.utils import from_global_id_or_error
 from .filters import ExportFileFilterInput
@@ -42,6 +43,12 @@ class CsvQueries(graphene.ObjectType):
 
 
 class CsvMutations(graphene.ObjectType):
-    export_products = ExportProducts.Field()
-    export_gift_cards = ExportGiftCards.Field()
-    export_voucher_codes = ExportVoucherCodes.Field()
+    export_products = ExportProducts.Field(
+        deprecation_reason=DEPRECATED_EXPORT_MUTATIONS
+    )
+    export_gift_cards = ExportGiftCards.Field(
+        deprecation_reason=DEPRECATED_EXPORT_MUTATIONS
+    )
+    export_voucher_codes = ExportVoucherCodes.Field(
+        deprecation_reason=DEPRECATED_EXPORT_MUTATIONS
+    )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -18175,7 +18175,7 @@ type Mutation {
   exportProducts(
     """Fields required to export product data."""
     input: ExportProductsInput!
-  ): ExportProducts @doc(category: "Products") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, PRODUCT_EXPORT_COMPLETED], syncEvents: [])
+  ): ExportProducts @doc(category: "Products") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, PRODUCT_EXPORT_COMPLETED], syncEvents: []) @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 
   """
   Export gift cards to csv file. 
@@ -18189,14 +18189,12 @@ type Mutation {
   exportGiftCards(
     """Fields required to export gift cards data."""
     input: ExportGiftCardsInput!
-  ): ExportGiftCards @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, GIFT_CARD_EXPORT_COMPLETED], syncEvents: [])
+  ): ExportGiftCards @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, GIFT_CARD_EXPORT_COMPLETED], syncEvents: []) @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 
   """
   Export voucher codes to csv/xlsx file.
   
-  Added in Saleor 3.18.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.18. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   
@@ -18206,7 +18204,7 @@ type Mutation {
   exportVoucherCodes(
     """Fields required to export voucher codes."""
     input: ExportVoucherCodesInput!
-  ): ExportVoucherCodes @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_CODE_EXPORT_COMPLETED], syncEvents: [])
+  ): ExportVoucherCodes @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_CODE_EXPORT_COMPLETED], syncEvents: []) @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 
   """
   Upload a file. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec 
@@ -27961,9 +27959,7 @@ input ExportGiftCardsInput @doc(category: "Gift cards") {
 """
 Export voucher codes to csv/xlsx file.
 
-Added in Saleor 3.18.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.18. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 


### PR DESCRIPTION
Deprecate export mutations as we don't want to support it anymore

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
