### PR TITLE
Fix products export with filters

### DIFF
--- a/saleor/graphql/csv/tests/mutations/test_export_products.py
+++ b/saleor/graphql/csv/tests/mutations/test_export_products.py
@@ -60,42 +60,24 @@ EXPORT_PRODUCTS_BY_APP_MUTATION = """
 """
 
 
-@pytest.mark.parametrize(
-    ("input", "called_data"),
-    [
-        (
-            {
-                "scope": ExportScope.ALL.name,
-                "exportInfo": {},
-                "fileType": FileTypeEnum.CSV.name,
-            },
-            {"all": ""},
-        ),
-        (
-            {
-                "scope": ExportScope.FILTER.name,
-                "filter": {"isPublished": True},
-                "exportInfo": {},
-                "fileType": FileTypeEnum.CSV.name,
-            },
-            {"filter": {"is_published": True}},
-        ),
-    ],
-)
 @patch("saleor.graphql.csv.mutations.export_products.export_products_task.delay")
-def test_export_products_mutation(
+def test_export_products_mutation_all_scope(
     export_products_mock,
     staff_api_client,
     product_list,
     permission_manage_products,
     permission_manage_apps,
-    input,
-    called_data,
 ):
     # given
     query = EXPORT_PRODUCTS_MUTATION
     user = staff_api_client.user
-    variables = {"input": input}
+    variables = {
+        "input": {
+            "scope": ExportScope.ALL.name,
+            "exportInfo": {},
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
 
     # when
     response = staff_api_client.post_graphql(
@@ -110,7 +92,58 @@ def test_export_products_mutation(
     export_file_data = data["exportFile"]
 
     export_products_mock.assert_called_once_with(
-        ANY, called_data, {}, FileTypeEnum.CSV.value
+        ANY, {"all": ""}, {}, FileTypeEnum.CSV.value
+    )
+
+    assert not data["errors"]
+    assert data["exportFile"]["id"]
+    assert export_file_data["createdAt"]
+    assert export_file_data["user"]["email"] == staff_api_client.user.email
+    assert export_file_data["app"] is None
+    assert ExportEvent.objects.filter(
+        user=user, app=None, type=ExportEvents.EXPORT_PENDING
+    ).exists()
+
+
+@patch("saleor.graphql.csv.mutations.export_products.export_products_task.delay")
+def test_export_products_mutation_filter_scope_with_channel(
+    export_products_mock,
+    staff_api_client,
+    product_list,
+    channel_USD,
+    permission_manage_products,
+    permission_manage_apps,
+):
+    # given
+    query = EXPORT_PRODUCTS_MUTATION
+    user = staff_api_client.user
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.pk)
+    variables = {
+        "input": {
+            "scope": ExportScope.FILTER.name,
+            "filter": {"isPublished": True},
+            "exportInfo": {"channels": [channel_id]},
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["exportProducts"]
+    export_file_data = data["exportFile"]
+
+    export_products_mock.assert_called_once_with(
+        ANY,
+        {"filter": {"is_published": True, "channel": channel_USD.slug}},
+        {"channels": [str(channel_USD.pk)]},
+        FileTypeEnum.CSV.value,
     )
 
     assert not data["errors"]
@@ -635,3 +668,236 @@ def test_export_products_webhooks(
     assert not data["errors"]
 
     product_export_completed_mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "filter_input",
+    [
+        {"stockAvailability": "OUT_OF_STOCK"},
+        {"isPublished": True},
+        {"isAvailable": True},
+        {"isVisibleInListing": True},
+        {"price": {"gte": 10, "lte": 100}},
+        {"minimalPrice": {"gte": 10, "lte": 100}},
+    ],
+)
+@patch("saleor.graphql.csv.mutations.export_products.export_products_task.delay")
+def test_export_products_with_channel_dependent_filter_requires_channel(
+    export_products_mock,
+    staff_api_client,
+    product_list,
+    channel_USD,
+    permission_manage_products,
+    permission_manage_apps,
+    filter_input,
+):
+    """Test that channel-dependent filters require exactly one channel in exportInfo."""
+    # given
+    query = EXPORT_PRODUCTS_MUTATION
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.pk)
+    variables = {
+        "input": {
+            "scope": ExportScope.FILTER.name,
+            "filter": filter_input,
+            "exportInfo": {"channels": [channel_id]},
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["exportProducts"]
+    assert not data["errors"]
+    assert data["exportFile"]["id"]
+
+    # Verify channel slug was injected into the filter
+    export_products_mock.assert_called_once()
+    call_args = export_products_mock.call_args[0]
+    scope = call_args[1]
+    assert "filter" in scope
+    assert scope["filter"]["channel"] == channel_USD.slug
+
+
+@pytest.mark.parametrize(
+    "filter_input",
+    [
+        {"stockAvailability": "OUT_OF_STOCK"},
+        {"isPublished": True},
+        {"isAvailable": True},
+        {"isVisibleInListing": True},
+        {"price": {"gte": 10, "lte": 100}},
+        {"minimalPrice": {"gte": 10, "lte": 100}},
+    ],
+)
+@patch("saleor.graphql.csv.mutations.export_products.export_products_task.delay")
+def test_export_products_with_channel_dependent_filter_no_channel_returns_error(
+    export_products_mock,
+    staff_api_client,
+    product_list,
+    permission_manage_products,
+    permission_manage_apps,
+    filter_input,
+):
+    """Test that channel-dependent filters fail when no channel is provided."""
+    # given
+    query = EXPORT_PRODUCTS_MUTATION
+    variables = {
+        "input": {
+            "scope": ExportScope.FILTER.name,
+            "filter": filter_input,
+            "exportInfo": {},
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["exportProducts"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "channels"
+    assert errors[0]["code"] == ExportErrorCode.REQUIRED.name
+    assert not data["exportFile"]
+
+    export_products_mock.assert_not_called()
+
+
+@patch("saleor.graphql.csv.mutations.export_products.export_products_task.delay")
+def test_export_products_with_channel_dependent_filter_multiple_channels_returns_error(
+    export_products_mock,
+    staff_api_client,
+    product_list,
+    channel_USD,
+    channel_PLN,
+    permission_manage_products,
+    permission_manage_apps,
+):
+    """Test that channel-dependent filters fail when multiple channels are provided."""
+    # given
+    query = EXPORT_PRODUCTS_MUTATION
+    channel_ids = [
+        graphene.Node.to_global_id("Channel", channel_USD.pk),
+        graphene.Node.to_global_id("Channel", channel_PLN.pk),
+    ]
+    variables = {
+        "input": {
+            "scope": ExportScope.FILTER.name,
+            "filter": {"stockAvailability": "OUT_OF_STOCK"},
+            "exportInfo": {"channels": channel_ids},
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["exportProducts"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "channels"
+    assert errors[0]["code"] == ExportErrorCode.REQUIRED.name
+    assert not data["exportFile"]
+
+    export_products_mock.assert_not_called()
+
+
+@patch("saleor.graphql.csv.mutations.export_products.export_products_task.delay")
+def test_export_products_with_non_channel_filter_does_not_require_channel(
+    export_products_mock,
+    staff_api_client,
+    product_list,
+    collection,
+    permission_manage_products,
+    permission_manage_apps,
+):
+    """Test that non-channel-dependent filters work without providing a channel."""
+    # given
+    query = EXPORT_PRODUCTS_MUTATION
+    collection_id = graphene.Node.to_global_id("Collection", collection.pk)
+    variables = {
+        "input": {
+            "scope": ExportScope.FILTER.name,
+            "filter": {"collections": [collection_id]},
+            "exportInfo": {},
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["exportProducts"]
+    assert not data["errors"]
+    assert data["exportFile"]["id"]
+
+    export_products_mock.assert_called_once()
+    call_args = export_products_mock.call_args[0]
+    scope = call_args[1]
+    # Channel should not be in the filter since we used a non-channel filter
+    assert "channel" not in scope.get("filter", {})
+
+
+@patch("saleor.graphql.csv.mutations.export_products.export_products_task.delay")
+def test_export_products_with_channel_dependent_filter_invalid_channel_returns_error(
+    export_products_mock,
+    staff_api_client,
+    product_list,
+    permission_manage_products,
+    permission_manage_apps,
+):
+    """Test that channel-dependent filters fail when invalid channel ID is provided."""
+    # given
+    query = EXPORT_PRODUCTS_MUTATION
+    invalid_channel_id = graphene.Node.to_global_id("Channel", 99999)
+    variables = {
+        "input": {
+            "scope": ExportScope.FILTER.name,
+            "filter": {"stockAvailability": "IN_STOCK"},
+            "exportInfo": {"channels": [invalid_channel_id]},
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["exportProducts"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "channels"
+    assert errors[0]["code"] == ExportErrorCode.NOT_FOUND.name
+    assert not data["exportFile"]
+
+    export_products_mock.assert_not_called()

--- a/saleor/graphql/product/filters/product_helpers.py
+++ b/saleor/graphql/product/filters/product_helpers.py
@@ -136,9 +136,9 @@ def filter_products_by_stock_availability(qs, stock_availability, channel_slug):
         .filter(Exists(stocks.filter(product_variant_id=OuterRef("pk"))))
         .values("product_id")
     )
-    if stock_availability == StockAvailability.IN_STOCK:
+    if stock_availability == StockAvailability.IN_STOCK.value:  # type: ignore[attr-defined]
         qs = qs.filter(Exists(variants.filter(product_id=OuterRef("pk"))))
-    if stock_availability == StockAvailability.OUT_OF_STOCK:
+    if stock_availability == StockAvailability.OUT_OF_STOCK.value:  # type: ignore[attr-defined]
         qs = qs.filter(~Exists(variants.filter(product_id=OuterRef("pk"))))
     return qs
 


### PR DESCRIPTION
Port of #18768

The products export was not working when filters that required channels were provided. 
This changes fixed such filtering, also introduced restriction, that export with channel based filters require providing exactly one channel.
Filters that concerns:
```
    [
        "is_published",
        "published_from",
        "is_available",
        "available_from",
        "is_visible_in_listing",
        "price",
        "minimal_price",
        "stock_availability",
    ]
  ```


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
