### PR TITLE
Move payload generation of ASYNC webhook to Promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Scalars `Minute`, `Hour` and `Day` now inherit from `NonNegativeInt`, which mean GraphQL disallows negative values for time units.
 
 ### Webhooks
+For order webhook events, sync webhooks (such as `ORDER_CALCULATE_TAXES` and `ORDER_FILTER_SHIPPING_METHODS`) are no longer pre-fired before sending async webhook events. Sync webhooks are now only triggered when their data is actually requested, improving performance and decoupling async event delivery from sync webhook execution.
 
 ### Other changes
 - Improved page search with search vectors. Pages can now be searched by slug, title, content, attribute values, and page type information.

--- a/saleor/core/utils/events.py
+++ b/saleor/core/utils/events.py
@@ -2,8 +2,6 @@ from django.db import transaction
 
 from ...checkout.fetch import CheckoutInfo
 from ...checkout.models import Checkout
-from ...order.fetch import OrderInfo
-from ...order.models import Order
 from ...webhook.event_types import WebhookEventAsyncType
 from ...webhook.models import Webhook
 
@@ -127,13 +125,12 @@ def call_event(func_obj, *func_args, **func_kwargs):
     Ensures that in atomic transaction event is called on_commit.
     """
     is_protected_instance = any(
-        isinstance(arg, Checkout | CheckoutInfo | Order | OrderInfo)
-        for arg in func_args
+        isinstance(arg, Checkout | CheckoutInfo) for arg in func_args
     )
     func_obj_self = getattr(func_obj, "__self__", None)
     is_plugin_manager_method = "PluginsManager" in str(
         getattr(func_obj_self, "__class__", "")
     )
     if is_protected_instance and is_plugin_manager_method:
-        raise NotImplementedError("`call_event` doesn't support checkout/order events.")
+        raise NotImplementedError("`call_event` doesn't support checkout events.")
     call_event_including_protected_events(func_obj, *func_args, **func_kwargs)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
@@ -7,7 +7,6 @@ from django.test import override_settings
 from .....core.models import EventDelivery
 from .....discount.models import VoucherCode
 from .....order import OrderStatus
-from .....order.actions import call_order_event
 from .....order.error_codes import OrderErrorCode
 from .....webhook.event_types import WebhookEventAsyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -302,10 +301,6 @@ def test_draft_order_delete_release_voucher_codes_single_use(
     assert voucher_code.is_active is True
 
 
-@patch(
-    "saleor.graphql.order.mutations.draft_order_delete.call_order_event",
-    wraps=call_order_event,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -314,7 +309,6 @@ def test_draft_order_delete_release_voucher_codes_single_use(
 def test_draft_order_delete_do_not_trigger_sync_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
     setup_order_webhooks,
     settings,
     staff_api_client,
@@ -356,7 +350,6 @@ def test_draft_order_delete_do_not_trigger_sync_webhooks(
         MessageGroupId="example.com:saleorappadditional",
     )
     assert not mocked_send_webhook_request_sync.called
-    assert wrapped_call_order_event.called
 
 
 def test_draft_order_delete_with_voucher_and_include_draft_order_in_voucher_usage_false(

--- a/saleor/graphql/order/tests/mutations/test_order_cancel.py
+++ b/saleor/graphql/order/tests/mutations/test_order_cancel.py
@@ -7,7 +7,7 @@ from .....core.models import EventDelivery
 from .....giftcard import GiftCardEvents
 from .....giftcard.events import gift_cards_bought_event
 from .....order import OrderStatus
-from .....order.actions import call_order_events, cancel_order
+from .....order.actions import cancel_order
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
@@ -132,10 +132,6 @@ def test_order_cancel_no_channel_access(
     assert_no_permission(response)
 
 
-@patch(
-    "saleor.order.actions.call_order_events",
-    wraps=call_order_events,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -146,7 +142,6 @@ def test_order_cancel_skip_trigger_webhooks(
     mock_clean_order_cancel,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_events,
     setup_order_webhooks,
     staff_api_client,
     permission_group_manage_orders,
@@ -214,4 +209,3 @@ def test_order_cancel_skip_trigger_webhooks(
         any_order=True,
     )
     assert not mocked_send_webhook_request_sync.called
-    assert wrapped_call_order_events.called

--- a/saleor/graphql/order/tests/mutations/test_order_confirm.py
+++ b/saleor/graphql/order/tests/mutations/test_order_confirm.py
@@ -13,7 +13,6 @@ from .....order import events as order_events
 from .....order.actions import (
     WEBHOOK_EVENTS_FOR_ORDER_CHARGED,
     WEBHOOK_EVENTS_FOR_ORDER_CONFIRMED,
-    call_order_event,
     handle_fully_paid_order,
     order_charged,
     order_confirmed,
@@ -604,10 +603,6 @@ def test_order_confirm_skip_address_validation(
     assert order.status == OrderStatus.UNFULFILLED
 
 
-@patch(
-    "saleor.order.actions.call_order_event",
-    wraps=call_order_event,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -618,7 +613,6 @@ def test_order_confirm_triggers_webhooks(
     capture_mock,
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
     setup_order_webhooks,
     staff_api_client,
     order_unconfirmed,
@@ -698,4 +692,3 @@ def test_order_confirm_triggers_webhooks(
         any_order=True,
     )
     assert not mocked_send_webhook_request_sync.called
-    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/mutations/test_order_fulfill.py
@@ -9,7 +9,7 @@ from .....core.models import EventDelivery
 from .....giftcard import GiftCardEvents
 from .....giftcard.models import GiftCard, GiftCardEvent
 from .....order import FulfillmentStatus, OrderEvents, OrderStatus
-from .....order.actions import call_order_events, order_fulfilled
+from .....order.actions import order_fulfilled
 from .....order.error_codes import OrderErrorCode
 from .....order.models import Fulfillment, FulfillmentLine
 from .....product.models import ProductVariant
@@ -1560,10 +1560,6 @@ def test_order_fulfill_tracking_number_updated_event_triggered(
     assert mocked_fulfillment_created[0][1] == WebhookEventAsyncType.FULFILLMENT_CREATED
 
 
-@patch(
-    "saleor.order.actions.call_order_events",
-    wraps=call_order_events,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -1572,7 +1568,6 @@ def test_order_fulfill_tracking_number_updated_event_triggered(
 def test_order_fulfill_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_events,
     setup_order_webhooks,
     staff_api_client,
     order_with_lines,
@@ -1658,7 +1653,6 @@ def test_order_fulfill_triggers_webhooks(
         ],
         any_order=True,
     )
-    assert wrapped_call_order_events.called
 
 
 def test_order_fulfill_fulfilled_order_race_condition(

--- a/saleor/graphql/order/tests/mutations/test_order_line_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_delete.py
@@ -8,7 +8,6 @@ from django.test import override_settings
 from .....core.models import EventDelivery
 from .....order import OrderStatus
 from .....order import events as order_events
-from .....order.actions import call_order_event
 from .....order.error_codes import OrderErrorCode
 from .....order.models import OrderEvent
 from .....warehouse.models import Stock
@@ -322,10 +321,6 @@ def test_order_line_delete_non_removable_gift(
         (OrderStatus.UNCONFIRMED, WebhookEventAsyncType.ORDER_UPDATED),
     ],
 )
-@patch(
-    "saleor.graphql.order.mutations.utils.call_order_event",
-    wraps=call_order_event,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -334,7 +329,6 @@ def test_order_line_delete_non_removable_gift(
 def test_order_line_delete_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
     setup_order_webhooks,
     draft_order,
     permission_group_manage_orders,
@@ -382,8 +376,15 @@ def test_order_line_delete_triggers_webhooks(
     assert mocked_send_webhook_request_sync.call_count == 2
     assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
-    tax_delivery_call, filter_shipping_call = (
-        mocked_send_webhook_request_sync.mock_calls
+    filter_shipping_call = next(
+        call
+        for call in mocked_send_webhook_request_sync.mock_calls
+        if call.args[0].webhook_id == shipping_filter_webhook.id
+    )
+    tax_delivery_call = next(
+        call
+        for call in mocked_send_webhook_request_sync.mock_calls
+        if call.args[0].webhook_id == tax_webhook.id
     )
 
     tax_delivery = tax_delivery_call.args[0]
@@ -395,5 +396,3 @@ def test_order_line_delete_triggers_webhooks(
         filter_shipping_delivery.event_type
         == WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS
     )
-
-    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_line_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_line_update.py
@@ -15,7 +15,6 @@ from .....discount.utils.voucher import (
 )
 from .....order import OrderStatus
 from .....order import events as order_events
-from .....order.actions import call_order_event
 from .....order.calculations import fetch_order_prices_if_expired
 from .....order.error_codes import OrderErrorCode
 from .....order.models import OrderEvent
@@ -631,10 +630,6 @@ def test_order_line_update_gift_promotion(
         (OrderStatus.UNCONFIRMED, WebhookEventAsyncType.ORDER_UPDATED),
     ],
 )
-@patch(
-    "saleor.graphql.order.mutations.utils.call_order_event",
-    wraps=call_order_event,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -643,7 +638,6 @@ def test_order_line_update_gift_promotion(
 def test_order_line_update_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
     setup_order_webhooks,
     order_with_lines,
     permission_group_manage_orders,
@@ -693,8 +687,15 @@ def test_order_line_update_triggers_webhooks(
     assert mocked_send_webhook_request_sync.call_count == 2
     assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
-    tax_delivery_call, filter_shipping_call = (
-        mocked_send_webhook_request_sync.mock_calls
+    filter_shipping_call = next(
+        call
+        for call in mocked_send_webhook_request_sync.mock_calls
+        if call.args[0].webhook_id == shipping_filter_webhook.id
+    )
+    tax_delivery_call = next(
+        call
+        for call in mocked_send_webhook_request_sync.mock_calls
+        if call.args[0].webhook_id == tax_webhook.id
     )
 
     tax_delivery = tax_delivery_call.args[0]
@@ -706,8 +707,6 @@ def test_order_line_update_triggers_webhooks(
         filter_shipping_delivery.event_type
         == WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS
     )
-
-    assert wrapped_call_order_event.called
 
 
 def test_order_line_update_catalogue_discount(

--- a/saleor/graphql/order/tests/mutations/test_order_note_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_update.py
@@ -7,7 +7,6 @@ from django.test import override_settings
 from .....account.models import CustomerEvent
 from .....core.models import EventDelivery
 from .....order import OrderEvents, OrderStatus
-from .....order.actions import call_order_event
 from .....order.error_codes import OrderNoteUpdateErrorCode
 from .....order.models import OrderEvent
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
@@ -216,10 +215,6 @@ def test_order_note_remove_fail_on_missing_permission(staff_api_client, order):
         (OrderStatus.UNCONFIRMED, WebhookEventAsyncType.ORDER_UPDATED),
     ],
 )
-@patch(
-    "saleor.graphql.order.mutations.utils.call_order_event",
-    wraps=call_order_event,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -228,7 +223,6 @@ def test_order_note_remove_fail_on_missing_permission(staff_api_client, order):
 def test_order_note_update_user_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
     setup_order_webhooks,
     staff_api_client,
     permission_manage_orders,
@@ -286,8 +280,15 @@ def test_order_note_update_user_triggers_webhooks(
     assert mocked_send_webhook_request_sync.call_count == 2
     assert not EventDelivery.objects.exclude(webhook_id=order_webhook.id).exists()
 
-    tax_delivery_call, filter_shipping_call = (
-        mocked_send_webhook_request_sync.mock_calls
+    filter_shipping_call = next(
+        call
+        for call in mocked_send_webhook_request_sync.mock_calls
+        if call.args[0].webhook_id == shipping_filter_webhook.id
+    )
+    tax_delivery_call = next(
+        call
+        for call in mocked_send_webhook_request_sync.mock_calls
+        if call.args[0].webhook_id == tax_webhook.id
     )
 
     tax_delivery = tax_delivery_call.args[0]
@@ -299,5 +300,3 @@ def test_order_note_update_user_triggers_webhooks(
         filter_shipping_delivery.event_type
         == WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS
     )
-
-    assert wrapped_call_order_event.called

--- a/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
+++ b/saleor/graphql/order/tests/mutations/test_order_update_shipping.py
@@ -12,7 +12,6 @@ from .....discount.utils.voucher import (
     create_or_update_voucher_discount_objects_for_order,
 )
 from .....order import OrderStatus
-from .....order.actions import call_order_event
 from .....order.calculations import fetch_order_prices_if_expired
 from .....order.error_codes import OrderErrorCode
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
@@ -670,10 +669,6 @@ def test_order_shipping_update_mutation_properly_recalculate_total(
     assert data["order"]["shippingMethod"] is None
 
 
-@patch(
-    "saleor.graphql.order.mutations.order_update_shipping.call_order_event",
-    wraps=call_order_event,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -682,7 +677,6 @@ def test_order_shipping_update_mutation_properly_recalculate_total(
 def test_order_update_shipping_triggers_webhooks(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
     setup_order_webhooks,
     staff_api_client,
     permission_group_manage_orders,
@@ -751,13 +745,7 @@ def test_order_update_shipping_triggers_webhooks(
         )
         assert filter_shipping_call.kwargs["timeout"] == settings.WEBHOOK_SYNC_TIMEOUT
 
-    assert wrapped_call_order_event.called
 
-
-@patch(
-    "saleor.graphql.order.mutations.order_update_shipping.call_order_event",
-    wraps=call_order_event,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -766,7 +754,6 @@ def test_order_update_shipping_triggers_webhooks(
 def test_draft_order_update_shipping_triggers_proper_updated_webhook(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
     setup_order_webhooks,
     staff_api_client,
     permission_group_manage_orders,
@@ -806,13 +793,7 @@ def test_draft_order_update_shipping_triggers_proper_updated_webhook(
         MessageGroupId="example.com:saleorappadditional",
     )
 
-    assert wrapped_call_order_event.called
 
-
-@patch(
-    "saleor.graphql.order.mutations.order_update_shipping.call_order_event",
-    wraps=call_order_event,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -821,7 +802,6 @@ def test_draft_order_update_shipping_triggers_proper_updated_webhook(
 def test_draft_order_update_shipping_triggers_proper_updated_webhook_for_null_shipping_method(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
     setup_order_webhooks,
     staff_api_client,
     permission_group_manage_orders,
@@ -859,13 +839,7 @@ def test_draft_order_update_shipping_triggers_proper_updated_webhook_for_null_sh
         MessageGroupId="example.com:saleorappadditional",
     )
 
-    assert wrapped_call_order_event.called
 
-
-@patch(
-    "saleor.graphql.order.mutations.order_update_shipping.call_order_event",
-    wraps=call_order_event,
-)
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
@@ -874,7 +848,6 @@ def test_draft_order_update_shipping_triggers_proper_updated_webhook_for_null_sh
 def test_editable_order_update_shipping_triggers_proper_updated_webhook_for_null_shipping_method(
     mocked_send_webhook_request_async,
     mocked_send_webhook_request_sync,
-    wrapped_call_order_event,
     setup_order_webhooks,
     staff_api_client,
     permission_group_manage_orders,
@@ -913,5 +886,3 @@ def test_editable_order_update_shipping_triggers_proper_updated_webhook_for_null
         queue=settings.ORDER_WEBHOOK_EVENTS_CELERY_QUEUE_NAME,
         MessageGroupId="example.com:saleorappadditional",
     )
-
-    assert wrapped_call_order_event.called

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Optional, TypedDict
 from uuid import UUID
 
 import graphene
-from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import transaction
 from django.db.models import F
@@ -18,8 +17,6 @@ from ..core.tracing import traced_atomic_transaction
 from ..core.transactions import transaction_with_commit_on_errors
 from ..core.utils.events import (
     call_event,
-    call_event_including_protected_events,
-    webhook_async_event_requires_sync_webhooks_to_trigger,
 )
 from ..giftcard import GiftCardLineData
 from ..order.lock_objects import order_lines_qs_select_for_update
@@ -33,17 +30,15 @@ from ..payment import (
 from ..payment.interface import RefundData
 from ..payment.models import Payment, Transaction, TransactionItem
 from ..plugins.manager import PluginsManager
-from ..shipping.models import ShippingMethodChannelListing
 from ..warehouse.management import (
     deallocate_stock,
     deallocate_stock_for_orders,
     decrease_stock,
 )
 from ..warehouse.models import Stock
-from ..webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
+from ..webhook.event_types import WebhookEventAsyncType
 from ..webhook.utils import get_webhooks_for_multiple_events
 from . import (
-    ORDER_EDITABLE_STATUS,
     FulfillmentLineData,
     FulfillmentStatus,
     OrderChargeStatus,
@@ -52,8 +47,6 @@ from . import (
     events,
     utils,
 )
-from .calculations import fetch_order_prices_if_expired
-from .delivery_context import get_valid_shipping_methods_for_order
 from .events import (
     draft_order_created_from_replace_event,
     fulfillment_refunded_event,
@@ -103,28 +96,23 @@ class OrderFulfillmentLineInfo(TypedDict):
 WEBHOOK_EVENTS_FOR_ORDER_FULFILLED = {
     WebhookEventAsyncType.ORDER_FULFILLED,
     WebhookEventAsyncType.ORDER_UPDATED,
-    *WebhookEventSyncType.ORDER_EVENTS,
 }
 
 WEBHOOK_EVENTS_FOR_ORDER_REFUNDED = {
     WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
     WebhookEventAsyncType.ORDER_REFUNDED,
     WebhookEventAsyncType.ORDER_UPDATED,
-    *WebhookEventSyncType.ORDER_EVENTS,
 }
 WEBHOOK_EVENTS_FOR_ORDER_CANCELED = {
     WebhookEventAsyncType.ORDER_CANCELLED,
     WebhookEventAsyncType.ORDER_UPDATED,
-    *WebhookEventSyncType.ORDER_EVENTS,
 }
 WEBHOOK_EVENTS_FOR_FULLY_PAID = {
     WebhookEventAsyncType.ORDER_UPDATED,
     WebhookEventAsyncType.ORDER_FULLY_PAID,
-    *WebhookEventSyncType.ORDER_EVENTS,
 }
 WEBHOOK_EVENTS_FOR_ORDER_AUTHORIZED = {
     WebhookEventAsyncType.ORDER_UPDATED,
-    *WebhookEventSyncType.ORDER_EVENTS,
 }
 
 WEBHOOK_EVENTS_FOR_ORDER_CHARGED = {
@@ -133,7 +121,6 @@ WEBHOOK_EVENTS_FOR_ORDER_CHARGED = {
 
 WEBHOOK_EVENTS_FOR_ORDER_CONFIRMED = {
     WebhookEventAsyncType.ORDER_CONFIRMED,
-    *WebhookEventSyncType.ORDER_EVENTS,
 }
 
 
@@ -157,38 +144,6 @@ ORDER_WEBHOOK_EVENT_MAP = {
     WebhookEventAsyncType.DRAFT_ORDER_CREATED: PluginsManager.draft_order_created.__name__,
     WebhookEventAsyncType.DRAFT_ORDER_UPDATED: PluginsManager.draft_order_updated.__name__,
 }
-
-
-def _trigger_order_sync_webhooks(
-    manager: "PluginsManager",
-    order: "Order",
-    webhook_event_map: dict[str, set["Webhook"]],
-    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
-):
-    # FIXME: We can drop this after migrating the ASYNC webhooks to promise
-    # approach
-    if (
-        webhook_event_map.get(WebhookEventSyncType.ORDER_CALCULATE_TAXES)
-        and order.should_refresh_prices
-    ):
-        fetch_order_prices_if_expired(
-            order,
-            manager,
-            # This is temporary, as the whole handler will be dropped when moving
-            # ASYNC webhooks to Promises.
-            requestor=None,
-            database_connection_name=database_connection_name,
-        ).get()
-    if webhook_event_map.get(WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS):
-        shipping_listings = ShippingMethodChannelListing.objects.filter(
-            channel_id=order.channel_id
-        )
-        get_valid_shipping_methods_for_order(
-            order,
-            shipping_listings,
-            manager.requestor_getter,
-            database_connection_name=database_connection_name,
-        ).get()
 
 
 def _get_extra_for_order_logger(order: "Order") -> dict:
@@ -292,7 +247,6 @@ def call_order_events(
     manager: "PluginsManager",
     event_names: list[str],
     order: "Order",
-    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     webhook_event_map: dict[str, set["Webhook"]] | None = None,
 ):
     missing_events = set(event_names).difference(ORDER_WEBHOOK_EVENT_MAP.keys())
@@ -302,44 +256,19 @@ def call_order_events(
         )
 
     if webhook_event_map is None:
-        webhook_event_map = get_webhooks_for_multiple_events(
-            [*event_names, *WebhookEventSyncType.ORDER_EVENTS]
-        )
-
-    any_event_requires_sync_webhooks = any(
-        webhook_async_event_requires_sync_webhooks_to_trigger(
-            event_name,
-            webhook_event_map,
-            possible_sync_events=WebhookEventSyncType.ORDER_EVENTS,
-        )
-        for event_name in event_names
-    )
-
-    should_trigger_sync = (
-        any_event_requires_sync_webhooks
-        and order.status in ORDER_EDITABLE_STATUS
-        and WebhookEventAsyncType.DRAFT_ORDER_DELETED not in event_names
-    )
-    if should_trigger_sync:
-        _trigger_order_sync_webhooks(
-            manager,
-            order,
-            database_connection_name=database_connection_name,
-            webhook_event_map=webhook_event_map,
-        )
+        webhook_event_map = get_webhooks_for_multiple_events(event_names)
 
     for event_name in event_names:
         plugin_manager_method_name = ORDER_WEBHOOK_EVENT_MAP[event_name]
         webhooks = webhook_event_map.get(event_name, set())
         event_func = getattr(manager, plugin_manager_method_name)
-        call_event_including_protected_events(event_func, order, webhooks=webhooks)
+        call_event(event_func, order, webhooks=webhooks)
 
 
 def call_order_event(
     manager: "PluginsManager",
     event_name: str,
     order: "Order",
-    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
     webhook_event_map: dict[str, set["Webhook"]] | None = None,
 ):
     if event_name not in ORDER_WEBHOOK_EVENT_MAP:
@@ -349,34 +278,11 @@ def call_order_event(
     event_func = getattr(manager, plugin_manager_method_name)
 
     if webhook_event_map is None:
-        webhook_event_map = get_webhooks_for_multiple_events(
-            [event_name, *WebhookEventSyncType.ORDER_EVENTS]
-        )
+        webhook_event_map = get_webhooks_for_multiple_events([event_name])
 
     webhooks = webhook_event_map.get(event_name, set())
 
-    if order.status not in ORDER_EDITABLE_STATUS:
-        call_event_including_protected_events(event_func, order, webhooks=webhooks)
-        return
-    if event_name == WebhookEventAsyncType.DRAFT_ORDER_DELETED:
-        call_event_including_protected_events(event_func, order, webhooks=webhooks)
-        return
-
-    if not webhook_async_event_requires_sync_webhooks_to_trigger(
-        event_name, webhook_event_map, WebhookEventSyncType.ORDER_EVENTS
-    ):
-        call_event_including_protected_events(event_func, order, webhooks=webhooks)
-        return
-
-    _trigger_order_sync_webhooks(
-        manager,
-        order,
-        database_connection_name=database_connection_name,
-        webhook_event_map=webhook_event_map,
-    )
-
-    call_event_including_protected_events(event_func, order, webhooks=webhooks)
-    return
+    call_event(event_func, order, webhooks=webhooks)
 
 
 def order_created(
@@ -814,7 +720,6 @@ def order_transaction_updated(
     if transaction_item.authorized_value != previous_authorized_value:
         webhook_events = {
             WebhookEventAsyncType.ORDER_UPDATED,
-            *WebhookEventSyncType.ORDER_EVENTS,
         }
         order_updated = True
 
@@ -827,7 +732,6 @@ def order_transaction_updated(
     elif transaction_item.charged_value != previous_charged_value:
         order_updated = True
         webhook_events.add(WebhookEventAsyncType.ORDER_UPDATED)
-        webhook_events = webhook_events.union(WebhookEventSyncType.ORDER_EVENTS)
 
     if transaction_item.refunded_value > previous_refunded_value:
         # order_updated False as order_refunded triggers order_updated

--- a/saleor/order/tests/webhooks/test_exclude_shipping.py
+++ b/saleor/order/tests/webhooks/test_exclude_shipping.py
@@ -10,6 +10,7 @@ from measurement.measures import Weight
 from prices import Money
 from promise import Promise
 
+from ....core.prices import quantize_price
 from ....shipping.interface import ShippingMethodData
 from ....webhook.const import CACHE_EXCLUDED_SHIPPING_TIME
 from ....webhook.event_types import WebhookEventSyncType
@@ -139,6 +140,28 @@ def test_excluded_shipping_methods_for_order(
     payload_dict = {"order": {"id": 1, "some_field": "12"}}
     payload = json.dumps(payload_dict)
     mocked_payload.return_value = payload
+    expected_cache_key_data = {
+        "order": {
+            "id": 1,
+            "some_field": "12",
+            "base_shipping_price_amount": str(
+                quantize_price(
+                    order_with_lines.base_shipping_price.amount,
+                    order_with_lines.currency,
+                )
+            ),
+            "lines_pricing": [
+                {
+                    "base_unit_price_amount": str(
+                        quantize_price(
+                            line.base_unit_price.amount, order_with_lines.currency
+                        )
+                    ),
+                }
+                for line in order_with_lines.lines.all()
+            ],
+        }
+    }
 
     # when
     excluded_methods = excluded_shipping_methods_for_order(
@@ -165,7 +188,7 @@ def test_excluded_shipping_methods_for_order(
         requestor=None,
     )
     expected_cache_key = generate_cache_key_for_webhook(
-        payload_dict,
+        expected_cache_key_data,
         shipping_webhook.target_url,
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         shipping_app.id,
@@ -245,6 +268,28 @@ def test_multiple_app_with_excluded_shipping_methods_for_order(
     payload_dict = {"order": {"id": 1, "some_field": "12"}}
     payload = json.dumps(payload_dict)
     mocked_payload.return_value = payload
+    expected_cache_key_data = {
+        "order": {
+            "id": 1,
+            "some_field": "12",
+            "base_shipping_price_amount": str(
+                quantize_price(
+                    order_with_lines.base_shipping_price.amount,
+                    order_with_lines.currency,
+                )
+            ),
+            "lines_pricing": [
+                {
+                    "base_unit_price_amount": str(
+                        quantize_price(
+                            line.base_unit_price.amount, order_with_lines.currency
+                        )
+                    ),
+                }
+                for line in order_with_lines.lines.all()
+            ],
+        }
+    }
 
     # when
     excluded_methods = excluded_shipping_methods_for_order(
@@ -285,13 +330,13 @@ def test_multiple_app_with_excluded_shipping_methods_for_order(
     )
     assert mocked_webhook.call_count == 2
     expected_cache_for_first_webhook_key = generate_cache_key_for_webhook(
-        payload_dict,
+        expected_cache_key_data,
         shipping_webhook.target_url,
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         shipping_app.id,
     )
     expected_cache_for_second_webhook_key = generate_cache_key_for_webhook(
-        payload_dict,
+        expected_cache_key_data,
         second_shipping_webhook.target_url,
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         second_shipping_app.id,
@@ -379,6 +424,28 @@ def test_multiple_webhooks_on_the_same_app_with_excluded_shipping_methods_for_or
     payload_dict = {"order": {"id": 1, "some_field": "12"}}
     payload = json.dumps(payload_dict)
     mocked_payload.return_value = payload
+    expected_cache_key_data = {
+        "order": {
+            "id": 1,
+            "some_field": "12",
+            "base_shipping_price_amount": str(
+                quantize_price(
+                    order_with_lines.base_shipping_price.amount,
+                    order_with_lines.currency,
+                )
+            ),
+            "lines_pricing": [
+                {
+                    "base_unit_price_amount": str(
+                        quantize_price(
+                            line.base_unit_price.amount, order_with_lines.currency
+                        )
+                    ),
+                }
+                for line in order_with_lines.lines.all()
+            ],
+        }
+    }
 
     # when
     excluded_methods = excluded_shipping_methods_for_order(
@@ -417,13 +484,13 @@ def test_multiple_webhooks_on_the_same_app_with_excluded_shipping_methods_for_or
     assert mocked_webhook.call_count == 2
 
     expected_cache_for_first_webhook_key = generate_cache_key_for_webhook(
-        payload_dict,
+        expected_cache_key_data,
         first_webhook.target_url,
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         shipping_app.id,
     )
     expected_cache_for_second_webhook_key = generate_cache_key_for_webhook(
-        payload_dict,
+        expected_cache_key_data,
         second_webhook.target_url,
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         shipping_app.id,

--- a/saleor/order/tests/webhooks/test_exclude_shipping_cache.py
+++ b/saleor/order/tests/webhooks/test_exclude_shipping_cache.py
@@ -8,6 +8,7 @@ import pytest
 from measurement.measures import Weight
 from prices import Money
 
+from ....core.prices import quantize_price
 from ....shipping.interface import ShippingMethodData
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.transport.utils import generate_cache_key_for_webhook
@@ -120,6 +121,28 @@ def test_excluded_shipping_methods_for_order_stores_in_cache_when_empty(
     payload_dict = {"order": {"id": 1, "some_field": "12"}}
     payload = json.dumps(payload_dict)
     mocked_payload.return_value = payload
+    expected_cache_key_data = {
+        "order": {
+            "id": 1,
+            "some_field": "12",
+            "base_shipping_price_amount": str(
+                quantize_price(
+                    order_with_lines.base_shipping_price.amount,
+                    order_with_lines.currency,
+                )
+            ),
+            "lines_pricing": [
+                {
+                    "base_unit_price_amount": str(
+                        quantize_price(
+                            line.base_unit_price.amount, order_with_lines.currency
+                        )
+                    ),
+                }
+                for line in order_with_lines.lines.all()
+            ],
+        }
+    }
 
     mocked_cache_get.return_value = None
 
@@ -137,7 +160,7 @@ def test_excluded_shipping_methods_for_order_stores_in_cache_when_empty(
     assert mocked_webhook.called
 
     expected_cache_key = generate_cache_key_for_webhook(
-        payload_dict,
+        expected_cache_key_data,
         shipping_webhook.target_url,
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         shipping_app.id,
@@ -182,6 +205,28 @@ def test_excluded_shipping_methods_for_order_stores_in_cache_when_payload_is_dif
     payload_dict = {"order": {"id": 1, "some_field": "12"}}
     payload = json.dumps(payload_dict)
     mocked_payload.return_value = payload
+    expected_cache_key_data = {
+        "order": {
+            "id": 1,
+            "some_field": "12",
+            "base_shipping_price_amount": str(
+                quantize_price(
+                    order_with_lines.base_shipping_price.amount,
+                    order_with_lines.currency,
+                )
+            ),
+            "lines_pricing": [
+                {
+                    "base_unit_price_amount": str(
+                        quantize_price(
+                            line.base_unit_price.amount, order_with_lines.currency
+                        )
+                    ),
+                }
+                for line in order_with_lines.lines.all()
+            ],
+        }
+    }
 
     mocked_cache_get.return_value = None
 
@@ -198,7 +243,7 @@ def test_excluded_shipping_methods_for_order_stores_in_cache_when_payload_is_dif
     assert mocked_webhook.called
 
     expected_cache_key = generate_cache_key_for_webhook(
-        payload_dict,
+        expected_cache_key_data,
         shipping_webhook.target_url,
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         shipping_app.id,

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -299,11 +299,6 @@ class PluginSample(BasePlugin):
     ) -> Optional["TaxData"]:
         return sample_tax_data(checkout_info.checkout)
 
-    def get_taxes_for_order(
-        self, order: "Order", app_identifier, previous_value
-    ) -> Optional["TaxData"]:
-        return sample_tax_data(order)
-
     def sample_not_implemented(self, previous_value):
         return NotImplemented
 

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -2510,7 +2510,7 @@ def test_trigger_webhook_sync_with_subscription_within_mutation_use_default_db(
 )
 @mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch(
-    "saleor.webhook.transport.asynchronous.transport.generate_payload_from_subscription"
+    "saleor.webhook.transport.asynchronous.transport.generate_payload_promise_from_subscription"
 )
 def test_trigger_webhook_async_with_subscription_use_main_db(
     mocked_generate_payload,

--- a/saleor/webhook/transport/asynchronous/tests/test_create_deliveries_for_subscriptions.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_create_deliveries_for_subscriptions.py
@@ -4,7 +4,9 @@ from unittest import mock
 import graphene
 from django.test import override_settings
 
-from .....graphql.webhook.subscription_payload import generate_payload_from_subscription
+from .....graphql.webhook.subscription_payload import (
+    generate_payload_promise_from_subscription,
+)
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.models import Webhook
 from ..transport import (
@@ -115,8 +117,8 @@ def test_create_deliveries_no_payload_changes_limiting_disabled(webhook_app, var
 
 @override_settings(ENABLE_LIMITING_WEBHOOKS_FOR_IDENTICAL_PAYLOADS=True)
 @mock.patch(
-    "saleor.webhook.transport.asynchronous.transport.generate_payload_from_subscription",
-    wraps=generate_payload_from_subscription,
+    "saleor.webhook.transport.asynchronous.transport.generate_payload_promise_from_subscription",
+    wraps=generate_payload_promise_from_subscription,
 )
 def test_create_deliveries_reuse_request_for_webhooks(
     mock_generate_payload_from_subscription, webhook_app, variant
@@ -171,7 +173,7 @@ def test_create_deliveries_for_multiple_subscription_objects(
     # when
     deliveries = create_deliveries_for_multiple_subscription_objects(
         event_type, product_list, webhooks
-    )
+    ).get()
 
     # then
     assert len(deliveries) == len(product_list)
@@ -198,7 +200,7 @@ def test_create_deliveries_for_multiple_subscription_objects_when_more_objs_than
     # when
     deliveries = create_deliveries_for_multiple_subscription_objects(
         event_type, product_list, webhooks
-    )
+    ).get()
 
     # then
     assert len(deliveries) == len(product_list)

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -14,6 +14,7 @@ from django.apps import apps
 from django.conf import settings
 from django.db import transaction
 from opentelemetry.trace import StatusCode
+from promise import Promise
 
 from ....celeryconf import app
 from ....core import EventDeliveryStatus
@@ -28,7 +29,6 @@ from ....core.tracing import webhooks_otel_trace
 from ....core.utils import get_domain
 from ....core.utils.url import sanitize_url_for_logging
 from ....graphql.webhook.subscription_payload import (
-    generate_payload_from_subscription,
     generate_payload_promise_from_subscription,
     get_pre_save_payload_key,
     initialize_request,
@@ -90,7 +90,7 @@ def create_deliveries_for_multiple_subscription_objects(
     allow_replica=False,
     pre_save_payloads: dict | None = None,
     request_time: datetime.datetime | None = None,
-) -> list[EventDelivery]:
+) -> Promise[list[EventDelivery]]:
     """Create event deliveries with payloads based on multiple subscription objects.
 
     Trigger webhooks for each object in `subscribable_objects`. EventDeliveries and
