### PR TITLE
Add missing cache to account tests

### DIFF
--- a/saleor/graphql/account/tests/mutations/authentication/test_token_create.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_token_create.py
@@ -397,11 +397,18 @@ def test_create_token_email_case_insensitive(
     assert data["token"]
 
 
+@patch("saleor.account.throttling.cache")
 @freeze_time("2020-03-18 12:00:00")
 def test_create_token_do_not_update_last_login_when_in_threshold(
-    api_client, customer_user, settings
+    mocked_cache,
+    api_client,
+    customer_user,
+    settings,
+    setup_mock_for_cache,
 ):
     # given
+    setup_mock_for_cache({}, mocked_cache)
+
     customer_password = customer_user._password
     customer_user.last_login = datetime.datetime.now(tz=datetime.UTC)
     customer_user.save()
@@ -423,11 +430,14 @@ def test_create_token_do_not_update_last_login_when_in_threshold(
     assert customer_user.last_login == expected_last_login
 
 
+@patch("saleor.account.throttling.cache")
 @freeze_time("2020-03-18 12:00:00")
 def test_create_token_do_update_last_login_when_out_of_threshold(
-    api_client, customer_user, settings
+    mocked_cache, api_client, customer_user, settings, setup_mock_for_cache
 ):
     # given
+    setup_mock_for_cache({}, mocked_cache)
+
     customer_password = customer_user._password
     customer_user.last_login = datetime.datetime.now(tz=datetime.UTC)
     customer_user.save()

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -1,6 +1,6 @@
 from functools import partial
 from unittest import mock
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import graphene
 import pytest
@@ -27,7 +27,10 @@ def test_middleware_dont_generate_sql_requests(client, settings, assert_num_quer
         assert response.status_code == 200
 
 
-def test_jwt_middleware(client, admin_user):
+@patch("saleor.account.throttling.cache")
+def test_jwt_middleware(mocked_cache, client, admin_user, setup_mock_for_cache):
+    setup_mock_for_cache({}, mocked_cache)
+
     # We should't base on `wsgi_request` attribute to check if user is authenticated.
     # Saleor is ASGI app, also request could be changed after response is returned.
     user_details_query = """

--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -308,11 +308,13 @@ def test_tracing_query_identifier_with_fragment(
     assert span.attributes[saleor_attributes.GRAPHQL_OPERATION_IDENTIFIER] == "products"
 
 
+@patch("saleor.account.throttling.cache")
 def test_tracing_query_identifier_for_unnamed_mutation(
-    staff_api_client,
-    get_test_spans,
+    mocked_cache, staff_api_client, get_test_spans, setup_mock_for_cache
 ):
     # given
+    setup_mock_for_cache({}, mocked_cache)
+
     query = """
         mutation{
           tokenCreate(email: "admin@example.com", password:"admin"){
@@ -331,11 +333,12 @@ def test_tracing_query_identifier_for_unnamed_mutation(
     )
 
 
+@patch("saleor.account.throttling.cache")
 def test_tracing_query_identifier_for_named_mutation(
-    staff_api_client,
-    get_test_spans,
+    mocked_cache, staff_api_client, get_test_spans, setup_mock_for_cache
 ):
     # given
+    setup_mock_for_cache({}, mocked_cache)
     query = """
         mutation MutationName{
           tokenCreate(email: "admin@example.com", password:"admin"){
@@ -354,11 +357,16 @@ def test_tracing_query_identifier_for_named_mutation(
     )
 
 
+@patch("saleor.account.throttling.cache")
 def test_tracing_query_identifier_for_many_mutations(
+    mocked_cache,
     staff_api_client,
     get_test_spans,
+    setup_mock_for_cache,
 ):
     # given
+    setup_mock_for_cache({}, mocked_cache)
+
     query = """
       mutation {
         tokenCreate(email: "admin@example.com", password:"admin"){


### PR DESCRIPTION
I want to merge this change because it adds a usage of dummy cache. Cache is used in account throttling logic. Previously we were using the non-mocked cache, which could cause the thread race between tests and cause flaky failures.


Port of changes https://github.com/saleor/saleor/pull/18795

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
