### PR TITLE
Allow to set up the app without providing `tokenTargetUrl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Validation is now performed on the frontend (Dashboard). This change increases v
 - Improve user search. Use search vector functionality to enable searching users by email address, first name, last name, and addresses.
 - Improved checkout search with search vectors. The `search_index_dirty` flag is set whenever indexed checkout data changes, and a background task runs every minute to update search vectors for dirty checkouts, processing the oldest first. Search results are returned in order of best match relevance.
 - Add optional usage telemetry. - #18789 by @wcislo-saleor
+- The app can now be installed without providing a `tokenTargetUrl` in the manifest file.
 
 ### Deprecations
 - Deprecate the `hasVariants` field on `ProductType`.

--- a/saleor/app/management/commands/install_app.py
+++ b/saleor/app/management/commands/install_app.py
@@ -75,4 +75,8 @@ class Command(BaseCommand):
             app_job.save(update_fields=["status"])
             raise e
 
-        return json.dumps({"auth_token": token}) if not quiet else None
+        response_message = None
+        if token and not quiet:
+            response_message = json.dumps({"auth_token": token})
+
+        return response_message

--- a/saleor/app/tests/test_app_commands.py
+++ b/saleor/app/tests/test_app_commands.py
@@ -51,7 +51,9 @@ def test_creates_app_from_manifest_app_has_all_required_permissions():
     assert set(app.permissions.all()) == set(expected_permission)
 
 
-def test_creates_app_from_manifest_sends_token(monkeypatch, app_manifest):
+def test_creates_app_from_manifest_sends_token_when_target_url_provided(
+    monkeypatch, app_manifest
+):
     mocked_get = Mock(return_value=Mock())
     mocked_get.return_value.json = Mock(return_value=app_manifest)
 
@@ -94,6 +96,44 @@ def test_creates_app_from_manifest_sends_token(monkeypatch, app_manifest):
         json={"auth_token": ANY},
         allow_redirects=False,
     )
+
+
+def test_creates_app_from_manifest_skips_sending_token_when_target_url_not_provided(
+    monkeypatch, app_manifest
+):
+    app_manifest.pop("tokenTargetUrl")
+
+    mocked_get = Mock(return_value=Mock())
+    mocked_get.return_value.json = Mock(return_value=app_manifest)
+
+    mocked_post = Mock(return_value=Mock())
+    mocked_post.return_value.status_code = 200
+
+    def _side_effect(_self, method, *args, **kwargs):
+        if method == "GET":
+            func = mocked_get
+        elif method == "POST":
+            func = mocked_post
+        else:
+            raise NotImplementedError("Method not implemented", method)
+        return func(method, *args, **kwargs)
+
+    monkeypatch.setattr(HTTPSession, "request", _side_effect)
+    manifest_url = "http://localhost:3000/manifest"
+
+    call_command("install_app", manifest_url)
+
+    app = App.objects.get()
+    get_call = call(
+        "GET",
+        manifest_url,
+        headers={"Saleor-Schema-Version": schema_version},
+        timeout=ANY,
+        allow_redirects=False,
+    )
+    mocked_get.assert_has_calls([get_call, get_call])
+    assert not mocked_post.called
+    assert app.tokens.count() == 0
 
 
 @pytest.mark.vcr

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -737,7 +737,7 @@ def test_install_app_webhook_incorrect_custom_headers(
     )
 
 
-def test_install_app_lack_of_token_target_url_in_manifest_data(
+def test_install_app_manifest_data_without_token_target_url(
     app_manifest, app_installation, monkeypatch, permission_manage_products
 ):
     # given
@@ -753,13 +753,11 @@ def test_install_app_lack_of_token_target_url_in_manifest_data(
 
     app_installation.permissions.set([permission_manage_products])
 
-    # when & then
-    with pytest.raises(ValidationError) as excinfo:
-        install_app(app_installation, activate=True)
+    # when
+    install_app(app_installation, activate=True)
 
-    error_dict = excinfo.value.error_dict
-    assert "tokenTargetUrl" in error_dict
-    assert error_dict["tokenTargetUrl"][0].message == "Field required."
+    # then
+    assert App.objects.count() == 1
 
 
 @pytest.fixture

--- a/saleor/app/tests/test_validators.py
+++ b/saleor/app/tests/test_validators.py
@@ -106,4 +106,5 @@ def test_new_tab_relative_url_without_app_url(app_manifest):
     app_manifest["extensions"] = [extension]
 
     # when & then
-    _clean_extension_url(extension, manifest_data=app_manifest)
+    with pytest.raises(ValidationError):
+        _clean_extension_url(extension, manifest_data=app_manifest)

--- a/saleor/graphql/app/tests/mutations/test_app_fetch_manifest.py
+++ b/saleor/graphql/app/tests/mutations/test_app_fetch_manifest.py
@@ -921,6 +921,7 @@ def test_app_fetch_manifest_extension_with_relative_url(
     staff_api_client, app_manifest, permission_manage_apps, monkeypatch
 ):
     # given
+    app_manifest["appUrl"] = "http://127.0.0.1:5000"
     app_manifest["extensions"] = [
         {
             "permissions": [],


### PR DESCRIPTION
This change removes the assumption that every third-party app must provide a tokenTargetUrl.
The tokenTargetUrl is used by Saleor to send the app token, but for apps that only serve an iframe, this step is unnecessary.
This PR simplifies the installation process, allowing apps to be fully static and not require a "register" endpoint.


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
