### PR TITLE
Deprecate digital contents in Saleor v3.22

### DIFF
--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -5,6 +5,7 @@ from ....core.db.connection import allow_writer
 from ....core.exceptions import PermissionDenied
 from ....permission.enums import ProductPermissions
 from ....product import models
+from ....product.deprecations import deprecated_digital_content
 from ....product.error_codes import ProductErrorCode
 from ...core import ResolveInfo
 from ...core.context import ChannelContext, disallow_replica_in_context
@@ -116,9 +117,8 @@ class DigitalContentCreate(BaseMutation):
         return data
 
     @classmethod
-    def perform_mutation(  # type: ignore[override]
-        cls, _root, info: ResolveInfo, /, input, variant_id: str
-    ):
+    @deprecated_digital_content
+    def perform_mutation(cls, _root, info: ResolveInfo, /, input, variant_id: str):
         variant = cls.get_node_or_error(
             info, variant_id, field="id", only_type=ProductVariant
         )
@@ -180,10 +180,9 @@ class DigitalContentDelete(BaseMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
 
     @classmethod
+    @deprecated_digital_content
     @allow_writer()
-    def mutate(  # type: ignore[override]
-        cls, root, info: ResolveInfo, /, *, variant_id: str
-    ):
+    def mutate(cls, root, info: ResolveInfo, /, *, variant_id: str):
         disallow_replica_in_context(info.context)
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
@@ -222,6 +221,7 @@ class DigitalContentUpdate(BaseMutation):
         support_private_meta_field = True
 
     @classmethod
+    @deprecated_digital_content
     def clean_input(cls, info: ResolveInfo, data):
         use_default_settings = data.get("use_default_settings")
         if use_default_settings:

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -5,6 +5,9 @@ from promise import Promise
 from ...permission.enums import ProductPermissions
 from ...permission.utils import has_one_of_permissions
 from ...product import models
+from ...product.deprecations import (
+    DEPRECATION_WARNING_MESSAGE as DEPRECATION_DIGITAL_CONTENT,
+)
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ...product.search import search_products
 from ..channel.dataloaders.by_self import ChannelBySlugLoader
@@ -160,6 +163,7 @@ class ProductQueries(graphene.ObjectType):
             ProductPermissions.MANAGE_PRODUCTS,
         ],
         doc_category=DOC_CATEGORY_PRODUCTS,
+        deprecation_reason=DEPRECATION_DIGITAL_CONTENT,
     )
     digital_contents = ConnectionField(
         DigitalContentCountableConnection,
@@ -168,6 +172,7 @@ class ProductQueries(graphene.ObjectType):
             ProductPermissions.MANAGE_PRODUCTS,
         ],
         doc_category=DOC_CATEGORY_PRODUCTS,
+        deprecation_reason=DEPRECATION_DIGITAL_CONTENT,
     )
     categories = FilterConnectionField(
         CategoryCountableConnection,
@@ -723,11 +728,19 @@ class ProductMutations(graphene.ObjectType):
     product_type_reorder_attributes = ProductTypeReorderAttributes.Field()
     product_reorder_attribute_values = ProductReorderAttributeValues.Field()
 
-    digital_content_create = DigitalContentCreate.Field()
-    digital_content_delete = DigitalContentDelete.Field()
-    digital_content_update = DigitalContentUpdate.Field()
+    digital_content_create = DigitalContentCreate.Field(
+        deprecation_reason=DEPRECATION_DIGITAL_CONTENT
+    )
+    digital_content_delete = DigitalContentDelete.Field(
+        deprecation_reason=DEPRECATION_DIGITAL_CONTENT
+    )
+    digital_content_update = DigitalContentUpdate.Field(
+        deprecation_reason=DEPRECATION_DIGITAL_CONTENT
+    )
 
-    digital_content_url_create = DigitalContentUrlCreate.Field()
+    digital_content_url_create = DigitalContentUrlCreate.Field(
+        deprecation_reason=DEPRECATION_DIGITAL_CONTENT
+    )
 
     product_variant_create = ProductVariantCreate.Field()
     product_variant_delete = ProductVariantDelete.Field()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -316,7 +316,7 @@ type Query {
   digitalContent(
     """ID of the digital content."""
     id: ID!
-  ): DigitalContent @doc(category: "Products")
+  ): DigitalContent @doc(category: "Products") @deprecated(reason: "Support for Digital Content is deprecated and will be removed in Saleor v3.23.0. This functionality is legacy and undocumented, and is not part of the supported API. Users should not rely on this behavior.")
 
   """
   List of digital content.
@@ -339,7 +339,7 @@ type Query {
     Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
     """
     last: Int
-  ): DigitalContentCountableConnection @doc(category: "Products")
+  ): DigitalContentCountableConnection @doc(category: "Products") @deprecated(reason: "Support for Digital Content is deprecated and will be removed in Saleor v3.23.0. This functionality is legacy and undocumented, and is not part of the supported API. Users should not rely on this behavior.")
 
   """List of the shop's categories."""
   categories(
@@ -16175,7 +16175,7 @@ type Mutation {
 
     """ID of a product variant to upload digital content."""
     variantId: ID!
-  ): DigitalContentCreate @doc(category: "Products")
+  ): DigitalContentCreate @doc(category: "Products") @deprecated(reason: "Support for Digital Content is deprecated and will be removed in Saleor v3.23.0. This functionality is legacy and undocumented, and is not part of the supported API. Users should not rely on this behavior.")
 
   """
   Remove digital content assigned to given variant. 
@@ -16185,7 +16185,7 @@ type Mutation {
   digitalContentDelete(
     """ID of a product variant with digital content to remove."""
     variantId: ID!
-  ): DigitalContentDelete @doc(category: "Products")
+  ): DigitalContentDelete @doc(category: "Products") @deprecated(reason: "Support for Digital Content is deprecated and will be removed in Saleor v3.23.0. This functionality is legacy and undocumented, and is not part of the supported API. Users should not rely on this behavior.")
 
   """
   Updates digital content. 
