### PR TITLE
Fix unsafe access to writer warnings

### DIFF
--- a/saleor/checkout/migrations/tasks/saleor3_20.py
+++ b/saleor/checkout/migrations/tasks/saleor3_20.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db.models import Exists, OuterRef
 
 from ....celeryconf import app
+from ....core.db.connection import allow_writer
 from ....discount import DiscountType
 from ....discount.models import CheckoutLineDiscount
 from ...models import Checkout, CheckoutLine
@@ -11,6 +12,7 @@ DUPLICATED_LINES_CHECKOUT_BATCH_SIZE = 250
 
 
 @app.task(queue=settings.DATA_MIGRATIONS_TASKS_QUEUE_NAME)
+@allow_writer()
 def clean_duplicated_gift_lines_task(created_after=None):
     extra_order_filter = {}
     if created_after:

--- a/saleor/order/migrations/tasks/saleor3_20.py
+++ b/saleor/order/migrations/tasks/saleor3_20.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db.models import Exists, OuterRef
 
 from ....celeryconf import app
+from ....core.db.connection import allow_writer
 from ...models import Order, OrderLine, OrderStatus
 
 # Takes about 0.1 second to process
@@ -9,6 +10,7 @@ DUPLICATED_LINES_ORDER_BATCH_SIZE = 200
 
 
 @app.task(queue=settings.DATA_MIGRATIONS_TASKS_QUEUE_NAME)
+@allow_writer()
 def clean_duplicated_gift_lines_task(created_after=None):
     extra_filter = {}
     if created_after:


### PR DESCRIPTION
Will be backported to relevant versions once approved.

Fixes two warnings: (`WARNING saleor.core.db.connection Unsafe access to the writer DB detected. Call `using()` on the `QuerySet` to utilize a replica DB, or employ the `allow_writer` context manager to explicitly permit access to the writer. ...`).

How to reproduce? Start with an empty database and run `python manage.py migrate`. Warnings will be shown at the end of migration process.