### PR TITLE
Promise-Based Checkout List Shipping Methods Webhook

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 from prices import Money
+from promise import Promise
 
 from ..core.db.connection import allow_writer
 from ..core.prices import quantize_price
@@ -553,7 +554,7 @@ def get_available_built_in_shipping_methods_for_checkout_info(
 def fetch_external_shipping_methods_for_checkout_info(
     checkout_info,
     available_built_in_methods: list[ShippingMethodData],
-) -> list[ShippingMethodData]:
+) -> Promise[list[ShippingMethodData]]:
     from .webhooks.list_shipping_methods import list_shipping_methods_for_checkout
 
     allow_replica = not (
@@ -740,7 +741,7 @@ def fetch_shipping_methods_for_checkout(
         for shipping_method in fetch_external_shipping_methods_for_checkout_info(
             checkout_info=checkout_info,
             available_built_in_methods=list(built_in_shipping_methods_dict.values()),
-        )
+        ).get()
     }
     all_methods = list(built_in_shipping_methods_dict.values()) + list(
         external_shipping_methods_dict.values()

--- a/saleor/checkout/tests/test_fetch.py
+++ b/saleor/checkout/tests/test_fetch.py
@@ -851,7 +851,7 @@ def test_fetch_shipping_methods_for_checkout_with_external_shipping_method(
         },
     )
 
-    mocked_webhook.return_value = [available_shipping_method]
+    mocked_webhook.return_value = Promise.resolve([available_shipping_method])
 
     checkout = checkout_with_item
     checkout.shipping_address = address
@@ -905,7 +905,7 @@ def test_fetch_shipping_methods_for_checkout_updates_existing_external_shipping_
         },
     )
 
-    mocked_webhook.return_value = [available_shipping_method]
+    mocked_webhook.return_value = Promise.resolve([available_shipping_method])
 
     checkout = checkout_with_item
     checkout.shipping_methods.create(
@@ -969,7 +969,7 @@ def test_fetch_shipping_methods_for_checkout_removes_non_applicable_external_shi
         },
     )
 
-    mocked_webhook.return_value = [available_shipping_method]
+    mocked_webhook.return_value = Promise.resolve([available_shipping_method])
 
     checkout = checkout_with_item
     checkout.shipping_methods.create(
@@ -1033,7 +1033,7 @@ def test_fetch_shipping_methods_for_checkout_non_applicable_assigned_external_sh
         },
     )
 
-    mocked_webhook.return_value = [available_shipping_method]
+    mocked_webhook.return_value = Promise.resolve([available_shipping_method])
 
     checkout = checkout_with_item
     expired_app_id = to_shipping_app_id(external_app, "expired-shipping-method-id")
@@ -1117,7 +1117,9 @@ def test_fetch_shipping_methods_for_checkout_with_excluded_external_shipping_met
         ]
     )
 
-    mocked_list_shipping_methods.return_value = [unavailable_shipping_method]
+    mocked_list_shipping_methods.return_value = Promise.resolve(
+        [unavailable_shipping_method]
+    )
 
     checkout = checkout_with_item
     checkout.shipping_address = address

--- a/saleor/checkout/tests/webhooks/test_list_shipping_methods.py
+++ b/saleor/checkout/tests/webhooks/test_list_shipping_methods.py
@@ -34,7 +34,7 @@ def test_list_shipping_methods_for_checkout_webhook_response_none(
         [],
         allow_replica=False,
         requestor=None,
-    )
+    ).get()
 
     # then
     assert not response
@@ -61,7 +61,7 @@ def test_list_shipping_methods_for_checkout_set_cache(
     # when
     list_shipping_methods_for_checkout(
         checkout_with_item, [], allow_replica=False, requestor=None
-    )
+    ).get()
 
     # then
     assert mocked_webhook.called
@@ -92,7 +92,7 @@ def test_list_shipping_methods_no_webhook_response_sets_short_term_cache(
     # when
     list_shipping_methods_for_checkout(
         checkout_with_item, [], allow_replica=False, requestor=None
-    )
+    ).get()
 
     # then
     assert mocked_webhook.called
@@ -124,7 +124,7 @@ def test_list_shipping_methods_for_checkout_use_cache(
     # when
     list_shipping_methods_for_checkout(
         checkout_with_item, [], allow_replica=False, requestor=None
-    )
+    ).get()
 
     # then
     assert not mocked_webhook.called
@@ -145,7 +145,7 @@ def test_list_shipping_methods_for_checkout_use_cache_for_empty_list(
     # when
     list_shipping_methods_for_checkout(
         checkout_with_item, [], allow_replica=False, requestor=None
-    )
+    ).get()
 
     # then
     assert not mocked_webhook.called
@@ -197,7 +197,7 @@ def test_checkout_change_invalidates_cache_key(
     )
     list_shipping_methods_for_checkout(
         checkout_with_item, [], allow_replica=False, requestor=None
-    )
+    ).get()
 
     # then
     assert cache_key != new_cache_key
@@ -254,7 +254,7 @@ def test_ignore_selected_fields_on_generating_cache_key(
     )
     list_shipping_methods_for_checkout(
         checkout_with_item, [], allow_replica=False, requestor=None
-    )
+    ).get()
 
     # then
     assert cache_key == new_cache_key

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -8,6 +8,7 @@ import pytest
 from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
+from promise import Promise
 
 from .....checkout.actions import call_checkout_info_event
 from .....checkout.error_codes import CheckoutErrorCode
@@ -1378,7 +1379,7 @@ def test_checkout_lines_marks_shipping_methods_as_stale(
     checkout_delivery,
 ):
     # given
-    mocked_webhook.return_value = []
+    mocked_webhook.return_value = Promise.resolve([])
     checkout = checkout_with_item
     checkout.assigned_delivery = checkout_delivery(checkout)
     checkout.save(update_fields=["assigned_delivery"])


### PR DESCRIPTION
- `list_shipping_methods_for_checkout` now returns `Promise[list[ShippingMethodData]]`

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
