### PR TITLE
ENG-1259 - Add semver guard to latest tag checks and fix lexicographic comparison in create-tag-with-release-pr.yml

### DIFF
--- a/.github/workflows/create-tag-with-release-pr.yml
+++ b/.github/workflows/create-tag-with-release-pr.yml
@@ -22,9 +22,22 @@ jobs:
         env:
           VERSION: ${{ steps.set-version.outputs.VERSION }}
         run: |
-          latest=$(gh api --jq .name /repos/saleor/saleor/releases/latest)
-          if [ "$VERSION" \> "$latest" ]
-          then
+          set -ux
+
+          # Only stable semver releases (e.g. 3.22.0) can be tagged as latest.
+          # Non-semver refs (branch names, PR refs) are not valid candidates to become latest.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag inferred from this run ('$VERSION') is not a semver release - can't be tagged as latest."
+            echo "IS_LATEST=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CURRENT_LATEST=$(gh api "/repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
+          HIGHEST=$( (echo "$CURRENT_LATEST"; echo "$VERSION") | sort -V | tail -1)
+
+          echo "Selected: $VERSION, Latest: $CURRENT_LATEST"
+
+          if [ "$VERSION" = "$HIGHEST" ]; then
             echo "IS_LATEST=true" >> $GITHUB_OUTPUT
           else
             echo "IS_LATEST=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -57,7 +57,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CURRENT_TAG: ${{ inputs.ref || github.ref_name }}
         run: |
-          set -u
+          set -ux
+
+          # Only stable semver releases (e.g. 3.22.0) can be tagged as latest.
+          # Non-semver refs (branch names, PR refs) are not valid candidates to become latest.
+          if ! [[ "$CURRENT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag inferred from this run ('$CURRENT_TAG') is not a semver release - can't be tagged as latest."
+            echo "IS_LATEST=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
           CURRENT_LATEST=$(gh api "/repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
           HIGHEST=$( (echo "$CURRENT_LATEST"; echo "$CURRENT_TAG") | sort -V | tail -1)
@@ -65,9 +73,9 @@ jobs:
           echo "Selected: $CURRENT_TAG, Latest: $CURRENT_LATEST"
 
           if [[ "$CURRENT_TAG" == "$HIGHEST" ]]; then
-            echo "is_latest=true" >> $GITHUB_OUTPUT
+            echo "IS_LATEST=true" >> $GITHUB_OUTPUT
           else
-            echo "is_latest=false" >> $GITHUB_OUTPUT
+            echo "IS_LATEST=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Docker metadata
@@ -83,7 +91,7 @@ jobs:
             type=pep440,pattern={{version}}
             type=pep440,pattern={{major}}.{{minor}}
             type=raw,value=${{ inputs.version }},enable=${{ inputs.version != null }}
-            type=raw,value=latest,enable=${{ steps.check-latest.outputs.is_latest }}
+            type=raw,value=latest,enable=${{ steps.check-latest.outputs.IS_LATEST }}
           context: git
 
 


### PR DESCRIPTION
Follow up to https://github.com/saleor/saleor/pull/18777 - it should be part of previous PR. Thanks to @NyanKiyoshi who noticed my solution is incomplete, and it would bite us sooner or later (by marking image for loadtests as latest).



