### PR TITLE
Change the migration to only drop foreign and unique keys

### DIFF
--- a/saleor/discount/migrations/0052_drop_sales_constraints.py
+++ b/saleor/discount/migrations/0052_drop_sales_constraints.py
@@ -26,6 +26,7 @@ begin
          select constraint_name
          from information_schema.table_constraints
          where table_name=tab
+         and constraint_type in ('FOREIGN KEY', 'UNIQUE')
       ) loop
          execute concat(
             'ALTER TABLE '||tab||' DROP CONSTRAINT IF EXISTS "'||r.constraint_name||'"'


### PR DESCRIPTION
In recent versions of PostgreSQL, this migrations tries to drop parts of the primary key identity constraints. Those can't be dropped in random order and dropping them is not necessary as they don't impose any external dependencies on the table that we're about to drop.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