@@ -16198,7 +16198,7 @@ type Mutation {
 
     """ID of a product variant with digital content to update."""
     variantId: ID!
-  ): DigitalContentUpdate @doc(category: "Products")
+  ): DigitalContentUpdate @doc(category: "Products") @deprecated(reason: "Support for Digital Content is deprecated and will be removed in Saleor v3.23.0. This functionality is legacy and undocumented, and is not part of the supported API. Users should not rely on this behavior.")
 
   """
   Generate new URL to digital content. 
@@ -16208,7 +16208,7 @@ type Mutation {
   digitalContentUrlCreate(
     """Fields required to create a new url."""
     input: DigitalContentUrlCreateInput!
-  ): DigitalContentUrlCreate @doc(category: "Products")
+  ): DigitalContentUrlCreate @doc(category: "Products") @deprecated(reason: "Support for Digital Content is deprecated and will be removed in Saleor v3.23.0. This functionality is legacy and undocumented, and is not part of the supported API. Users should not rely on this behavior.")
 
   """
   Creates a new variant for a product. 

--- a/saleor/product/deprecations.py
+++ b/saleor/product/deprecations.py
@@ -1,0 +1,23 @@
+import functools
+import warnings
+
+from saleor.core.deprecations import SaleorDeprecationWarning
+
+DEPRECATION_WARNING_MESSAGE = (
+    "Support for Digital Content is deprecated and will be removed in Saleor v3.23.0. "
+    "This functionality is legacy and undocumented, and is not part of the supported "
+    "API. Users should not rely on this behavior."
+)
+
+
+def deprecated_digital_content(func):
+    @functools.wraps(func)
+    def _inner(*args, **kwargs):
+        warnings.warn(
+            message=DEPRECATION_WARNING_MESSAGE,
+            category=SaleorDeprecationWarning,
+            stacklevel=1,
+        )
+        return func(*args, **kwargs)
+
+    return _inner

--- a/saleor/product/views.py
+++ b/saleor/product/views.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.http import FileResponse, HttpResponseNotFound
 from django.shortcuts import get_object_or_404
 
+from .deprecations import deprecated_digital_content
 from .models import DigitalContentUrl
 from .utils.digital_products import (
     digital_content_url_is_valid,
@@ -12,6 +13,7 @@ from .utils.digital_products import (
 )
 
 
+@deprecated_digital_content
 def digital_product(request, token: str) -> FileResponse | HttpResponseNotFound:
     """Return the direct download link to content if given token is still valid."""
 


### PR DESCRIPTION
_Cherrypick of c900de1249036b4946cfceb46dc7e0ff935e450b_

Digital content is an undocumented & legacy feature that is not part of our intended API, and we do not expect nor want anyone to use this feature due to being unsupported.

This will be deprecated in all existing minor version (3.20 to 3.22), and will be removed from Saleor soon on `main` branch (for 3.23.0)


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [x] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
