### PR TITLE
Adjust preserving all address fields

### DIFF
--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -209,6 +209,8 @@ class CountryAwareAddressForm(AddressForm):
                 data = normalized_data
                 del data["sorting_code"]
 
+                # applied only when `enable_normalization` is True, as otherwise
+                # the original data are preserved anyway
                 if getattr(self, "preserve_all_address_fields", False):
                     self._restore_non_allowed_fields(data, original_data)
         except i18naddress.InvalidAddressError as exc:

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -586,6 +586,91 @@ def test_checkout_billing_address_update_with_disabled_fields_normalization(
     assert billing_address.street_address_1 == address_data["streetAddress1"]
 
 
+@pytest.mark.parametrize("preserve_all_address_fields", [True, False])
+def test_checkout_billing_address_update_with_disabled_normalization_and_preserve_all_fields(
+    checkout_with_items, user_api_client, site_settings, preserve_all_address_fields
+):
+    # given
+    site_settings.preserve_all_address_fields = preserve_all_address_fields
+    site_settings.save(update_fields=["preserve_all_address_fields"])
+
+    address_data = {
+        "firstName": "John",
+        "lastName": "Doe",
+        "streetAddress1": "Bahnhofstrasse 1",
+        "city": "Zürich",
+        "postalCode": "8001",
+        "country": "CH",
+        "countryArea": "Zürich",
+    }
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": address_data,
+        "validationRules": {"enableFieldsNormalization": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+    assert checkout_with_items.billing_address
+    billing_address = checkout_with_items.billing_address
+    assert billing_address.city == address_data["city"]
+    assert billing_address.country_area == address_data["countryArea"]
+    assert billing_address.postal_code == address_data["postalCode"]
+    assert billing_address.street_address_1 == address_data["streetAddress1"]
+
+
+def test_checkout_billing_address_update_with_enabled_normalization_and_not_preserve_all_fields(
+    checkout_with_items, user_api_client, site_settings
+):
+    # given
+    site_settings.preserve_all_address_fields = False
+    site_settings.save(update_fields=["preserve_all_address_fields"])
+
+    address_data = {
+        "firstName": "John",
+        "lastName": "Doe",
+        "streetAddress1": "Bahnhofstrasse 1",
+        "city": "Zürich",
+        "postalCode": "8001",
+        "country": "CH",
+        # country area should be cleared during normalization as it's not preserved
+        # and not required for CH addresses
+        "countryArea": "Zürich",
+    }
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": address_data,
+        "validationRules": {"enableFieldsNormalization": True},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+    assert checkout_with_items.billing_address
+    billing_address = checkout_with_items.billing_address
+    assert billing_address.city == address_data["city"]
+    assert not billing_address.country_area
+    assert billing_address.postal_code == address_data["postalCode"]
+    assert billing_address.street_address_1 == address_data["streetAddress1"]
+
+
 def test_with_active_problems_flow(
     api_client,
     checkout_with_problems,


### PR DESCRIPTION
- add comment explains why it's applied only when normalization is turn on
- add more tests for such cases

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
