### PR TITLE
Make `USED_IN_ORDER` gift card events accessible for users with `MANAGE_ORDERS`

### DIFF
--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -2,12 +2,15 @@ from decimal import Decimal
 
 import graphene
 import pytest
+from django.utils import timezone
 from prices import Money, TaxedMoney
 
 from .....checkout.utils import PRIVATE_META_APP_SHIPPING_ID
 from .....core.prices import quantize_price
 from .....core.taxes import zero_taxed_money
 from .....discount import DiscountType
+from .....giftcard import GiftCardEvents, events
+from .....giftcard.models import GiftCardEvent
 from .....order import FulfillmentStatus, OrderOrigin, OrderStatus
 from .....order.events import transaction_event
 from .....order.models import Order, OrderGrantedRefund
@@ -1922,6 +1925,90 @@ def test_order_query_gift_cards(
     assert (
         gift_card.current_balance.amount == gift_card_data["currentBalance"]["amount"]
     )
+
+
+QUERY_ORDER_GIFT_CARD_EVENTS = """
+    query OrderQuery($id: ID!) {
+        order(id: $id) {
+            giftCards {
+                events {
+                    type
+                    orderId
+                }
+            }
+        }
+    }
+"""
+
+
+def test_order_query_gift_card_events_manage_orders_only_returns_used_in_order(
+    staff_api_client,
+    permission_group_manage_orders,
+    order_with_lines,
+    gift_card,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order_with_lines.gift_cards.add(gift_card)
+
+    GiftCardEvent.objects.create(
+        gift_card=gift_card, type=GiftCardEvents.ISSUED, date=timezone.now()
+    )
+    events.gift_cards_bought_event([gift_card], order_with_lines, None, None)
+    events.gift_cards_used_in_order_event(
+        [(gift_card, 10.0)], order_with_lines, None, None
+    )
+
+    order_id = graphene.Node.to_global_id("Order", order_with_lines.id)
+    variables = {"id": order_id}
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_ORDER_GIFT_CARD_EVENTS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    events_data = content["data"]["order"]["giftCards"][0]["events"]
+    assert len(events_data) == 1
+    assert events_data[0]["type"] == GiftCardEvents.USED_IN_ORDER.upper()
+    assert events_data[0]["orderId"] == order_id
+
+
+def test_order_query_gift_card_events_manage_orders_and_gift_cards_returns_all_events(
+    staff_api_client,
+    permission_group_manage_orders,
+    permission_manage_gift_card,
+    order_with_lines,
+    gift_card,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    staff_api_client.user.user_permissions.add(permission_manage_gift_card)
+    order_with_lines.gift_cards.add(gift_card)
+
+    GiftCardEvent.objects.create(
+        gift_card=gift_card, type=GiftCardEvents.ISSUED, date=timezone.now()
+    )
+    events.gift_cards_bought_event([gift_card], order_with_lines, None, None)
+    events.gift_cards_used_in_order_event(
+        [(gift_card, 10.0)], order_with_lines, None, None
+    )
+
+    order_id = graphene.Node.to_global_id("Order", order_with_lines.id)
+    variables = {"id": order_id}
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_ORDER_GIFT_CARD_EVENTS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    events_data = content["data"]["order"]["giftCards"][0]["events"]
+    assert len(events_data) == 3
+    event_types = {event["type"] for event in events_data}
+    assert event_types == {
+        GiftCardEvents.ISSUED.upper(),
+        GiftCardEvents.BOUGHT.upper(),
+        GiftCardEvents.USED_IN_ORDER.upper(),
+    }
 
 
 QUERY_ORDER_PRICES = """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11513,9 +11513,9 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   product: Product
 
   """
-  List of events associated with the gift card.
+  List of events associated with the gift card. Requires MANAGE_GIFT_CARD permission to access all events. Users with MANAGE_ORDERS permission can access only USED_IN_ORDER events.
   
-  Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Requires one of the following permissions: MANAGE_GIFT_CARD, MANAGE_ORDERS.
   """
   events(
     """Filtering options for gift card events."""


### PR DESCRIPTION
Allow fetching gift card `USED_IN_ORDER` events by users with `MANAGE_ORDERS` as it's a order specific data, required to properly show gift card used amount in dashboard order view.


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
