### PR TITLE
Drop duplicated `CACHE_EXCLUDED_SHIPPING_TIME` flag

### DIFF
--- a/saleor/order/webhooks/exclude_shipping.py
+++ b/saleor/order/webhooks/exclude_shipping.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     from ...app.models import App
     from ...order.models import Order
 
-CACHE_EXCLUDED_SHIPPING_TIME = 60 * 3
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
I want to merge this change because it drops the duplicated flag `CACHE_EXCLUDED_SHIPPING_TIME`. It is already defined in `shipping/webhooks/shared.py` file

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
