### PR TITLE
Fixed a problem where version number in pyproject.toml and uv.lock wouldn't get updated during a release

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -16,7 +16,7 @@
       "out": [
         {
           "file": "pyproject.toml",
-          "path": "tool.poetry.version"
+          "path": "project.version"
         },
         {
           "file": "./saleor/__init__.py",


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/18839.