### PR TITLE
Fix externalUrl validation to accept relative URL paths

### DIFF
--- a/saleor/webhook/tests/response_schemas/test_transaction.py
+++ b/saleor/webhook/tests/response_schemas/test_transaction.py
@@ -88,6 +88,30 @@ def test_transaction_schema_valid_only_required_fields(data):
 
 
 @pytest.mark.parametrize(
+    "external_url",
+    [
+        "/dashboard/apps/QXBwOjI=/app/transactions/abc123",
+        "/relative/path",
+        "https://example.com/transactions/123",
+    ],
+)
+def test_transaction_schema_with_relative_and_absolute_external_url(external_url):
+    # given
+    data = {
+        "pspReference": "psp-123",
+        "amount": Decimal("100.50"),
+        "externalUrl": external_url,
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+    }
+
+    # when
+    transaction = TransactionBaseSchema.model_validate(data)
+
+    # then
+    assert str(transaction.external_url) == external_url
+
+
+@pytest.mark.parametrize(
     "amount",
     [Decimal("100.50"), 100.50, 100, "100.50"],
 )


### PR DESCRIPTION
## Summary

Fixes #18012. The `external_url` field in `TransactionBaseSchema` used pydantic's `HttpUrl` type, which rejects valid relative URL paths like `/dashboard/apps/QXBwOjI=/app/transactions/...`. Per RFC 3986, characters like `=` are permitted in URL path segments, and relative paths starting with `/` are valid URLs for navigation.

### Changes

**`saleor/webhook/response_schemas/transaction.py`**:
- Changed `external_url` field type from `DefaultIfNone[HttpUrl]` to `DefaultIfNone[str]`
- Added `clean_external_url` field validator that:
  - Accepts relative paths starting with `/`
  - Validates absolute URLs via `TypeAdapter(HttpUrl)`
  - Passes through empty values unchanged

**`saleor/webhook/tests/response_schemas/test_transaction.py`**:
- Added parameterized test covering relative paths (including base64 `=` characters), simple relative paths, and absolute URLs

## Test plan

- [x] Added `test_transaction_schema_with_relative_and_absolute_external_url` covering the reported case
- [x] Existing tests for `external_url` (null → empty string default, absolute URL) remain passing
- [x] Absolute URL validation is preserved via `TypeAdapter(HttpUrl)` in the field validator

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments!*