### PR TITLE
Extend `install_app` management command to support sending data to the app during registration

### DIFF
--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -53,7 +53,11 @@ def validate_app_install_response(response: Response):
         ) from e
 
 
-def send_app_token(target_url: str, token: str):
+def send_app_token(
+    target_url: str,
+    token: str,
+    additional_data: dict | None = None,
+):
     domain = get_domain()
     headers = {
         "Content-Type": "application/json",
@@ -63,7 +67,10 @@ def send_app_token(target_url: str, token: str):
         AppHeaders.API_URL: build_absolute_uri(reverse("api"), domain),
         AppHeaders.SCHEMA_VERSION: schema_version,
     }
-    json_data = {"auth_token": token}
+    json_data: dict[str, str | dict] = {"auth_token": token}
+    if additional_data:
+        json_data["additional_data"] = additional_data
+
     response = HTTPClient.send_request(
         "POST",
         target_url,
@@ -213,7 +220,9 @@ def fetch_manifest(manifest_url: str, timeout=settings.COMMON_REQUESTS_TIMEOUT):
 
 
 def install_app(
-    app_installation: AppInstallation, activate: bool = False
+    app_installation: AppInstallation,
+    activate: bool = False,
+    additional_data: dict | None = None,
 ) -> tuple[App, AppToken | None]:
     manifest_data = fetch_manifest(app_installation.manifest_url)
     assigned_permissions = app_installation.permissions.all()
@@ -303,7 +312,11 @@ def install_app(
         _, token = app.tokens.create(name="Default token")  # type: ignore[call-arg] # calling create on a related manager # noqa: E501
 
         try:
-            send_app_token(target_url=tokent_target_url, token=token)
+            send_app_token(
+                target_url=tokent_target_url,
+                token=token,
+                additional_data=additional_data,
+            )
         except requests.RequestException as e:
             fetch_brand_data_async(manifest_data, app_installation=app_installation)
             app.delete()

--- a/saleor/app/management/commands/install_app.py
+++ b/saleor/app/management/commands/install_app.py
@@ -30,6 +30,12 @@ class Command(BaseCommand):
             dest="quiet",
             help="Hide auth token output after installation",
         )
+        parser.add_argument(
+            "--additional-data",
+            nargs="*",
+            default=[],
+            help="Arbitrary key-value pairs in the format key=value to be sent to app registration endpoint",
+        )
 
     def validate_manifest_url(self, manifest_url: str):
         url_validator = AppURLValidator()
@@ -40,6 +46,20 @@ class Command(BaseCommand):
                 f"Incorrect format of manifest-url: {manifest_url}"
             ) from e
 
+    def clean_additional_data(self, key_value_pairs):
+        additional_data = {}
+
+        for pair in key_value_pairs:
+            if "=" not in pair:
+                raise CommandError(
+                    f'Invalid argument format: "{pair}". Expected format is key=value.'
+                )
+
+            key, value = pair.split("=", 1)
+            additional_data[key] = value
+
+        return additional_data
+
     def handle(self, *args: Any, **options: Any) -> str | None:
         activate = options["activate"]
         quiet = options["quiet"]
@@ -48,6 +68,7 @@ class Command(BaseCommand):
         self.validate_manifest_url(manifest_url)
         manifest_data = fetch_manifest(manifest_url)
         permissions = clean_permissions(manifest_data.get("permissions", []))
+        additional_data = self.clean_additional_data(options["additional_data"])
 
         if quiet and (
             app := App.objects.not_removed()
@@ -66,7 +87,11 @@ class Command(BaseCommand):
             app_job.permissions.set(permissions)
 
         try:
-            app, token = install_app(app_job, activate)
+            app, token = install_app(
+                app_installation=app_job,
+                activate=activate,
+                additional_data=additional_data,
+            )
             app.is_installed = True
             app.save(update_fields=["is_installed"])
             app_job.delete()

--- a/saleor/app/tests/test_app_commands.py
+++ b/saleor/app/tests/test_app_commands.py
@@ -270,3 +270,50 @@ def test_creates_app_with_identifier():
     assert len(tokens) == 1
     assert app.uuid is not None
     assert app.identifier == "test.test"
+
+
+@pytest.mark.parametrize(
+    ("additional_data_args", "expected_additional_data"),
+    [
+        ([], {}),
+        (
+            ["key1=value1", "key2=value2"],
+            {"key1": "value1", "key2": "value2"},
+        ),
+    ],
+)
+def test_install_app_additional_data_handling(
+    additional_data_args, expected_additional_data
+):
+    # given
+    manifest_url = "http://otherapp:3000/manifest"
+    manifest_data = {
+        "id": "app.test.example",
+        "name": "Test App",
+        "version": "1.0.0",
+        "permissions": [],
+    }
+    mock_app = Mock(spec=App)
+    mock_token = "test-token"
+
+    with patch(
+        "saleor.app.management.commands.install_app.fetch_manifest",
+        return_value=manifest_data,
+    ), patch(
+        "saleor.app.management.commands.install_app.install_app",
+        return_value=(mock_app, mock_token),
+    ) as mocked_install_app:
+        # when
+        call_command(
+            "install_app",
+            manifest_url,
+            additional_data=additional_data_args,
+            activate=True,
+        )
+
+    # then
+    mocked_install_app.assert_called_once_with(
+        app_installation=ANY,
+        activate=True,
+        additional_data=expected_additional_data,
+    )

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -23,9 +23,47 @@ from ..installation_utils import (
     fetch_brand_data_task,
     fetch_icon_image,
     install_app,
+    send_app_token,
     validate_app_install_response,
 )
 from ..models import App
+
+
+def test_send_app_token_with_additional_data(monkeypatch):
+    # given
+    target_url = "http://otherapp:3000/register"
+    token = "test-token"
+    additional_data = {"key1": "value1", "key2": "value2"}
+
+    mock_request = Mock(return_value=Mock(status_code=200))
+    monkeypatch.setattr(HTTPSession, "request", mock_request)
+
+    # when
+    send_app_token(target_url=target_url, token=token, additional_data=additional_data)
+
+    # then
+    _, call_kwargs = mock_request.call_args
+    request_body = call_kwargs["json"]
+    assert request_body["auth_token"] == token
+    assert request_body["additional_data"] == additional_data
+
+
+def test_send_app_token_without_additional_data(monkeypatch):
+    # given
+    target_url = "http://otherapp:3000/register"
+    token = "test-token"
+
+    mock_request = Mock(return_value=Mock(status_code=200))
+    monkeypatch.setattr(HTTPSession, "request", mock_request)
+
+    # when
+    send_app_token(target_url=target_url, token=token)
+
+    # then
+    _, call_kwargs = mock_request.call_args
+    request_body = call_kwargs["json"]
+    assert request_body["auth_token"] == token
+    assert "additional_data" not in request_body
 
 
 def test_validate_app_install_response():


### PR DESCRIPTION
In certain scenarios, it might be convenient to send configuration data when creating an App. This pull request extends `install_app` management command to support that. 


