### PR TITLE
Fixed a problem where version number in pyproject.toml and uv.lock wouldn't get updated during a release

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -16,7 +16,7 @@
       "out": [
         {
           "file": "pyproject.toml",
-          "path": "tool.poetry.version"
+          "path": "project.version"
         },
         {
           "file": "./saleor/__init__.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.22.29"
+version = "3.22.37"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"
@@ -292,6 +292,3 @@ target-version = "py312"
 
     [tool.ruff.lint.isort]
     known-first-party = [ "saleor" ]
-
-[tool.poetry]
-version = "3.22.37"

--- a/uv.lock
+++ b/uv.lock
@@ -2544,7 +2544,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.22.29"
+version = "3.22.37"
 source = { virtual = "." }
 dependencies = [
     { name = "adyen", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
Will be ported to `main`.

`.release-it.json` is updated to no longer output version to `tool.poetry.version` path.

`pyproject.toml` is manually updated to the current latest version because `release-it/bumper` does search and replace so even if output path is correct it wouldn't update the version because version does not match the current one ([reference](https://github.com/release-it/bumper#:~:text=%E2%9A%A0%EF%B8%8F,be%20written%20out.)).

Why it is a problem? Look at all these different versions that are supposed to be the same (`3.22.37`).
- https://github.com/saleor/saleor/blob/3.22.37/pyproject.toml#L7
- https://github.com/saleor/saleor/blob/3.22.37/package.json#L3
- https://github.com/saleor/saleor/blob/3.22.37/uv.lock#L2547
- https://github.com/saleor/saleor/blob/3.22.37/package-lock.json#L3
- https://github.com/saleor/saleor/blob/3.22.37/saleor/__init__.py#L6