### PR TITLE
Fix pagination for resolvers operates on lists

### DIFF
--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -456,6 +456,24 @@ def slice_connection_iterable(
         edge_type=edge_type or connection_type.Edge,
         pageinfo_type=pageinfo_type or graphene.relay.PageInfo,
     )
+    # This function handles pagination for list-based data (e.g., from dataloaders).
+    # The graphql-relay `connection_from_list_slice` follows the strict Relay
+    # spec where `has_previous_page` is only set when using `last` and
+    # `has_next_page` only when using `first`. Our queryset-based pagination
+    # (`connection_from_queryset_slice` → `_get_page_info`) is more lenient:
+    # it sets `has_previous_page = True` whenever an `after` cursor is present
+    # (forward pagination) and `has_next_page = True` whenever a `before` cursor
+    # is present (backward pagination). Align the list path with the queryset
+    # path so that nested connection fields (e.g., `me { orders }`) behave
+    # consistently with root-level connections.
+    first = args.get("first")
+    last = args.get("last")
+    after = args.get("after")
+    before = args.get("before")
+    if first and after:
+        slice.page_info.has_previous_page = True
+    if last and before:
+        slice.page_info.has_next_page = True
 
     if "total_count" in connection_type._meta.fields:
         slice.total_count = _len


### PR DESCRIPTION
Fix invalid pagination for fields that returns list of objects and uses paginations.

In case the query resolvers (like for `me.checkouts`, `me.orders`, `.me.giftCards`) use dataloaders that return lists, goes through different pagination code paths than root-level queries that use querysets. 
  - Queryset path (`connection_from_queryset_slice` → `_get_page_info`): Sets `has_previous_page = bool(cursor)` when using first/after — correctly returns `True` when an after cursor is present.
  - List path (`slice_connection_iterable` → graphql-relay's `connection_from_list_slice`): Sets `has_previous_page = isinstance(last, int)` — which is always `False` when paginating forward with first/after since last is None

 `slice_connection_iterable` now patches the page info after `connection_from_list_slice` returns, aligning it with the queryset path:
  - When first + after are provided →` has_previous_page = True`
  - When last + before are provided → `has_next_page = True`
 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
