### PR TITLE
Release 3.22.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.33",
+  "version": "3.22.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.33",
+      "version": "3.22.34",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.33",
+  "version": "3.22.34",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,4 +294,4 @@ target-version = "py312"
     known-first-party = [ "saleor" ]
 
 [tool.poetry]
-version = "3.22.33"
+version = "3.22.34"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.33"
+__version__ = "3.22.34"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.22.34 (9bde80196c)
* Refactor media validation in product mutations (#18803) (12be3c7ff5)
* Deprecate digital contents in Saleor v3.22 (#18796) (20a8cba881)
* Add missing cache to account tests (#18801) (ae96842a96)
