### PR TITLE
Release 3.22.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.38",
+  "version": "3.22.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.38",
+      "version": "3.22.39",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.38",
+  "version": "3.22.39",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.22.38"
+version = "3.22.39"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.38"
+__version__ = "3.22.39"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2544,7 +2544,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.22.38"
+version = "3.22.39"
 source = { virtual = "." }
 dependencies = [
     { name = "adyen", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
* Release 3.22.39 (d5a0b8b79d)
* Fix media creation mutations when `alt` field is `null` (#18864) (#18873) (edd3b820ed)
* Fix trackInventory not being applied in productBulkCreate (#18875) (93d55e62d3)
* Extend `user.orders` with where option (#18866) (c8fd3b993f)
* Make USED_IN_ORDER giftcard events accesible for users with MANAGE_ORDERS permission (#18868) (5c1d8259ca)
* Adjust preserving all address fields (#18849) (d783e2d8ed)
