### PR TITLE
(fix/cicd) publish-containers.yml was incompatible with our reusable notify-slack.yaml

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -116,11 +116,11 @@ jobs:
   notify:
     if: ${{ failure() }}
     needs: [prepare-variables, build-push]
-    uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@ac946d73a756846acaba11e06fb485b445edac10 # v1.9.0
+    uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@eb0c692da7bf13f5e1a82c17488b24c514dd10a1 # v1.10.0
     with:
       type: build
-      ref: ${{ needs.prepare-variables.outputs.version }}
+      ref: ${{ needs.prepare-variables.outputs.version || inputs.ref || github.ref_name }}
       status: failure
-      mention_group_id: ${{ secrets.SLACK_MENTION_GROUP_ID }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      mention_group_id: ${{ secrets.SLACK_MENTION_GROUP_ID }}


### PR DESCRIPTION
https://github.com/saleor/saleor-internal-actions v1.9.0 was incompatible with this workflow - as the `mention_group_id` is not a secret on reusable workflow side, it cannot be passed from secret on callers side as well (TIL). I released v1.10.0 which supports passing this value from secrets (see: https://github.com/saleor/saleor-internal-actions/releases/tag/v1.10.0_

I am also adding extra guardrails in case `prepare-variables` fails, as in this case the `ref` will be empty and notification step will fail as it expects `ref` to be provided.