@@ -110,17 +110,14 @@ def create_deliveries_for_multiple_subscription_objects(
         logger.info(
             "Skipping subscription webhook. Event %s is not subscribable.", event_type
         )
-        return []
-
-    event_payloads = []
-    event_payloads_data = []
-    event_deliveries = []
-    event_deliveries_for_bulk_update = []
+        return Promise.resolve([])
 
     is_sync_event = event_type in WebhookEventSyncType.ALL
     dataloaders: dict[str, type[DataLoader]] = {}
     request_map: dict[int, SaleorContext] = {}
 
+    promises = []
+    subscribable_object_with_webhook = []
     for subscribable_object in subscribable_objects:
         # Dataloaders are shared between calls to generate_payload_from_subscription to
         # reuse their cache. This avoids unnecessary DB queries when different webhooks
@@ -139,13 +136,24 @@ def create_deliveries_for_multiple_subscription_objects(
                 )
                 request_map[webhook.app_id] = request
 
-            data = generate_payload_from_subscription(
+            promise = generate_payload_promise_from_subscription(
                 event_type=event_type,
                 subscribable_object=subscribable_object,
                 subscription_query=webhook.subscription_query,
                 request=request,
             )
+            subscribable_object_with_webhook.append((subscribable_object, webhook))
+            promises.append(promise)
 
+    def process_webhook_payloads(webhook_payloads):
+        event_payloads = []
+        event_payloads_data = []
+        event_deliveries = []
+        event_deliveries_for_bulk_update = []
+
+        for (subscribable_object, webhook), data in zip(
+            subscribable_object_with_webhook, webhook_payloads, strict=False
+        ):
             if not data:
                 logger.info(
                     "No payload was generated with subscription for event: %s",
@@ -196,16 +204,18 @@ def create_deliveries_for_multiple_subscription_objects(
                 event_payloads_data = []
                 event_deliveries_for_bulk_update = []
 
-    with allow_writer():
-        # Use transaction to ensure EventPayload and EventDelivery are created together, preventing inconsistent DB state.
-        with transaction.atomic():
-            EventPayload.objects.bulk_create_with_payload_files(
-                event_payloads, event_payloads_data
-            )
-            event_deliveries.extend(
-                EventDelivery.objects.bulk_create(event_deliveries_for_bulk_update)
-            )
-        return event_deliveries
+        with allow_writer():
+            # Use transaction to ensure EventPayload and EventDelivery are created together, preventing inconsistent DB state.
+            with transaction.atomic():
+                EventPayload.objects.bulk_create_with_payload_files(
+                    event_payloads, event_payloads_data
+                )
+                event_deliveries.extend(
+                    EventDelivery.objects.bulk_create(event_deliveries_for_bulk_update)
+                )
+            return event_deliveries
+
+    return Promise.all(promises).then(process_webhook_payloads)
 
 
 def create_deliveries_for_subscriptions(
@@ -237,7 +247,7 @@ def create_deliveries_for_subscriptions(
         allow_replica,
         pre_save_payloads,
         request_time,
-    )
+    ).get()
 
 
 def create_deliveries_for_deferred_payload_subscriptions(
@@ -353,6 +363,7 @@ def trigger_webhooks_async_for_multiple_objects(
 
     # List of deliveries with payloads.
     deliveries: list[EventDelivery] = []
+    delivery_promise: Promise[list[EventDelivery]] | None = None
 
     # List of deliveries and data to generate deferred payloads for each subscribable
     # object. Note: we assume that all subscribable objects are of the same type.
@@ -400,16 +411,14 @@ def trigger_webhooks_async_for_multiple_objects(
                 )
             )
         else:
-            deliveries.extend(
-                create_deliveries_for_multiple_subscription_objects(
-                    event_type=event_type,
-                    subscribable_objects=subscribable_objects,
-                    webhooks=subscription_webhooks,
-                    requestor=requestor,
-                    allow_replica=allow_replica,
-                    pre_save_payloads=pre_save_payloads,
-                    request_time=request_time,
-                )
+            delivery_promise = create_deliveries_for_multiple_subscription_objects(
+                event_type=event_type,
+                subscribable_objects=subscribable_objects,
+                webhooks=subscription_webhooks,
+                requestor=requestor,
+                allow_replica=allow_replica,
+                pre_save_payloads=pre_save_payloads,
+                request_time=request_time,
             )
 
     domain = get_domain()
@@ -439,22 +448,27 @@ def trigger_webhooks_async_for_multiple_objects(
             MessageGroupId=message_group_id,
         )
 
-    for delivery in deliveries:
-        message_group_id = get_sqs_message_group_id(domain, delivery.webhook.app)
-        # TODO: switch to new `send_webhooks_async_for_app` task when we have
-        # deduplication mechanism in place.
+    def process_deliveries(deliveries_list):
+        for delivery in deliveries_list:
+            message_group_id = get_sqs_message_group_id(domain, delivery.webhook.app)
+            # TODO: switch to new `send_webhooks_async_for_app` task when we have
+            # deduplication mechanism in place.
 
-        send_webhook_request_async.apply_async(
-            kwargs={
-                "event_delivery_id": delivery.pk,
-                "telemetry_context": get_task_context().to_dict(),
-            },
-            queue=get_queue_name_for_webhook(
-                delivery.webhook,
-                default_queue=queue or settings.WEBHOOK_CELERY_QUEUE_NAME,
-            ),
-            MessageGroupId=message_group_id,  # for AWS SQS fair queues
-        )
+            send_webhook_request_async.apply_async(
+                kwargs={
+                    "event_delivery_id": delivery.pk,
+                    "telemetry_context": get_task_context().to_dict(),
+                },
+                queue=get_queue_name_for_webhook(
+                    delivery.webhook,
+                    default_queue=queue or settings.WEBHOOK_CELERY_QUEUE_NAME,
+                ),
+                MessageGroupId=message_group_id,  # for AWS SQS fair queues
+            )
+
+    process_deliveries(deliveries)
+    if delivery_promise:
+        delivery_promise.then(process_deliveries).get()
 
 
 def trigger_webhooks_async(

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -222,7 +222,6 @@ def trigger_webhook_sync_promise_if_not_cached(
     - Send a synchronous webhook request if cache is expired.
     - Fetch response from cache if it is still valid.
     """
-
     cache_key = generate_cache_key_for_webhook(
         cache_data, webhook.target_url, event_type, webhook.app_id
     )


### PR DESCRIPTION
I want to merge this change because it changes the payload generation to use Promise. 

Changes:
- Moved async webhook payload generation to Promise-based flow create_deliveries_for_multiple_subscription_objects now generates all subscription payloads as Promises
- Removed pre-firing of sync webhooks before async order events. Deleted _trigger_order_sync_webhooks() and all the logic that synchronously called ORDER_CALCULATE_TAXES and ORDER_FILTER_SHIPPING_METHODS before sending async webhooks like ORDER_UPDATED or ORDER_FULFILLED. 
- Fix the cache used for shipping webhooks.


The flow is still not fully promisable, as this is the first step (We're still calling .get()), but we can already use it to simplify some of the flows.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
