### PR TITLE
Add `undiscountedSubtotal` field to Order

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -52,7 +52,7 @@ from ..order.utils import (
     update_order_display_gross_prices,
 )
 from ..payment import PaymentError, TransactionKind, gateway
-from ..payment.model_helpers import get_subtotal
+from ..payment.model_helpers import get_subtotal, get_undiscounted_subtotal
 from ..payment.models import Payment, Transaction
 from ..payment.utils import fetch_customer_id, store_customer_id
 from ..product.models import ProductTranslation, ProductVariantTranslation
@@ -723,6 +723,10 @@ def _prepare_order_data(
         [order_line_info.line for order_line_info in order_data["lines"]],
         taxed_total.currency,
     )
+    undiscounted_subtotal = get_undiscounted_subtotal(
+        [order_line_info.line for order_line_info in order_data["lines"]],
+        taxed_total.currency,
+    )
 
     order_data.update(
         {
@@ -730,6 +734,7 @@ def _prepare_order_data(
             "tracking_client_id": checkout.tracking_code or "",
             "total": taxed_total,
             "subtotal": subtotal,
+            "undiscounted_subtotal": undiscounted_subtotal,
             "undiscounted_total": undiscounted_total,
             "shipping_tax_rate": shipping_tax_rate,
             "tax_error": checkout.tax_error,
@@ -1488,14 +1493,13 @@ def _create_order_from_checkout(
     )
 
     # update undiscounted order total
-    undiscounted_total = (
-        sum(
-            [line_info.line.undiscounted_total_price for line_info in order_lines_info],
-            start=zero_taxed_money(taxed_total.currency),
-        )
-        + undiscounted_base_shipping_price
+    undiscounted_lines_total = sum(
+        [line_info.line.undiscounted_total_price for line_info in order_lines_info],
+        start=zero_taxed_money(taxed_total.currency),
     )
+    undiscounted_total = undiscounted_lines_total + undiscounted_base_shipping_price
     order.undiscounted_total = undiscounted_total
+    order.undiscounted_subtotal = undiscounted_lines_total
     currency = checkout_info.checkout.currency
     subtotal_list = [line.line.total_price for line in order_lines_info]
     order.subtotal = sum(subtotal_list, zero_taxed_money(currency))
@@ -1503,6 +1507,8 @@ def _create_order_from_checkout(
         update_fields=[
             "undiscounted_total_net_amount",
             "undiscounted_total_gross_amount",
+            "undiscounted_subtotal_net_amount",
+            "undiscounted_subtotal_gross_amount",
             "subtotal_net_amount",
             "subtotal_gross_amount",
         ]

--- a/saleor/discount/utils/order.py
+++ b/saleor/discount/utils/order.py
@@ -15,6 +15,7 @@ from ...core.taxes import zero_money
 from ...order.base_calculations import base_order_subtotal
 from ...order.lock_objects import order_qs_select_for_update
 from ...order.models import Order, OrderLine
+from ...payment.model_helpers import get_undiscounted_subtotal
 from .. import DiscountType
 from ..interface import VariantPromotionRuleInfo
 from ..models import DiscountValueType, OrderLineDiscount
@@ -226,6 +227,9 @@ def _set_order_base_prices(order: Order, lines_info: list["EditableOrderLineInfo
     subtotal = base_order_subtotal(order, lines)
     shipping_price = order.undiscounted_base_shipping_price
     total = subtotal + shipping_price
+    undiscounted_subtotal = quantize_price(
+        get_undiscounted_subtotal(lines, order.currency), order.currency
+    )
 
     update_fields = []
     if order.subtotal != TaxedMoney(net=subtotal, gross=subtotal):
@@ -234,6 +238,11 @@ def _set_order_base_prices(order: Order, lines_info: list["EditableOrderLineInfo
     if order.total != TaxedMoney(net=total, gross=total):
         order.total = TaxedMoney(net=total, gross=total)
         update_fields.extend(["total_net_amount", "total_gross_amount"])
+    if order.undiscounted_subtotal != undiscounted_subtotal:
+        order.undiscounted_subtotal = undiscounted_subtotal
+        update_fields.extend(
+            ["undiscounted_subtotal_net_amount", "undiscounted_subtotal_gross_amount"]
+        )
 
     if update_fields:
         with allow_writer():

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -35,7 +35,8 @@ from .....payment import ChargeStatus, PaymentError, TransactionKind
 from .....payment.error_codes import PaymentErrorCode
 from .....payment.gateways.dummy_credit_card import TOKEN_VALIDATION_MAPPING
 from .....payment.interface import GatewayResponse
-from .....payment.model_helpers import get_subtotal
+from .....core.prices import quantize_price
+from .....payment.model_helpers import get_subtotal, get_undiscounted_subtotal
 from .....plugins.manager import PluginsManager, get_plugins_manager
 from .....product.models import ProductChannelListing, ProductVariantChannelListing
 from .....shipping.models import ShippingMethod
@@ -276,6 +277,10 @@ def test_checkout_complete(
     assert order.total.gross == total.gross
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.metadata == checkout.metadata_storage.metadata
     assert order.private_metadata == checkout.metadata_storage.private_metadata
@@ -1039,6 +1044,10 @@ def test_checkout_with_voucher_complete(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + discount_amount
@@ -1153,6 +1162,10 @@ def test_checkout_with_order_promotion_complete(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + discount_amount
@@ -1435,6 +1448,10 @@ def test_checkout_with_voucher_complete_product_on_promotion(
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + (
@@ -1564,6 +1581,10 @@ def test_checkout_with_voucher_on_specific_product_complete(
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + (
@@ -1679,6 +1700,10 @@ def test_checkout_complete_with_voucher_single_use(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + discount_amount
@@ -1795,6 +1820,10 @@ def test_checkout_complete_with_voucher_paid_with_gift_card_and_payment(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == subtotal + shipping_price + discount_amount
@@ -1911,6 +1940,10 @@ def test_checkout_complete_with_voucher_paid_by_gift_card(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert (
@@ -2037,6 +2070,10 @@ def test_checkout_complete_free_shipping_voucher_and_gift_card(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.shipping_price == zero_taxed_money(order.currency)
@@ -2185,6 +2222,10 @@ def test_checkout_complete_product_on_promotion(
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + (
@@ -2566,6 +2607,10 @@ def test_checkout_complete_product_on_old_sale(
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + (
@@ -2745,6 +2790,10 @@ def test_checkout_with_voucher_on_specific_product_complete_with_product_on_prom
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + (
@@ -2910,6 +2959,10 @@ def test_checkout_complete_without_inventory_tracking(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
 
     order_line = order.lines.first()
@@ -3858,6 +3911,10 @@ def test_checkout_complete_0_total_value(
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert checkout_line_quantity == order_line.quantity
     assert checkout_line_variant == order_line.variant
@@ -4276,6 +4333,10 @@ def test_checkout_complete_with_preorder_variant(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.lines.count() == len(variants_and_quantities)
     for variant_id, quantity in variants_and_quantities.items():
@@ -5712,6 +5773,10 @@ def test_checkout_complete_empty_product_translation(
     assert order.total.gross == total.gross
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.metadata == checkout.metadata_storage.metadata
     assert order.private_metadata == checkout.metadata_storage.private_metadata

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -24,6 +24,7 @@ from .....checkout.fetch import (
 )
 from .....checkout.models import Checkout, CheckoutDelivery, CheckoutLine
 from .....core.exceptions import InsufficientStock, InsufficientStockData
+from .....core.prices import quantize_price
 from .....core.taxes import TaxError, zero_money, zero_taxed_money
 from .....discount import DiscountType, DiscountValueType, RewardValueType
 from .....discount.models import CheckoutLineDiscount, OrderLineDiscount, Promotion
@@ -35,7 +36,6 @@ from .....payment import ChargeStatus, PaymentError, TransactionKind
 from .....payment.error_codes import PaymentErrorCode
 from .....payment.gateways.dummy_credit_card import TOKEN_VALIDATION_MAPPING
 from .....payment.interface import GatewayResponse
-from .....core.prices import quantize_price
 from .....payment.model_helpers import get_subtotal, get_undiscounted_subtotal
 from .....plugins.manager import PluginsManager, get_plugins_manager
 from .....product.models import ProductChannelListing, ProductVariantChannelListing
@@ -45,6 +45,14 @@ from .....warehouse.models import Reservation, Stock, WarehouseClickAndCollectOp
 from .....warehouse.tests.utils import get_available_quantity_for_stock
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
+
+
+def _assert_undiscounted_subtotal_matches_lines(order: Order) -> None:
+    assert order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(order.lines.all(), order.currency),
+        order.currency,
+    )
+
 
 MUTATION_CHECKOUT_COMPLETE = """
     mutation checkoutComplete(
@@ -277,10 +285,7 @@ def test_checkout_complete(
     assert order.total.gross == total.gross
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.metadata == checkout.metadata_storage.metadata
     assert order.private_metadata == checkout.metadata_storage.private_metadata
@@ -1044,10 +1049,7 @@ def test_checkout_with_voucher_complete(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + discount_amount
@@ -1162,10 +1164,7 @@ def test_checkout_with_order_promotion_complete(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + discount_amount
@@ -1448,10 +1447,7 @@ def test_checkout_with_voucher_complete_product_on_promotion(
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + (
@@ -1581,10 +1577,7 @@ def test_checkout_with_voucher_on_specific_product_complete(
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + (
@@ -1700,10 +1693,7 @@ def test_checkout_complete_with_voucher_single_use(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + discount_amount
@@ -1820,10 +1810,7 @@ def test_checkout_complete_with_voucher_paid_with_gift_card_and_payment(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == subtotal + shipping_price + discount_amount
@@ -1940,10 +1927,7 @@ def test_checkout_complete_with_voucher_paid_by_gift_card(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert (
@@ -2070,10 +2054,7 @@ def test_checkout_complete_free_shipping_voucher_and_gift_card(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.shipping_price == zero_taxed_money(order.currency)
@@ -2222,10 +2203,7 @@ def test_checkout_complete_product_on_promotion(
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + (
@@ -2607,10 +2585,7 @@ def test_checkout_complete_product_on_old_sale(
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + (
@@ -2790,10 +2765,7 @@ def test_checkout_with_voucher_on_specific_product_complete_with_product_on_prom
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.total == total
     assert order.undiscounted_total == total + (
@@ -2959,10 +2931,7 @@ def test_checkout_complete_without_inventory_tracking(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
 
     order_line = order.lines.first()
@@ -3911,10 +3880,7 @@ def test_checkout_complete_0_total_value(
     order_line = order.lines.first()
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert checkout_line_quantity == order_line.quantity
     assert checkout_line_variant == order_line.variant
@@ -4333,10 +4299,7 @@ def test_checkout_complete_with_preorder_variant(
 
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.lines.count() == len(variants_and_quantities)
     for variant_id, quantity in variants_and_quantities.items():
@@ -5773,10 +5736,7 @@ def test_checkout_complete_empty_product_translation(
     assert order.total.gross == total.gross
     subtotal = get_subtotal(order.lines.all(), order.currency)
     assert order.subtotal == subtotal
-    assert order.undiscounted_subtotal == quantize_price(
-        get_undiscounted_subtotal(order.lines.all(), order.currency),
-        order.currency,
-    )
+    _assert_undiscounted_subtotal_matches_lines(order)
     assert data["order"]["subtotal"]["gross"]["amount"] == subtotal.gross.amount
     assert order.metadata == checkout.metadata_storage.metadata
     assert order.private_metadata == checkout.metadata_storage.private_metadata

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -282,6 +282,8 @@ class OrderAmounts:
     total_net: Decimal
     subtotal_net: Decimal
     subtotal_gross: Decimal
+    undiscounted_subtotal_net: Decimal
+    undiscounted_subtotal_gross: Decimal
     undiscounted_total_gross: Decimal
     undiscounted_total_net: Decimal
     shipping_tax_rate: Decimal
@@ -1390,6 +1392,8 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
             total_net=order_subtotal_net_amount + shipping_price_net_amount,
             subtotal_net=order_subtotal_net_amount,
             subtotal_gross=order_subtotal_gross_amount,
+            undiscounted_subtotal_net=order_undiscounted_subtotal_net_amount,
+            undiscounted_subtotal_gross=order_undiscounted_subtotal_gross_amount,
             undiscounted_total_gross=order_undiscounted_subtotal_gross_amount
             + shipping_price_gross_amount,
             undiscounted_total_net=order_undiscounted_subtotal_net_amount
@@ -2182,6 +2186,12 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
         )
         order_data.order.subtotal_net_amount = order_amounts.subtotal_net
         order_data.order.subtotal_gross_amount = order_amounts.subtotal_gross
+        order_data.order.undiscounted_subtotal_net_amount = (
+            order_amounts.undiscounted_subtotal_net
+        )
+        order_data.order.undiscounted_subtotal_gross_amount = (
+            order_amounts.undiscounted_subtotal_gross
+        )
 
         order_data.order.customer_note = order_input.get("customer_note") or ""
         order_data.order.redirect_url = order_input.get("redirect_url")

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from .....account.models import Address
 from .....core import JobStatus
 from .....core.prices import quantize_price
+from .....payment.model_helpers import get_undiscounted_subtotal
 from .....discount.models import OrderDiscount
 from .....discount.utils.manual_discount import DiscountValueType
 from .....invoice.models import Invoice
@@ -755,6 +756,10 @@ def test_order_bulk_create(
     )
     assert db_order.subtotal_gross_amount == expected_order_subtotal_gross
     assert db_order.subtotal_net_amount == expected_order_subtotal_net
+    assert db_order.undiscounted_subtotal == quantize_price(
+        get_undiscounted_subtotal(db_order.lines.all(), db_order.currency),
+        db_order.currency,
+    )
     assert db_order.total_gross_amount == expected_order_total_gross
     assert db_order.total_net_amount == expected_order_total_net
     assert db_order.undiscounted_total_gross_amount == expected_order_total_gross

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -10,7 +10,6 @@ from django.utils import timezone
 from .....account.models import Address
 from .....core import JobStatus
 from .....core.prices import quantize_price
-from .....payment.model_helpers import get_undiscounted_subtotal
 from .....discount.models import OrderDiscount
 from .....discount.utils.manual_discount import DiscountValueType
 from .....invoice.models import Invoice
@@ -31,6 +30,7 @@ from .....order.models import (
     OrderLine,
 )
 from .....payment import TransactionEventType
+from .....payment.model_helpers import get_undiscounted_subtotal
 from .....payment.models import TransactionEvent, TransactionItem
 from .....warehouse.models import Stock
 from ....core.enums import ErrorPolicyEnum

--- a/saleor/graphql/order/tests/queries/test_order_undiscounted_subtotal.py
+++ b/saleor/graphql/order/tests/queries/test_order_undiscounted_subtotal.py
@@ -1,0 +1,79 @@
+import graphene
+from prices import Money, TaxedMoney
+
+from .....core.prices import quantize_price
+from .....core.taxes import zero_taxed_money
+from ....tests.utils import get_graphql_content
+
+
+ORDER_UNDISCOUNTED_SUBTOTAL_QUERY = """
+    query OrderUndiscountedSubtotal($id: ID!) {
+        order(id: $id) {
+            undiscountedSubtotal {
+                gross {
+                    amount
+                    currency
+                }
+                net {
+                    amount
+                    currency
+                }
+            }
+            lines {
+                undiscountedTotalPrice {
+                    gross {
+                        amount
+                    }
+                    net {
+                        amount
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def test_undiscounted_subtotal_equals_sum_of_line_undiscounted_totals(
+    staff_api_client, permission_group_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    variables = {"id": graphene.Node.to_global_id("Order", order.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_UNDISCOUNTED_SUBTOTAL_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["order"]
+    assert data is not None
+
+    order.refresh_from_db()
+    expected = zero_taxed_money(order.currency)
+    for line in order.lines.all():
+        line.refresh_from_db()
+        expected += line.undiscounted_total_price
+    expected = quantize_price(expected, order.currency)
+    assert order.undiscounted_subtotal == expected
+
+    api_subtotal = data["undiscountedSubtotal"]
+    currency = api_subtotal["gross"]["currency"]
+    api_taxed = TaxedMoney(
+        net=Money(api_subtotal["net"]["amount"], currency),
+        gross=Money(api_subtotal["gross"]["amount"], currency),
+    )
+    assert api_taxed == expected
+    order.refresh_from_db()
+    assert order.undiscounted_subtotal == api_taxed
+
+    line_sum = zero_taxed_money(currency)
+    for line_data in data["lines"]:
+        line_sum += TaxedMoney(
+            net=Money(line_data["undiscountedTotalPrice"]["net"]["amount"], currency),
+            gross=Money(
+                line_data["undiscountedTotalPrice"]["gross"]["amount"], currency
+            ),
+        )
+    assert quantize_price(line_sum, currency) == expected

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -80,6 +80,7 @@ from ..core.descriptions import (
     ADDED_IN_320,
     ADDED_IN_321,
     ADDED_IN_322,
+    ADDED_IN_323,
     DEPRECATED_IN_3X_INPUT,
     PREVIEW_FEATURE,
 )
@@ -1616,6 +1617,14 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
     undiscounted_total = graphene.Field(
         TaxedMoney, description="Undiscounted total amount of the order.", required=True
     )
+    undiscounted_subtotal = graphene.Field(
+        TaxedMoney,
+        description=(
+            "Sum of each order line's undiscounted total price, excluding shipping."
+            + ADDED_IN_323
+        ),
+        required=True,
+    )
     shipping_method = graphene.Field(
         ShippingMethod,
         description="Shipping method for this order.",
@@ -2212,6 +2221,26 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
             OrderPriceCalculationByOrderIdAndWebhookSyncLoader(info.context)
             .load((order.id, root.allow_sync_webhooks))
             .then(_get_undiscounted_total)
+        )
+
+    @staticmethod
+    @traced_resolver
+    @prevent_sync_event_circular_query
+    def resolve_undiscounted_subtotal(
+        root: SyncWebhookControlContext[models.Order], info
+    ):
+        order = root.node
+
+        def _get_undiscounted_subtotal(data):
+            refreshed_order, _lines = data
+            return quantize_price(
+                refreshed_order.undiscounted_subtotal, refreshed_order.currency
+            )
+
+        return (
+            OrderPriceCalculationByOrderIdAndWebhookSyncLoader(info.context)
+            .load((order.id, root.allow_sync_webhooks))
+            .then(_get_undiscounted_subtotal)
         )
 
     @staticmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11851,6 +11851,13 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Undiscounted total amount of the order."""
   undiscountedTotal: TaxedMoney!
 
+  """
+  Sum of each order line's undiscounted total price, excluding shipping.
+
+  Added in Saleor 3.23.
+  """
+  undiscountedSubtotal: TaxedMoney!
+
   """Shipping method for this order."""
   shippingMethod: ShippingMethod @deprecated(reason: "Use `deliveryMethod` instead.")
 

--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -324,6 +324,10 @@ def assign_order_prices(
     order.subtotal_net_amount = subtotal.amount
     order.subtotal_gross_amount = subtotal.amount
 
+    undiscounted_subtotal_money = undiscounted_order_subtotal(order, lines)
+    order.undiscounted_subtotal_net_amount = undiscounted_subtotal_money.amount
+    order.undiscounted_subtotal_gross_amount = undiscounted_subtotal_money.amount
+
     undiscounted_total = undiscounted_order_total(
         order, lines, database_connection_name=database_connection_name
     )

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -142,6 +142,8 @@ def process_order_prices(
                         update_fields=[
                             "subtotal_net_amount",
                             "subtotal_gross_amount",
+                            "undiscounted_subtotal_net_amount",
+                            "undiscounted_subtotal_gross_amount",
                             "total_net_amount",
                             "total_gross_amount",
                             "undiscounted_total_net_amount",
@@ -524,6 +526,7 @@ def _recalculate_with_plugins(
         pass
 
     undiscounted_shipping_price = order.undiscounted_base_shipping_price
+    order.undiscounted_subtotal = quantize_price(undiscounted_subtotal, order.currency)
     order.undiscounted_total = undiscounted_subtotal + TaxedMoney(
         net=undiscounted_shipping_price, gross=undiscounted_shipping_price
     )
@@ -608,6 +611,7 @@ def _apply_tax_data(
         undiscounted_subtotal += order_line.undiscounted_total_price
 
     order.subtotal = subtotal
+    order.undiscounted_subtotal = quantize_price(undiscounted_subtotal, currency)
     order.total = shipping_price + subtotal
     order.undiscounted_total = undiscounted_shipping_price + undiscounted_subtotal
 
@@ -624,6 +628,9 @@ def _remove_tax_gross(order, lines):
     order.total_gross_amount = order.total_net_amount
     order.undiscounted_total_gross_amount = order.undiscounted_total_net_amount
     order.subtotal_gross_amount = order.subtotal_net_amount
+    order.undiscounted_subtotal_gross_amount = (
+        order.undiscounted_subtotal_net_amount
+    )
     order.shipping_price_gross_amount = order.shipping_price_net_amount
     order.shipping_tax_rate = Decimal("0.00")
 
@@ -644,6 +651,9 @@ def _remove_tax_net(order, lines):
     order.total_net_amount = order.total_gross_amount
     order.undiscounted_total_net_amount = order.undiscounted_total_gross_amount
     order.subtotal_net_amount = order.subtotal_gross_amount
+    order.undiscounted_subtotal_net_amount = (
+        order.undiscounted_subtotal_gross_amount
+    )
     order.shipping_price_net_amount = order.shipping_price_gross_amount
     order.shipping_tax_rate = Decimal("0.00")
 

--- a/saleor/order/migrations/0222_order_undiscounted_subtotal.py
+++ b/saleor/order/migrations/0222_order_undiscounted_subtotal.py
@@ -1,0 +1,82 @@
+from decimal import Decimal
+
+from django.db import migrations, models
+from django.db.models import OuterRef, Subquery, Sum
+
+
+BATCH_SIZE = 1000
+
+
+def populate_undiscounted_subtotals(apps, schema_editor):
+    Order = apps.get_model("order", "Order")
+    OrderLine = apps.get_model("order", "OrderLine")
+
+    last_pk = 0
+    while True:
+        batch_pks = list(
+            Order.objects.filter(pk__gt=last_pk)
+            .order_by("pk")
+            .values_list("pk", flat=True)[:BATCH_SIZE]
+        )
+        if not batch_pks:
+            break
+
+        net_subq = Subquery(
+            OrderLine.objects.filter(order_id=OuterRef("pk"))
+            .values("order_id")
+            .annotate(s=Sum("undiscounted_total_price_net_amount"))
+            .values("s")[:1]
+        )
+        gross_subq = Subquery(
+            OrderLine.objects.filter(order_id=OuterRef("pk"))
+            .values("order_id")
+            .annotate(s=Sum("undiscounted_total_price_gross_amount"))
+            .values("s")[:1]
+        )
+
+        orders = list(
+            Order.objects.filter(pk__in=batch_pks).annotate(
+                _und_net=net_subq,
+                _und_gross=gross_subq,
+            )
+        )
+        for order in orders:
+            order.undiscounted_subtotal_net_amount = order._und_net or Decimal("0")
+            order.undiscounted_subtotal_gross_amount = order._und_gross or Decimal("0")
+
+        Order.objects.bulk_update(
+            orders,
+            ["undiscounted_subtotal_net_amount", "undiscounted_subtotal_gross_amount"],
+        )
+        last_pk = batch_pks[-1]
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("order", "0221_remove_digital_orderevents"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="order",
+            name="undiscounted_subtotal_net_amount",
+            field=models.DecimalField(
+                decimal_places=3,
+                default=Decimal("0"),
+                max_digits=20,
+            ),
+        ),
+        migrations.AddField(
+            model_name="order",
+            name="undiscounted_subtotal_gross_amount",
+            field=models.DecimalField(
+                decimal_places=3,
+                default=Decimal("0"),
+                max_digits=20,
+            ),
+        ),
+        migrations.RunPython(
+            populate_undiscounted_subtotals,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -342,6 +342,20 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
         net_amount_field="subtotal_net_amount",
         gross_amount_field="subtotal_gross_amount",
     )
+    undiscounted_subtotal_net_amount = models.DecimalField(
+        max_digits=settings.DEFAULT_MAX_DIGITS,
+        decimal_places=settings.DEFAULT_DECIMAL_PLACES,
+        default=Decimal("0.0"),
+    )
+    undiscounted_subtotal_gross_amount = models.DecimalField(
+        max_digits=settings.DEFAULT_MAX_DIGITS,
+        decimal_places=settings.DEFAULT_DECIMAL_PLACES,
+        default=Decimal("0.0"),
+    )
+    undiscounted_subtotal = TaxedMoneyField(
+        net_amount_field="undiscounted_subtotal_net_amount",
+        gross_amount_field="undiscounted_subtotal_gross_amount",
+    )
 
     voucher = models.ForeignKey(
         Voucher, blank=True, null=True, related_name="+", on_delete=models.SET_NULL

--- a/saleor/order/tests/fixtures/draft_order.py
+++ b/saleor/order/tests/fixtures/draft_order.py
@@ -258,6 +258,9 @@ def draft_order_and_promotions(
     # reset prices
     order.total = TaxedMoney(net=zero_money(currency), gross=zero_money(currency))
     order.subtotal = TaxedMoney(net=zero_money(currency), gross=zero_money(currency))
+    order.undiscounted_subtotal = TaxedMoney(
+        net=zero_money(currency), gross=zero_money(currency)
+    )
     order.undiscounted_total = TaxedMoney(
         net=zero_money(currency), gross=zero_money(currency)
     )

--- a/saleor/order/tests/fixtures/order.py
+++ b/saleor/order/tests/fixtures/order.py
@@ -19,7 +19,7 @@ from ....discount.utils.voucher import (
     get_products_voucher_discount,
     validate_voucher_in_order,
 )
-from ....payment.model_helpers import get_subtotal
+from ....payment.model_helpers import get_subtotal, get_undiscounted_subtotal
 from ....plugins.manager import get_plugins_manager
 from ....product.models import (
     Product,
@@ -59,6 +59,9 @@ def recalculate_order(order):
 
     order.total = total
     order.subtotal = get_subtotal(order.lines.all(), order.currency)
+    order.undiscounted_subtotal = get_undiscounted_subtotal(
+        order.lines.all(), order.currency
+    )
     order.undiscounted_total = undiscounted_total
 
     if discount:

--- a/saleor/order/tests/test_fetch_order_prices.py
+++ b/saleor/order/tests/test_fetch_order_prices.py
@@ -129,6 +129,14 @@ def test_fetch_order_prices_catalogue_discount_flat_rates(
     assert order.total_gross_amount == order.total_net_amount * tax_rate
     assert order.subtotal_net_amount == order.total_net_amount - shipping_net_price
     assert order.subtotal_gross_amount == order.subtotal_net_amount * tax_rate
+    assert order.undiscounted_subtotal_net_amount == (
+        line_1.undiscounted_total_price_net_amount
+        + line_2.undiscounted_total_price_net_amount
+    )
+    assert order.undiscounted_subtotal_gross_amount == (
+        line_1.undiscounted_total_price_gross_amount
+        + line_2.undiscounted_total_price_gross_amount
+    )
 
 
 @pytest.mark.parametrize("create_new_discounts", [True, False])

--- a/saleor/payment/model_helpers.py
+++ b/saleor/payment/model_helpers.py
@@ -24,3 +24,10 @@ def get_total_authorized(payments: Iterable[Payment], fallback_currency: str):
 def get_subtotal(order_lines: Iterable["OrderLine"], fallback_currency: str):
     subtotal_iterator = (line.total_price for line in order_lines)
     return sum(subtotal_iterator, zero_taxed_money(currency=fallback_currency))
+
+
+def get_undiscounted_subtotal(
+    order_lines: Iterable["OrderLine"], fallback_currency: str
+):
+    subtotal_iterator = (line.undiscounted_total_price for line in order_lines)
+    return sum(subtotal_iterator, zero_taxed_money(currency=fallback_currency))

--- a/saleor/static/populatedb_data-no-default-variant.json
+++ b/saleor/static/populatedb_data-no-default-variant.json
@@ -1,0 +1,9104 @@
+[
+  {
+    "model": "discount.sale",
+    "pk": 56,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Seasonal sale",
+      "type": "percentage",
+      "start_date": "2022-05-14T22:00:00Z",
+      "end_date": null,
+      "created_at": "2022-05-16T12:35:53.164Z",
+      "updated_at": "2022-05-16T12:35:53.164Z",
+      "categories": [],
+      "collections": [],
+      "products": [128, 137, 126, 141, 143],
+      "variants": []
+    }
+  },
+  {
+    "model": "discount.salechannellisting",
+    "pk": 111,
+    "fields": {
+      "sale": 56,
+      "channel": 2,
+      "discount_value": "10.000",
+      "currency": "PLN"
+    }
+  },
+  {
+    "model": "discount.salechannellisting",
+    "pk": 112,
+    "fields": {
+      "sale": 56,
+      "channel": 1,
+      "discount_value": "10.000",
+      "currency": "USD"
+    }
+  },
+  {
+    "model": "giftcard.giftcardtag",
+    "pk": 1,
+    "fields": { "name": "issued-gift-cards" }
+  },
+  {
+    "model": "product.category",
+    "pk": 25,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Accessories",
+      "slug": "accessories",
+      "description": null,
+      "description_plaintext": "",
+      "parent": null,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 1,
+      "rght": 8,
+      "tree_id": 1,
+      "level": 0
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 26,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Audiobooks",
+      "slug": "audiobooks",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 25,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 2,
+      "rght": 3,
+      "tree_id": 1,
+      "level": 1
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 27,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Apparel",
+      "slug": "apparel",
+      "description": null,
+      "description_plaintext": "",
+      "parent": null,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 1,
+      "rght": 28,
+      "tree_id": 2,
+      "level": 0
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 28,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Sneakers",
+      "slug": "sneakers",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 27,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 2,
+      "rght": 3,
+      "tree_id": 2,
+      "level": 1
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 29,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Sweatshirts",
+      "slug": "sweatshirts",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 27,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 4,
+      "rght": 5,
+      "tree_id": 2,
+      "level": 1
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 33,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Headware",
+      "slug": "headware",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 27,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 14,
+      "rght": 21,
+      "tree_id": 2,
+      "level": 1
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 35,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Beanies",
+      "slug": "beanies",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 33,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 15,
+      "rght": 16,
+      "tree_id": 2,
+      "level": 2
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 36,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Scarfs",
+      "slug": "scarfs",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 33,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 17,
+      "rght": 18,
+      "tree_id": 2,
+      "level": 2
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 37,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Sunglasses",
+      "slug": "sunglasses",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 33,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 19,
+      "rght": 20,
+      "tree_id": 2,
+      "level": 2
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 38,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Shirts",
+      "slug": "shirts",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 27,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 22,
+      "rght": 27,
+      "tree_id": 2,
+      "level": 1
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 39,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "T-shirts",
+      "slug": "t-shirts",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 38,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 23,
+      "rght": 24,
+      "tree_id": 2,
+      "level": 2
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 40,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Polo shirts",
+      "slug": "polo-shirts-2",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 38,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 25,
+      "rght": 26,
+      "tree_id": 2,
+      "level": 2
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 41,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Homewares",
+      "slug": "homewares",
+      "description": {
+        "time": 1652606793760,
+        "blocks": [
+          {
+            "id": "ckre1-oB3I",
+            "data": {
+              "text": "Everything a programmer's comfort requires&nbsp;"
+            },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.22.2"
+      },
+      "description_plaintext": "Everything a programmer's comfort requires&nbsp;",
+      "parent": 25,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 4,
+      "rght": 5,
+      "tree_id": 1,
+      "level": 1
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 42,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Groceries",
+      "slug": "groceries",
+      "description": null,
+      "description_plaintext": "",
+      "parent": null,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 1,
+      "rght": 4,
+      "tree_id": 3,
+      "level": 0
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 43,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Juices",
+      "slug": "juices",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 42,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 2,
+      "rght": 3,
+      "tree_id": 3,
+      "level": 1
+    }
+  },
+  {
+    "model": "product.category",
+    "pk": 44,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Gift cards",
+      "slug": "gift-cards",
+      "description": null,
+      "description_plaintext": "",
+      "parent": 25,
+      "background_image": "",
+      "background_image_alt": "",
+      "lft": 6,
+      "rght": 7,
+      "tree_id": 1,
+      "level": 1
+    }
+  },
+  {
+    "model": "product.producttype",
+    "pk": 17,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Audiobook",
+      "slug": "audiobook",
+      "kind": "normal",
+      "has_variants": true,
+      "is_shipping_required": false,
+      "is_digital": false,
+      "weight": "0.0:g"
+    }
+  },
+  {
+    "model": "product.producttype",
+    "pk": 18,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Shoe",
+      "slug": "shoe",
+      "kind": "normal",
+      "has_variants": true,
+      "is_shipping_required": true,
+      "is_digital": false,
+      "weight": "1000.0:g"
+    }
+  },
+  {
+    "model": "product.producttype",
+    "pk": 19,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Sweatshirt",
+      "slug": "sweatshirt",
+      "kind": "normal",
+      "has_variants": false,
+      "is_shipping_required": true,
+      "is_digital": false,
+      "weight": "1000.0:g"
+    }
+  },
+  {
+    "model": "product.producttype",
+    "pk": 20,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Top",
+      "slug": "shirt",
+      "kind": "normal",
+      "has_variants": true,
+      "is_shipping_required": true,
+      "is_digital": false,
+      "weight": "1000.0:g"
+    }
+  },
+  {
+    "model": "product.producttype",
+    "pk": 21,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Beanies & Scarfs",
+      "slug": "beanie",
+      "kind": "normal",
+      "has_variants": false,
+      "is_shipping_required": true,
+      "is_digital": false,
+      "weight": "1000.0:g"
+    }
+  },
+  {
+    "model": "product.producttype",
+    "pk": 22,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Simple",
+      "slug": "simple",
+      "kind": "normal",
+      "has_variants": false,
+      "is_shipping_required": false,
+      "is_digital": false,
+      "weight": "0.0:g"
+    }
+  },
+  {
+    "model": "product.producttype",
+    "pk": 23,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Juice",
+      "slug": "juice",
+      "kind": "normal",
+      "has_variants": false,
+      "is_shipping_required": true,
+      "is_digital": false,
+      "weight": "100.0:g"
+    }
+  },
+  {
+    "model": "product.producttype",
+    "pk": 24,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Simple Gift Card",
+      "slug": "gift-card",
+      "kind": "gift_card",
+      "has_variants": false,
+      "is_shipping_required": false,
+      "is_digital": false,
+      "weight": "0.0:g"
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 126,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "Headless + Omnichannel",
+      "seo_description": "Launch new markets fast",
+      "product_type": 17,
+      "name": "Headless + Omnichannel in a pill",
+      "slug": "headless-omnichannel-commerce",
+      "description": {
+        "time": 1652952009724,
+        "blocks": [
+          {
+            "id": "32SKrcyWwb",
+            "data": { "text": "Launch <b>new markets fast</b>" },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.22.2"
+      },
+      "description_plaintext": "Launch new markets fast",
+      "search_document": "",
+      "search_vector": "'audio':11B 'digit':10B 'fast':9C 'headless':1A,13A 'headless-omnichannel-mp3':12A 'launch':6C 'market':8C 'mp3':15A,16A,17B 'new':7C 'omnichannel':2A,14A 'pill':5A",
+      "category": 26,
+      "created_at": "2022-05-12T22:07:58.327Z",
+      "updated_at": "2022-05-19T09:20:18.453Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 127,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "White Plimsolls",
+      "seo_description": "PE at school wouldn’t have been such a drag with these on your feet. Slip on the style and stride tall with Saleor branded plimsolls. PE now stands for pretty elegant shoes.",
+      "product_type": 18,
+      "name": "White Plimsolls",
+      "slug": "white-plimsolls",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'39':4A,17B '40':6A,18B '41':8A,19B '42':10A,20B '43':12A,21B '44':14A,22B '45':16A,23B '918223582':3A '918223583':5A '918223584':7A '918223585':9A '918223586':11A '918223587':13A '918223588':15A 'plimsol':2A 'white':1A",
+      "category": 28,
+      "created_at": "2022-05-13T14:34:39.934Z",
+      "updated_at": "2022-05-13T20:11:18.993Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 128,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 18,
+      "name": "Blue Plimsolls",
+      "slug": "blue-plimsolls",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'40':4A,9B '41':6A,10B '42':8A,11B '818223582':3A '818223583':5A '818223584':7A 'blue':1A 'plimsol':2A",
+      "category": 28,
+      "created_at": "2022-05-13T20:14:01.299Z",
+      "updated_at": "2022-05-13T20:39:54.551Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 129,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 18,
+      "name": "Dash Force",
+      "slug": "dash-force",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'39':4A,13B '40':6A,14B '41':8A,15B '42':10A,16B '43':12A,17B '618223581':3A '618223582':5A '618223583':7A '618223584':9A '618223585':11A 'dash':1A 'forc':2A",
+      "category": 28,
+      "created_at": "2022-05-13T20:44:05.403Z",
+      "updated_at": "2022-05-13T20:47:18.902Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 130,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 18,
+      "name": "Paul's Balance 420",
+      "slug": "balance-trail-720",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'118223581':5A '118223582':7A '118223583':9A '118223584':11A '118223585':13A '39':6A,15B '40':8A,16B '41':10A,17B '42':12A,18B '420':4A '45':14A,19B 'balanc':3A 'paul':1A",
+      "category": 28,
+      "created_at": "2022-05-13T20:50:54.123Z",
+      "updated_at": "2022-05-13T21:15:21.592Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 131,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 19,
+      "name": "Grey Hoodie",
+      "slug": "grey-hoodie",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'cotton':3B 'grey':1A 'hoodi':2A 'uhjvzhvjdfzhcmlhbnq6mzq1':4A",
+      "category": 29,
+      "created_at": "2022-05-13T21:07:45.009Z",
+      "updated_at": "2022-05-13T21:10:33.993Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 132,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 19,
+      "name": "Blue Hoodie",
+      "slug": "blue-hoodie",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'blue':1A 'hoodi':2A 'polyest':3B 'uhjvzhvjdfzhcmlhbnq6mzq2':4A",
+      "category": 29,
+      "created_at": "2022-05-13T21:11:28.525Z",
+      "updated_at": "2022-05-16T16:40:43.118Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 133,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 19,
+      "name": "White Hoodie",
+      "slug": "white-hoodie",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'cotton':3B 'hoodi':2A 'uhjvzhvjdfzhcmlhbnq6mzq3':4A 'white':1A",
+      "category": 29,
+      "created_at": "2022-05-13T21:13:28.944Z",
+      "updated_at": "2022-05-13T21:14:28.328Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 134,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 20,
+      "name": "Monospace Tee",
+      "slug": "ascii-tee",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'328223580':4A '328223581':5A '328223582':7A '328223583':9A '328223584':11A 'cotton':3B 'l':8A,14B 'm':6A,13B 'monospac':1A 'tee':2A 'xl':10A,15B 'xxl':12A,16B",
+      "category": 39,
+      "created_at": "2022-05-13T21:20:59.727Z",
+      "updated_at": "2022-05-15T09:38:17.179Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 135,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 20,
+      "name": "Team Shirt",
+      "slug": "team-shirt",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'128223580':4A '128223581':5A '128223582':7A '128223583':9A '128223584':11A 'elastan':3B 'l':8A,14B 'm':6A,13B 'shirt':2A 'team':1A 'xl':10A,15B 'xxl':12A,16B",
+      "category": 39,
+      "created_at": "2022-05-13T21:29:38.009Z",
+      "updated_at": "2022-05-14T21:37:02.094Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 136,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 20,
+      "name": "Darko Polo",
+      "slug": "darko-polo",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'111223580':4A '111223581':5A '111223582':7A 'cotton':3B 'darko':1A 'm':6A,9B 'polo':2A 'xxl':8A,10B",
+      "category": 40,
+      "created_at": "2022-05-13T21:37:35.753Z",
+      "updated_at": "2022-05-14T21:36:42.372Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 137,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 20,
+      "name": "Blue Polygon Shirt",
+      "slug": "blue-polygon-shirt",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'218223580':5A '218223581':7A '218223582':9A 'blue':1A 'cotton':4B 'l':8A,12B 'm':6A,11B 'polygon':2A 'shirt':3A 'xl':10A,13B",
+      "category": 39,
+      "created_at": "2022-05-13T21:41:46.295Z",
+      "updated_at": "2022-05-14T21:36:18.923Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 138,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 20,
+      "name": "Dark Polygon Tee",
+      "slug": "dark-polygon-tee",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'112223580':5A '112223581':6A '112223582':8A 'cotton':4B 'dark':1A 'l':9A,11B 'm':7A,10B 'polygon':2A 'tee':3A",
+      "category": 39,
+      "created_at": "2022-05-13T21:44:02.972Z",
+      "updated_at": "2022-05-14T21:36:31.780Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 141,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 21,
+      "name": "Pirate's Beanie",
+      "slug": "pirates-beanie",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'beani':3A 'cotton':4B 'pirat':1A 'uhjvzhvjdfzhcmlhbnq6mzy4':5A",
+      "category": 35,
+      "created_at": "2022-05-13T23:50:16.297Z",
+      "updated_at": "2022-05-14T21:33:36.545Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 143,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 21,
+      "name": "Neck Warmer",
+      "slug": "tactical-neck-warmer",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'neck':1A 'uhjvzhvjdfzhcmlhbnq6mzcw':4A 'warmer':2A 'wool':3B",
+      "category": 36,
+      "created_at": "2022-05-14T21:10:01.383Z",
+      "updated_at": "2022-05-14T21:33:04.263Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 144,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 22,
+      "name": "DRY Sunglasses",
+      "slug": "dry-sunglasses",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'dri':1A 'sunglass':2A 'uhjvzhvjdfzhcmlhbnq6mzcx':3A",
+      "category": 37,
+      "created_at": "2022-05-14T21:24:57.725Z",
+      "updated_at": "2022-05-14T21:25:09.229Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 145,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 17,
+      "name": "Battle-tested at brands like Lush",
+      "slug": "battle-tested-at-brands-like-lush",
+      "description": {
+        "time": 1652811542659,
+        "blocks": [
+          {
+            "id": "g2sLxZcLZa",
+            "data": { "text": "Scale <b>effortlessly</b>" },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.22.2"
+      },
+      "description_plaintext": "Scale effortlessly",
+      "search_document": "",
+      "search_vector": "'9018223582':10A '9018223583':12A '9018223584':14A 'battl':2A 'battle-test':1A 'brand':5A 'dvd':11A,16B 'effortless':9C 'itun':13A,17B 'like':6A 'lush':7A 'mp3':15A,18B 'scale':8C 'test':3A",
+      "category": 26,
+      "created_at": "2022-05-14T21:53:34.556Z",
+      "updated_at": "2022-05-19T09:15:38.806Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 146,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 17,
+      "name": "Enterprise Cloud + On-premises",
+      "slug": "enterprise-cloud-on-premises-tales",
+      "description": {
+        "time": 1652727780700,
+        "blocks": [
+          {
+            "id": "w3x66nix3o",
+            "data": { "text": "Open Source <b>without the DevOps</b>" },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.24.3"
+      },
+      "description_plaintext": "Open Source without the DevOps",
+      "search_document": "",
+      "search_vector": "'113223582':13A '113223583':15A '113223584':17A '113223585':19A 'cd':20A,24B 'cloud':2A 'devop':10C 'dvd':16A,22B 'enterpris':1A 'itun':18A,23B 'on-premis':3A 'open':6C 'premis':5A 'publish':12B 'saleor':11B 'sourc':7C 'vinyl':14A,21B 'without':8C",
+      "category": 26,
+      "created_at": "2022-05-15T09:03:06.009Z",
+      "updated_at": "2022-05-19T09:19:50.290Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 147,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 17,
+      "name": "Own your stack and data",
+      "slug": "own-your-stack-and-data",
+      "description": {
+        "time": 1652952066167,
+        "blocks": [
+          {
+            "id": "KQt85UC1t1",
+            "data": {
+              "text": "Own your investment, <b>ditch vendor lock-in</b>"
+            },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.22.2"
+      },
+      "description_plaintext": "Own your investment, ditch vendor lock-in",
+      "search_document": "",
+      "search_vector": "'124223581':15A '124223582':17A 'data':5A 'ditch':9C 'invest':8C 'itun':16A,19B 'lock':12C 'lock-in':11C 'mp3':18A,20B 'publish':14B 'saleor':13B 'stack':3A 'vendor':10C",
+      "category": 26,
+      "created_at": "2022-05-15T09:10:17.077Z",
+      "updated_at": "2022-05-19T09:22:29.677Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 150,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 22,
+      "name": "Mighty Mug",
+      "slug": "mighty-mug",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'mighti':1A 'mug':2A 'uhjvzhvjdfzhcmlhbnq6mzgy':3A",
+      "category": 41,
+      "created_at": "2022-05-15T09:28:13.067Z",
+      "updated_at": "2022-05-15T09:28:13.368Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 151,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 22,
+      "name": "The Dash Cushion",
+      "slug": "the-dash-cushion",
+      "description": {
+        "time": 1652719110298,
+        "blocks": [
+          { "id": "KL2jdkdLiu", "data": { "text": "" }, "type": "paragraph" }
+        ],
+        "version": "2.24.3"
+      },
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'cushion':3A 'dash':2A 'uhjvzhvjdfzhcmlhbnq6mzgz':4A",
+      "category": 41,
+      "created_at": "2022-05-15T09:32:27.163Z",
+      "updated_at": "2022-05-16T16:38:35.766Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 152,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 23,
+      "name": "Apple Juice",
+      "slug": "apple-juice",
+      "description": {
+        "time": 1652727409980,
+        "blocks": [
+          {
+            "id": "rGR983yNVl",
+            "data": {
+              "text": "Fell straight from the tree, on to Newton’s head, then into the bottle. The autumn taste of English apples. Brought to you by gravity."
+            },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.24.3"
+      },
+      "description_plaintext": "Fell straight from the tree, on to Newton’s head, then into the bottle. The autumn taste of English apples. Brought to you by gravity.",
+      "search_document": "",
+      "search_vector": "'appl':1A,22C,28B 'autumn':18C 'bottl':16C 'brought':23C 'english':21C 'fell':3C 'graviti':27C 'head':12C 'juic':2A 'newton':10C 'straight':4C 'tast':19C 'tree':7C 'uhjvzhvjdfzhcmlhbnq6mzg0':29A",
+      "category": 43,
+      "created_at": "2022-05-16T16:19:50.880Z",
+      "updated_at": "2022-05-18T12:21:40.815Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 153,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 23,
+      "name": "Bean Juice",
+      "slug": "bean-juice",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'bean':1A,3B 'juic':2A 'uhjvzhvjdfzhcmlhbnq6mzg1':4A",
+      "category": 43,
+      "created_at": "2022-05-16T16:25:11.442Z",
+      "updated_at": "2022-05-16T16:25:11.768Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 154,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 23,
+      "name": "Banana Juice",
+      "slug": "banana-juice",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'banana':1A,3B 'juic':2A 'uhjvzhvjdfzhcmlhbnq6mzg2':4A",
+      "category": 43,
+      "created_at": "2022-05-16T16:27:16.648Z",
+      "updated_at": "2022-05-16T16:27:16.933Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 155,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 23,
+      "name": "Carrot Juice",
+      "slug": "carrot-juice",
+      "description": {
+        "time": 1652790989820,
+        "blocks": [
+          {
+            "id": "VWVrSI_Cza",
+            "data": {
+              "text": "Improve your eyesight the natural way with <b>100% pure, squeezed carrot juice</b>. The sweet, orange nectar of <i>Mother Earth</i>."
+            },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.22.2"
+      },
+      "description_plaintext": "Improve your eyesight the natural way with 100% pure, squeezed carrot juice. The sweet, orange nectar of Mother Earth.",
+      "search_document": "",
+      "search_vector": "'100':10C 'carrot':1A,13C,22B 'earth':21C 'eyesight':5C 'improv':3C 'juic':2A,14C 'mother':20C 'natur':7C 'nectar':18C 'orang':17C 'pure':11C 'squeez':12C 'sweet':16C 'uhjvzhvjdfzhcmlhbnq6mzg3':23A 'way':8C",
+      "category": 43,
+      "created_at": "2022-05-16T16:28:14.885Z",
+      "updated_at": "2022-05-17T12:36:31.471Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 156,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 22,
+      "name": "Monokai Dimmed Sunnies",
+      "slug": "monokai-dimmed-sunnies",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'dim':2A 'monokai':1A 'sunni':3A 'uhjvzhvjdfzhcmlhbnq6mzg4':4A",
+      "category": 37,
+      "created_at": "2022-05-17T11:44:16.884Z",
+      "updated_at": "2022-05-17T11:44:17.205Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 157,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 20,
+      "name": "Reversed Monotype Tee",
+      "slug": "reversed-monotype-tee",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'9182235820':4A '9182235821':6A 'monotyp':2A 'revers':1A 'tee':3A 'xl':5A,8B 'xxl':7A,9B",
+      "category": 39,
+      "created_at": "2022-05-17T11:48:18.537Z",
+      "updated_at": "2022-05-17T11:50:42.152Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 160,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 24,
+      "name": "Gift card 100",
+      "slug": "gift-card",
+      "description": {
+        "time": 1652788779629,
+        "blocks": [
+          {
+            "id": "x5bGwCbYOX",
+            "data": { "text": "Gift card to use in the shop." },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.24.3"
+      },
+      "description_plaintext": "Gift card to use in the shop.",
+      "search_document": "",
+      "search_vector": "'100':3A 'card':2A,5C 'gift':1A,4C 'shop':10C 'uhjvzhvjdfzhcmlhbnq6mzkz':11A 'use':7C",
+      "category": 44,
+      "created_at": "2022-05-17T11:57:19.204Z",
+      "updated_at": "2022-05-18T19:30:32.578Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 161,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 20,
+      "name": "Cubes Fountain Tee",
+      "slug": "cubes-fountain-tee",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'49182235820':5A '49182235821':6A '49182235822':8A '49182235823':10A '49182235824':12A 'cotton':4B 'cube':1A 'fountain':2A 'l':9A,15B 'm':7A,14B 'tee':3A 'xl':11A,16B 'xxl':13A,17B",
+      "category": 39,
+      "created_at": "2022-05-17T12:02:44.850Z",
+      "updated_at": "2022-05-18T12:21:19.661Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 162,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 22,
+      "name": "White Parrot Cushion",
+      "slug": "white-parrot-cusion",
+      "description": {
+        "time": 1652875592737,
+        "blocks": [
+          {
+            "id": "46o78ZqlJ8",
+            "data": {
+              "text": "Minimalist interiors need simple, sleek soft furnishings. Don’t parrot what others do, set your own monochrome trends with Saleor designs."
+            },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.22.2"
+      },
+      "description_plaintext": "Minimalist interiors need simple, sleek soft furnishings. Don’t parrot what others do, set your own monochrome trends with Saleor designs.",
+      "search_document": "",
+      "search_vector": "'cushion':3A 'design':24C 'furnish':10C 'interior':5C 'minimalist':4C 'monochrom':20C 'need':6C 'other':15C 'parrot':2A,13C 'saleor':23C 'set':17C 'simpl':7C 'sleek':8C 'soft':9C 'trend':21C 'uhjvzhvjdfzhcmlhbnq6mzk5':25A 'white':1A",
+      "category": 41,
+      "created_at": "2022-05-18T12:06:53.986Z",
+      "updated_at": "2022-05-18T12:07:49.831Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 163,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 24,
+      "name": "Gift card 500",
+      "slug": "gift-card-500",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'500':3A 'card':2A 'gift':1A 'uhjvzhvjdfzhcmlhbnq6ndaw':4A",
+      "category": 44,
+      "created_at": "2022-05-18T19:29:35.052Z",
+      "updated_at": "2022-05-18T19:29:47.127Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.product",
+    "pk": 164,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "product_type": 24,
+      "name": "Gift card 50",
+      "slug": "gift-card-50",
+      "description": null,
+      "description_plaintext": "",
+      "search_document": "",
+      "search_vector": "'50':3A 'card':2A 'gift':1A 'uhjvzhvjdfzhcmlhbnq6ndax':4A",
+      "category": 44,
+      "created_at": "2022-05-18T19:31:14.463Z",
+      "updated_at": "2022-05-18T19:31:14.751Z",
+      "charge_taxes": false,
+      "weight": null,
+      "rating": 0.0
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 74,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 126,
+      "channel": 2,
+      "visible_in_listings": false,
+      "available_for_purchase_at": "2022-05-12T22:28:54.347Z",
+      "currency": "PLN",
+      "discounted_price_amount": "36.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 75,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 126,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-12T00:00:00Z",
+      "currency": "USD",
+      "discounted_price_amount": "9.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 76,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 127,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T00:00:00Z",
+      "currency": "PLN",
+      "discounted_price_amount": "240.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 77,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 127,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T00:00:00Z",
+      "currency": "USD",
+      "discounted_price_amount": "80.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 78,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 128,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T20:39:54.804Z",
+      "currency": "PLN",
+      "discounted_price_amount": "207.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 79,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 128,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T20:39:54.813Z",
+      "currency": "USD",
+      "discounted_price_amount": "67.500"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 80,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 129,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T20:47:19.212Z",
+      "currency": "PLN",
+      "discounted_price_amount": "420.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 81,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 129,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T20:47:19.242Z",
+      "currency": "USD",
+      "discounted_price_amount": "90.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 82,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 130,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T20:58:06.889Z",
+      "currency": "PLN",
+      "discounted_price_amount": "209.960"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 83,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 130,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T20:58:06.895Z",
+      "currency": "USD",
+      "discounted_price_amount": "50.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 84,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 131,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:10:34.318Z",
+      "currency": "PLN",
+      "discounted_price_amount": "100.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 85,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 131,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:10:34.327Z",
+      "currency": "USD",
+      "discounted_price_amount": "30.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 86,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 132,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-16T16:40:43.400Z",
+      "currency": "PLN",
+      "discounted_price_amount": "120.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 87,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 132,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-16T16:40:43.412Z",
+      "currency": "USD",
+      "discounted_price_amount": "35.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 88,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 133,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:14:28.706Z",
+      "currency": "PLN",
+      "discounted_price_amount": "120.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 89,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 133,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:14:28.718Z",
+      "currency": "USD",
+      "discounted_price_amount": "35.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 90,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 134,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:22:42.287Z",
+      "currency": "PLN",
+      "discounted_price_amount": "90.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 91,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 134,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:22:42.298Z",
+      "currency": "USD",
+      "discounted_price_amount": "20.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 92,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 135,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:31:26.409Z",
+      "currency": "PLN",
+      "discounted_price_amount": "200.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 93,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 135,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:31:26.426Z",
+      "currency": "USD",
+      "discounted_price_amount": "40.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 94,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 136,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:39:11.647Z",
+      "currency": "PLN",
+      "discounted_price_amount": "150.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 95,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 136,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:39:11.656Z",
+      "currency": "USD",
+      "discounted_price_amount": "45.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 96,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 137,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:42:58.688Z",
+      "currency": "PLN",
+      "discounted_price_amount": "135.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 97,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 137,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:42:58.694Z",
+      "currency": "USD",
+      "discounted_price_amount": "40.500"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 98,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 138,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:45:11.183Z",
+      "currency": "PLN",
+      "discounted_price_amount": "150.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 99,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "product": 138,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-13T21:45:11.191Z",
+      "currency": "USD",
+      "discounted_price_amount": "45.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 104,
+    "fields": {
+      "published_at": "2022-05-14T00:00:00Z",
+      "is_published": true,
+      "product": 141,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-14T21:33:36.864Z",
+      "currency": "PLN",
+      "discounted_price_amount": "45.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 105,
+    "fields": {
+      "published_at": "2022-05-14T00:00:00Z",
+      "is_published": true,
+      "product": 141,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-14T21:33:36.876Z",
+      "currency": "USD",
+      "discounted_price_amount": "9.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 108,
+    "fields": {
+      "published_at": "2022-05-14T00:00:00Z",
+      "is_published": true,
+      "product": 143,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-14T21:33:04.609Z",
+      "currency": "PLN",
+      "discounted_price_amount": "81.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 109,
+    "fields": {
+      "published_at": "2022-05-14T00:00:00Z",
+      "is_published": true,
+      "product": 143,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-14T21:33:04.615Z",
+      "currency": "USD",
+      "discounted_price_amount": "18.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 110,
+    "fields": {
+      "published_at": "2022-05-14T00:00:00Z",
+      "is_published": true,
+      "product": 144,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-14T21:25:09.403Z",
+      "currency": "PLN",
+      "discounted_price_amount": "60.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 111,
+    "fields": {
+      "published_at": "2022-05-14T00:00:00Z",
+      "is_published": true,
+      "product": 144,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-14T21:25:09.408Z",
+      "currency": "USD",
+      "discounted_price_amount": "15.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 112,
+    "fields": {
+      "published_at": "2022-05-14T00:00:00Z",
+      "is_published": true,
+      "product": 145,
+      "channel": 2,
+      "visible_in_listings": false,
+      "available_for_purchase_at": "2022-05-14T21:56:09.039Z",
+      "currency": "PLN",
+      "discounted_price_amount": "45.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 113,
+    "fields": {
+      "published_at": "2022-05-14T00:00:00Z",
+      "is_published": true,
+      "product": 145,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-14T21:56:09.046Z",
+      "currency": "USD",
+      "discounted_price_amount": "10.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 114,
+    "fields": {
+      "published_at": "2022-05-15T00:00:00Z",
+      "is_published": true,
+      "product": 146,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-15T09:07:27.049Z",
+      "currency": "PLN",
+      "discounted_price_amount": "29.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 115,
+    "fields": {
+      "published_at": "2022-05-15T00:00:00Z",
+      "is_published": true,
+      "product": 146,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T12:09:56.745Z",
+      "currency": "USD",
+      "discounted_price_amount": "8.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 116,
+    "fields": {
+      "published_at": "2022-05-15T00:00:00Z",
+      "is_published": true,
+      "product": 147,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-15T09:21:45.107Z",
+      "currency": "PLN",
+      "discounted_price_amount": "9.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 117,
+    "fields": {
+      "published_at": "2022-05-15T00:00:00Z",
+      "is_published": true,
+      "product": 147,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-15T09:21:45.111Z",
+      "currency": "USD",
+      "discounted_price_amount": "2.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 120,
+    "fields": {
+      "published_at": "2022-05-15T00:00:00Z",
+      "is_published": true,
+      "product": 150,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-15T09:28:13.277Z",
+      "currency": "PLN",
+      "discounted_price_amount": "29.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 121,
+    "fields": {
+      "published_at": "2022-05-15T00:00:00Z",
+      "is_published": true,
+      "product": 150,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-15T09:28:13.293Z",
+      "currency": "USD",
+      "discounted_price_amount": "11.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 122,
+    "fields": {
+      "published_at": "2022-05-15T00:00:00Z",
+      "is_published": true,
+      "product": 151,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-16T16:38:36.080Z",
+      "currency": "PLN",
+      "discounted_price_amount": "70.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 123,
+    "fields": {
+      "published_at": "2022-05-15T00:00:00Z",
+      "is_published": true,
+      "product": 151,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-16T16:38:36.086Z",
+      "currency": "USD",
+      "discounted_price_amount": "18.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 124,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "product": 152,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T12:21:41.061Z",
+      "currency": "PLN",
+      "discounted_price_amount": "5.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 125,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "product": 152,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T12:21:41.066Z",
+      "currency": "USD",
+      "discounted_price_amount": "1.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 126,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "product": 153,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-16T16:25:11.675Z",
+      "currency": "PLN",
+      "discounted_price_amount": "5.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 127,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "product": 153,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-16T16:25:11.691Z",
+      "currency": "USD",
+      "discounted_price_amount": "1.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 128,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "product": 154,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-16T16:27:16.884Z",
+      "currency": "PLN",
+      "discounted_price_amount": "5.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 129,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "product": 154,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-16T16:27:16.897Z",
+      "currency": "USD",
+      "discounted_price_amount": "1.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 130,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "product": 155,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-17T12:36:31.769Z",
+      "currency": "PLN",
+      "discounted_price_amount": "5.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 131,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "product": 155,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-17T12:36:31.775Z",
+      "currency": "USD",
+      "discounted_price_amount": "1.990"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 132,
+    "fields": {
+      "published_at": "2022-05-17T00:00:00Z",
+      "is_published": true,
+      "product": 156,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-17T11:44:17.092Z",
+      "currency": "PLN",
+      "discounted_price_amount": "90.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 133,
+    "fields": {
+      "published_at": "2022-05-17T00:00:00Z",
+      "is_published": true,
+      "product": 156,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-17T11:44:17.105Z",
+      "currency": "USD",
+      "discounted_price_amount": "17.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 134,
+    "fields": {
+      "published_at": "2022-05-17T00:00:00Z",
+      "is_published": true,
+      "product": 157,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-17T11:50:42.404Z",
+      "currency": "PLN",
+      "discounted_price_amount": "120.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 135,
+    "fields": {
+      "published_at": "2022-05-17T00:00:00Z",
+      "is_published": true,
+      "product": 157,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-17T11:50:42.416Z",
+      "currency": "USD",
+      "discounted_price_amount": "25.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 136,
+    "fields": {
+      "published_at": "2022-05-17T00:00:00Z",
+      "is_published": true,
+      "product": 160,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T19:30:32.863Z",
+      "currency": "PLN",
+      "discounted_price_amount": "450.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 137,
+    "fields": {
+      "published_at": "2022-05-17T00:00:00Z",
+      "is_published": true,
+      "product": 160,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T19:30:32.870Z",
+      "currency": "USD",
+      "discounted_price_amount": "100.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 138,
+    "fields": {
+      "published_at": "2022-05-17T00:00:00Z",
+      "is_published": true,
+      "product": 161,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-17T12:04:24.093Z",
+      "currency": "PLN",
+      "discounted_price_amount": "130.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 139,
+    "fields": {
+      "published_at": "2022-05-17T00:00:00Z",
+      "is_published": true,
+      "product": 161,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-17T12:04:24.101Z",
+      "currency": "USD",
+      "discounted_price_amount": "30.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 140,
+    "fields": {
+      "published_at": "2022-05-18T00:00:00Z",
+      "is_published": true,
+      "product": 162,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T12:07:50.177Z",
+      "currency": "PLN",
+      "discounted_price_amount": "230.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 141,
+    "fields": {
+      "published_at": "2022-05-18T00:00:00Z",
+      "is_published": true,
+      "product": 162,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T12:07:50.182Z",
+      "currency": "USD",
+      "discounted_price_amount": "50.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 142,
+    "fields": {
+      "published_at": "2022-05-18T00:00:00Z",
+      "is_published": true,
+      "product": 163,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T19:29:47.375Z",
+      "currency": "PLN",
+      "discounted_price_amount": "2300.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 143,
+    "fields": {
+      "published_at": "2022-05-18T00:00:00Z",
+      "is_published": true,
+      "product": 163,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T19:29:47.387Z",
+      "currency": "USD",
+      "discounted_price_amount": "500.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 144,
+    "fields": {
+      "published_at": "2022-05-18T00:00:00Z",
+      "is_published": true,
+      "product": 164,
+      "channel": 2,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T19:31:14.637Z",
+      "currency": "PLN",
+      "discounted_price_amount": "230.000"
+    }
+  },
+  {
+    "model": "product.productchannellisting",
+    "pk": 145,
+    "fields": {
+      "published_at": "2022-05-18T00:00:00Z",
+      "is_published": true,
+      "product": 164,
+      "channel": 1,
+      "visible_in_listings": true,
+      "available_for_purchase_at": "2022-05-18T19:31:14.662Z",
+      "currency": "USD",
+      "discounted_price_amount": "50.000"
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 324,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "headless-omnichannel-mp3",
+      "name": "MP3",
+      "product": 126,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-12T22:09:40.752Z",
+      "updated_at": "2022-05-12T22:29:28.421Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 325,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "918223582",
+      "name": "39",
+      "product": 127,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T15:01:07.152Z",
+      "updated_at": "2022-05-13T19:48:53.078Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 326,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "918223583",
+      "name": "40",
+      "product": 127,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T19:52:24.369Z",
+      "updated_at": "2022-05-13T20:08:56.891Z",
+      "weight": "1000.0:g"
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 327,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "918223584",
+      "name": "41",
+      "product": 127,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T19:53:03.367Z",
+      "updated_at": "2022-05-13T20:10:53.560Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 328,
+    "fields": {
+      "sort_order": 3,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "918223585",
+      "name": "42",
+      "product": 127,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T19:53:28.144Z",
+      "updated_at": "2022-05-13T20:10:59.528Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 329,
+    "fields": {
+      "sort_order": 4,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "918223586",
+      "name": "43",
+      "product": 127,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T19:53:52.354Z",
+      "updated_at": "2022-05-13T20:11:06.863Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 330,
+    "fields": {
+      "sort_order": 5,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "918223587",
+      "name": "44",
+      "product": 127,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T19:55:25.701Z",
+      "updated_at": "2022-05-13T20:11:13.296Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 331,
+    "fields": {
+      "sort_order": 6,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "918223588",
+      "name": "45",
+      "product": 127,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:06:43.538Z",
+      "updated_at": "2022-05-13T20:11:18.983Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 332,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "818223583",
+      "name": "41",
+      "product": 128,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:39:26.112Z",
+      "updated_at": "2022-05-13T20:39:26.185Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 333,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "818223582",
+      "name": "40",
+      "product": 128,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:39:26.216Z",
+      "updated_at": "2022-05-13T20:39:26.245Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 334,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "818223584",
+      "name": "42",
+      "product": 128,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:39:26.254Z",
+      "updated_at": "2022-05-13T20:39:26.280Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 335,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "618223581",
+      "name": "39",
+      "product": 129,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:47:03.499Z",
+      "updated_at": "2022-05-13T20:47:03.620Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 336,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "618223582",
+      "name": "40",
+      "product": 129,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:47:03.655Z",
+      "updated_at": "2022-05-13T20:47:03.695Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 337,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "618223583",
+      "name": "41",
+      "product": 129,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:47:03.705Z",
+      "updated_at": "2022-05-13T20:47:03.731Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 338,
+    "fields": {
+      "sort_order": 3,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "618223584",
+      "name": "42",
+      "product": 129,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:47:03.738Z",
+      "updated_at": "2022-05-13T20:47:03.775Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 339,
+    "fields": {
+      "sort_order": 4,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "618223585",
+      "name": "43",
+      "product": 129,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:47:03.809Z",
+      "updated_at": "2022-05-13T20:47:03.837Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 340,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "118223581",
+      "name": "39",
+      "product": 130,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:57:45.685Z",
+      "updated_at": "2022-05-13T20:57:45.754Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 341,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "118223582",
+      "name": "40",
+      "product": 130,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:57:45.785Z",
+      "updated_at": "2022-05-13T20:57:45.820Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 342,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "118223583",
+      "name": "41",
+      "product": 130,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:57:45.826Z",
+      "updated_at": "2022-05-13T20:57:45.854Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 343,
+    "fields": {
+      "sort_order": 3,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "118223584",
+      "name": "42",
+      "product": 130,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:57:45.861Z",
+      "updated_at": "2022-05-13T20:57:45.880Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 344,
+    "fields": {
+      "sort_order": 4,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "118223585",
+      "name": "45",
+      "product": 130,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T20:57:45.887Z",
+      "updated_at": "2022-05-13T20:57:45.927Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 345,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6MzQ1",
+      "product": 131,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:07:45.439Z",
+      "updated_at": "2022-05-13T21:10:33.980Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 346,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6MzQ2",
+      "product": 132,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:11:28.927Z",
+      "updated_at": "2022-05-16T16:40:43.108Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 347,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6MzQ3",
+      "product": 133,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:13:29.305Z",
+      "updated_at": "2022-05-13T21:14:28.317Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 348,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "328223580",
+      "name": "S",
+      "product": 134,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:22:25.536Z",
+      "updated_at": "2022-05-13T23:26:53.236Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 349,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "328223581",
+      "name": "M",
+      "product": 134,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:22:25.647Z",
+      "updated_at": "2022-05-13T23:26:53.374Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 350,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "328223582",
+      "name": "L",
+      "product": 134,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:22:25.700Z",
+      "updated_at": "2022-05-13T23:26:53.453Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 351,
+    "fields": {
+      "sort_order": 3,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "328223583",
+      "name": "XL",
+      "product": 134,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:22:25.736Z",
+      "updated_at": "2022-05-13T23:26:53.488Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 352,
+    "fields": {
+      "sort_order": 4,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "328223584",
+      "name": "XXL",
+      "product": 134,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:22:25.789Z",
+      "updated_at": "2022-05-13T23:26:53.520Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 353,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "128223580",
+      "name": "S",
+      "product": 135,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:30:50.614Z",
+      "updated_at": "2022-05-13T23:26:53.207Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 354,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "128223581",
+      "name": "M",
+      "product": 135,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:30:50.694Z",
+      "updated_at": "2022-05-13T23:26:53.296Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 355,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "128223582",
+      "name": "L",
+      "product": 135,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:30:50.756Z",
+      "updated_at": "2022-05-13T23:26:53.422Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 356,
+    "fields": {
+      "sort_order": 3,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "128223583",
+      "name": "XL",
+      "product": 135,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:30:50.795Z",
+      "updated_at": "2022-05-13T23:26:53.470Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 357,
+    "fields": {
+      "sort_order": 4,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "128223584",
+      "name": "XXL",
+      "product": 135,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:30:50.889Z",
+      "updated_at": "2022-05-13T23:26:53.507Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 358,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "111223580",
+      "name": "S",
+      "product": 136,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:38:56.282Z",
+      "updated_at": "2022-05-13T23:26:53.164Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 359,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "111223581",
+      "name": "M",
+      "product": 136,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:38:56.373Z",
+      "updated_at": "2022-05-13T23:26:53.257Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 360,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "111223582",
+      "name": "XXL",
+      "product": 136,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:38:56.422Z",
+      "updated_at": "2022-05-13T23:26:53.392Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 361,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "218223580",
+      "name": "M",
+      "product": 137,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:42:43.229Z",
+      "updated_at": "2022-05-13T23:26:53.217Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 362,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "218223581",
+      "name": "L",
+      "product": 137,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:42:43.314Z",
+      "updated_at": "2022-05-13T23:26:53.309Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 363,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "218223582",
+      "name": "XL",
+      "product": 137,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:42:43.351Z",
+      "updated_at": "2022-05-13T23:26:53.439Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 364,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "112223580",
+      "name": "S",
+      "product": 138,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:44:58.194Z",
+      "updated_at": "2022-05-13T23:26:53.194Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 365,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "112223581",
+      "name": "M",
+      "product": 138,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:44:58.258Z",
+      "updated_at": "2022-05-13T23:26:53.285Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 366,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "112223582",
+      "name": "L",
+      "product": 138,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T21:44:58.304Z",
+      "updated_at": "2022-05-13T23:26:53.407Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 368,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6MzY4",
+      "product": 141,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-13T23:50:16.869Z",
+      "updated_at": "2022-05-14T21:33:36.523Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 370,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzcw",
+      "product": 143,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-14T21:10:01.587Z",
+      "updated_at": "2022-05-14T21:33:04.241Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 371,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzcx",
+      "product": 144,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-14T21:24:57.904Z",
+      "updated_at": "2022-05-14T21:25:09.225Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 372,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "9018223582",
+      "name": "DVD",
+      "product": 145,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-14T21:55:45.910Z",
+      "updated_at": "2022-05-14T21:55:45.938Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 373,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "9018223583",
+      "name": "iTunes",
+      "product": 145,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-14T21:55:45.950Z",
+      "updated_at": "2022-05-14T21:55:45.974Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 374,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "9018223584",
+      "name": "MP3",
+      "product": 145,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-14T21:55:45.983Z",
+      "updated_at": "2022-05-14T21:55:46.009Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 375,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "113223582",
+      "name": "Vinyl",
+      "product": 146,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-15T09:05:27.383Z",
+      "updated_at": "2022-05-15T09:05:27.419Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 376,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "113223583",
+      "name": "DVD",
+      "product": 146,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-15T09:05:27.430Z",
+      "updated_at": "2022-05-15T09:05:27.464Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 377,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "113223584",
+      "name": "iTunes",
+      "product": 146,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-15T09:05:27.476Z",
+      "updated_at": "2022-05-15T09:05:27.516Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 378,
+    "fields": {
+      "sort_order": 3,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "113223585",
+      "name": "CD",
+      "product": 146,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-15T09:05:27.531Z",
+      "updated_at": "2022-05-15T09:05:27.585Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 379,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "124223581",
+      "name": "iTunes",
+      "product": 147,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-15T09:21:06.168Z",
+      "updated_at": "2022-05-15T09:21:06.190Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 380,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "124223582",
+      "name": "MP3",
+      "product": 147,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-15T09:21:06.197Z",
+      "updated_at": "2022-05-15T09:21:06.218Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 382,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzgy",
+      "product": 150,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-15T09:28:13.324Z",
+      "updated_at": "2022-05-15T09:28:13.363Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 383,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzgz",
+      "product": 151,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-15T09:32:27.397Z",
+      "updated_at": "2022-05-16T16:38:35.759Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 384,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzg0",
+      "product": 152,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-16T16:19:51.191Z",
+      "updated_at": "2022-05-18T12:21:40.806Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 385,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzg1",
+      "product": 153,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-16T16:25:11.701Z",
+      "updated_at": "2022-05-16T16:25:11.757Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 386,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzg2",
+      "product": 154,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-16T16:27:16.900Z",
+      "updated_at": "2022-05-16T16:27:16.924Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 387,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzg3",
+      "product": 155,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-16T16:28:15.149Z",
+      "updated_at": "2022-05-17T12:36:31.454Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 388,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzg4",
+      "product": 156,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-17T11:44:17.115Z",
+      "updated_at": "2022-05-17T11:44:17.201Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 389,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "9182235820",
+      "name": "XL",
+      "product": 157,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-17T11:50:09.662Z",
+      "updated_at": "2022-05-17T11:50:09.694Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 390,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "9182235821",
+      "name": "XXL",
+      "product": 157,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-17T11:50:09.704Z",
+      "updated_at": "2022-05-17T11:50:09.730Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 393,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzkz",
+      "product": 160,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-17T11:57:19.386Z",
+      "updated_at": "2022-05-18T19:30:32.573Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 394,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "49182235820",
+      "name": "S",
+      "product": 161,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-17T12:03:59.123Z",
+      "updated_at": "2022-05-17T12:03:59.178Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 395,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "49182235821",
+      "name": "M",
+      "product": 161,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-17T12:03:59.193Z",
+      "updated_at": "2022-05-17T12:03:59.243Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 396,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "49182235822",
+      "name": "L",
+      "product": 161,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-17T12:03:59.262Z",
+      "updated_at": "2022-05-17T12:03:59.311Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 397,
+    "fields": {
+      "sort_order": 3,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "49182235823",
+      "name": "XL",
+      "product": 161,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-17T12:03:59.329Z",
+      "updated_at": "2022-05-17T12:03:59.383Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 398,
+    "fields": {
+      "sort_order": 4,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": "49182235824",
+      "name": "XXL",
+      "product": 161,
+      "track_inventory": true,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-17T12:03:59.400Z",
+      "updated_at": "2022-05-17T12:03:59.450Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 399,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6Mzk5",
+      "product": 162,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-18T12:06:54.246Z",
+      "updated_at": "2022-05-18T12:07:49.819Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 400,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6NDAw",
+      "product": 163,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-18T19:29:35.277Z",
+      "updated_at": "2022-05-18T19:29:47.123Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariant",
+    "pk": 401,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "sku": null,
+      "name": "UHJvZHVjdFZhcmlhbnQ6NDAx",
+      "product": 164,
+      "track_inventory": false,
+      "is_preorder": false,
+      "preorder_end_date": null,
+      "preorder_global_threshold": null,
+      "quantity_limit_per_customer": null,
+      "created_at": "2022-05-18T19:31:14.677Z",
+      "updated_at": "2022-05-18T19:31:14.745Z",
+      "weight": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 224,
+    "fields": {
+      "variant": 324,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "40.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 225,
+    "fields": {
+      "variant": 324,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "10.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 226,
+    "fields": {
+      "variant": 325,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "240.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 227,
+    "fields": {
+      "variant": 325,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "80.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 228,
+    "fields": {
+      "variant": 326,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "240.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 229,
+    "fields": {
+      "variant": 327,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "240.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 230,
+    "fields": {
+      "variant": 328,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "240.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 231,
+    "fields": {
+      "variant": 329,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "240.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 232,
+    "fields": {
+      "variant": 330,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "240.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 233,
+    "fields": {
+      "variant": 331,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "240.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 234,
+    "fields": {
+      "variant": 326,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "80.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 235,
+    "fields": {
+      "variant": 327,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "80.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 236,
+    "fields": {
+      "variant": 328,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "80.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 237,
+    "fields": {
+      "variant": 329,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "80.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 238,
+    "fields": {
+      "variant": 330,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "80.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 239,
+    "fields": {
+      "variant": 331,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "80.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 240,
+    "fields": {
+      "variant": 332,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "230.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 241,
+    "fields": {
+      "variant": 332,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "75.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 242,
+    "fields": {
+      "variant": 333,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "230.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 243,
+    "fields": {
+      "variant": 333,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "75.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 244,
+    "fields": {
+      "variant": 334,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "230.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 245,
+    "fields": {
+      "variant": 334,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "75.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 246,
+    "fields": {
+      "variant": 335,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "420.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 247,
+    "fields": {
+      "variant": 335,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 248,
+    "fields": {
+      "variant": 336,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "420.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 249,
+    "fields": {
+      "variant": 336,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 250,
+    "fields": {
+      "variant": 337,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "420.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 251,
+    "fields": {
+      "variant": 337,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 252,
+    "fields": {
+      "variant": 338,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "420.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 253,
+    "fields": {
+      "variant": 338,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 254,
+    "fields": {
+      "variant": 339,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "420.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 255,
+    "fields": {
+      "variant": 339,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 256,
+    "fields": {
+      "variant": 340,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "209.960",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 257,
+    "fields": {
+      "variant": 340,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "50.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 258,
+    "fields": {
+      "variant": 341,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "209.960",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 259,
+    "fields": {
+      "variant": 341,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "50.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 260,
+    "fields": {
+      "variant": 342,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "209.960",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 261,
+    "fields": {
+      "variant": 342,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "50.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 262,
+    "fields": {
+      "variant": 343,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "209.960",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 263,
+    "fields": {
+      "variant": 343,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "50.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 264,
+    "fields": {
+      "variant": 344,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "209.960",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 265,
+    "fields": {
+      "variant": 344,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "50.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 266,
+    "fields": {
+      "variant": 345,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "100.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 267,
+    "fields": {
+      "variant": 345,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "30.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 268,
+    "fields": {
+      "variant": 346,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "120.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 269,
+    "fields": {
+      "variant": 346,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "35.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 270,
+    "fields": {
+      "variant": 347,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "120.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 271,
+    "fields": {
+      "variant": 347,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "35.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 272,
+    "fields": {
+      "variant": 348,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 273,
+    "fields": {
+      "variant": 348,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "20.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 274,
+    "fields": {
+      "variant": 349,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 275,
+    "fields": {
+      "variant": 349,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "20.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 276,
+    "fields": {
+      "variant": 350,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 277,
+    "fields": {
+      "variant": 350,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "20.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 278,
+    "fields": {
+      "variant": 351,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 279,
+    "fields": {
+      "variant": 351,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "20.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 280,
+    "fields": {
+      "variant": 352,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 281,
+    "fields": {
+      "variant": 352,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "20.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 282,
+    "fields": {
+      "variant": 353,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "200.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 283,
+    "fields": {
+      "variant": 353,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "40.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 284,
+    "fields": {
+      "variant": 354,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "200.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 285,
+    "fields": {
+      "variant": 354,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "40.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 286,
+    "fields": {
+      "variant": 355,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "200.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 287,
+    "fields": {
+      "variant": 355,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "40.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 288,
+    "fields": {
+      "variant": 356,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "200.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 289,
+    "fields": {
+      "variant": 356,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "40.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 290,
+    "fields": {
+      "variant": 357,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "200.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 291,
+    "fields": {
+      "variant": 357,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "40.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 292,
+    "fields": {
+      "variant": 358,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "150.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 293,
+    "fields": {
+      "variant": 358,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 294,
+    "fields": {
+      "variant": 359,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "150.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 295,
+    "fields": {
+      "variant": 359,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 296,
+    "fields": {
+      "variant": 360,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "150.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 297,
+    "fields": {
+      "variant": 360,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 298,
+    "fields": {
+      "variant": 361,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "150.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 299,
+    "fields": {
+      "variant": 361,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 300,
+    "fields": {
+      "variant": 362,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "150.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 301,
+    "fields": {
+      "variant": 362,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 302,
+    "fields": {
+      "variant": 363,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "150.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 303,
+    "fields": {
+      "variant": 363,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 304,
+    "fields": {
+      "variant": 364,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "150.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 305,
+    "fields": {
+      "variant": 364,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 306,
+    "fields": {
+      "variant": 365,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "150.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 307,
+    "fields": {
+      "variant": 365,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 308,
+    "fields": {
+      "variant": 366,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "150.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 309,
+    "fields": {
+      "variant": 366,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 312,
+    "fields": {
+      "variant": 368,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "50.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 313,
+    "fields": {
+      "variant": 368,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "10.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 316,
+    "fields": {
+      "variant": 370,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 317,
+    "fields": {
+      "variant": 370,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "20.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 318,
+    "fields": {
+      "variant": 371,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "60.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 319,
+    "fields": {
+      "variant": 371,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "15.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 320,
+    "fields": {
+      "variant": 372,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 321,
+    "fields": {
+      "variant": 372,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "10.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 322,
+    "fields": {
+      "variant": 373,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 323,
+    "fields": {
+      "variant": 373,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "10.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 324,
+    "fields": {
+      "variant": 374,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "45.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 325,
+    "fields": {
+      "variant": 374,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "10.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 326,
+    "fields": {
+      "variant": 375,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "29.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 327,
+    "fields": {
+      "variant": 375,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "8.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 328,
+    "fields": {
+      "variant": 376,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "29.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 329,
+    "fields": {
+      "variant": 376,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "8.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 330,
+    "fields": {
+      "variant": 377,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "29.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 331,
+    "fields": {
+      "variant": 377,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "8.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 332,
+    "fields": {
+      "variant": 378,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "29.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 333,
+    "fields": {
+      "variant": 378,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "8.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 334,
+    "fields": {
+      "variant": 379,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "9.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 335,
+    "fields": {
+      "variant": 379,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "2.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 336,
+    "fields": {
+      "variant": 380,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "9.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 337,
+    "fields": {
+      "variant": 380,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "2.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 338,
+    "fields": {
+      "variant": 382,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "29.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 339,
+    "fields": {
+      "variant": 382,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "11.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 340,
+    "fields": {
+      "variant": 383,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "70.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 341,
+    "fields": {
+      "variant": 383,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "18.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 342,
+    "fields": {
+      "variant": 384,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "5.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 343,
+    "fields": {
+      "variant": 384,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "1.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 344,
+    "fields": {
+      "variant": 385,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "5.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 345,
+    "fields": {
+      "variant": 385,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "1.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 346,
+    "fields": {
+      "variant": 386,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "5.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 347,
+    "fields": {
+      "variant": 386,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "1.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 348,
+    "fields": {
+      "variant": 387,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "5.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 349,
+    "fields": {
+      "variant": 387,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "1.990",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 350,
+    "fields": {
+      "variant": 388,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "90.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 351,
+    "fields": {
+      "variant": 388,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "17.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 352,
+    "fields": {
+      "variant": 389,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "120.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 353,
+    "fields": {
+      "variant": 389,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "25.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 354,
+    "fields": {
+      "variant": 390,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "120.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 355,
+    "fields": {
+      "variant": 390,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "25.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 356,
+    "fields": {
+      "variant": 393,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "450.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 357,
+    "fields": {
+      "variant": 393,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "100.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 358,
+    "fields": {
+      "variant": 394,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "130.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 359,
+    "fields": {
+      "variant": 394,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "30.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 360,
+    "fields": {
+      "variant": 395,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "130.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 361,
+    "fields": {
+      "variant": 395,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "30.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 362,
+    "fields": {
+      "variant": 396,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "130.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 363,
+    "fields": {
+      "variant": 396,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "30.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 364,
+    "fields": {
+      "variant": 397,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "130.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 365,
+    "fields": {
+      "variant": 397,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "30.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 366,
+    "fields": {
+      "variant": 398,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "130.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 367,
+    "fields": {
+      "variant": 398,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "30.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 368,
+    "fields": {
+      "variant": 399,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "230.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 369,
+    "fields": {
+      "variant": 399,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "50.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 370,
+    "fields": {
+      "variant": 400,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "2300.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 371,
+    "fields": {
+      "variant": 400,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "500.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 372,
+    "fields": {
+      "variant": 401,
+      "channel": 2,
+      "currency": "PLN",
+      "price_amount": "230.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productvariantchannellisting",
+    "pk": 373,
+    "fields": {
+      "variant": 401,
+      "channel": 1,
+      "currency": "USD",
+      "price_amount": "50.000",
+      "cost_price_amount": null,
+      "preorder_quantity_threshold": null
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 291,
+    "fields": {
+      "sort_order": 1,
+      "product": 127,
+      "image": "products/white-plimsolls-1_89b84f81.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 292,
+    "fields": {
+      "sort_order": 2,
+      "product": 127,
+      "image": "products/white-plimsolls-4_5be43acb.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 293,
+    "fields": {
+      "sort_order": 3,
+      "product": 127,
+      "image": "products/white-plimsolls-3_1ca670b6.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 294,
+    "fields": {
+      "sort_order": 0,
+      "product": 127,
+      "image": "products/white-plimsolls-2_0d32e6cd.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 295,
+    "fields": {
+      "sort_order": 2,
+      "product": 128,
+      "image": "products/blue-plimsolls-4_a736db7c.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 296,
+    "fields": {
+      "sort_order": 3,
+      "product": 128,
+      "image": "products/blue-plimsolls-3_33357cf1.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 297,
+    "fields": {
+      "sort_order": 1,
+      "product": 128,
+      "image": "products/blue-plimsolls-2_41772a01.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 298,
+    "fields": {
+      "sort_order": 0,
+      "product": 128,
+      "image": "products/blue-plimsolls-1_faee630a.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 299,
+    "fields": {
+      "sort_order": 1,
+      "product": 129,
+      "image": "products/dash-force-2_a2967ead.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 300,
+    "fields": {
+      "sort_order": 0,
+      "product": 129,
+      "image": "products/dash-force-1_8e457aea.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 301,
+    "fields": {
+      "sort_order": 1,
+      "product": 130,
+      "image": "products/paul-blanace-420-2_a7e37c20.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 302,
+    "fields": {
+      "sort_order": 0,
+      "product": 130,
+      "image": "products/paul-balance-420-1_bc781886.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 303,
+    "fields": {
+      "sort_order": 0,
+      "product": 131,
+      "image": "products/grey-hoodie_a4b54cef.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 304,
+    "fields": {
+      "sort_order": 0,
+      "product": 132,
+      "image": "products/blue-hoodie_39853ca5.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 305,
+    "fields": {
+      "sort_order": 0,
+      "product": 133,
+      "image": "products/white-hoodie_0bebcc44.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 306,
+    "fields": {
+      "sort_order": 1,
+      "product": 134,
+      "image": "products/ascii-shirt-2_90b22406.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 307,
+    "fields": {
+      "sort_order": 0,
+      "product": 134,
+      "image": "products/ascii-shirt-1_84725100.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 308,
+    "fields": {
+      "sort_order": 1,
+      "product": 135,
+      "image": "products/dash-shirt-2_961de104.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 309,
+    "fields": {
+      "sort_order": 0,
+      "product": 135,
+      "image": "products/dash-shirt-1_57989641.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 310,
+    "fields": {
+      "sort_order": 1,
+      "product": 136,
+      "image": "products/polo-shirt-2_d06e6c66.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 311,
+    "fields": {
+      "sort_order": 0,
+      "product": 136,
+      "image": "products/polo-shirt-1_afa3edfa.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 312,
+    "fields": {
+      "sort_order": 0,
+      "product": 137,
+      "image": "products/blue-shirt-1_c56ca56a.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 313,
+    "fields": {
+      "sort_order": 1,
+      "product": 137,
+      "image": "products/blue-shirt-2_7cc6a9e4.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 314,
+    "fields": {
+      "sort_order": 1,
+      "product": 138,
+      "image": "products/dark-shirt-2_4f6092c6.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 315,
+    "fields": {
+      "sort_order": 0,
+      "product": 138,
+      "image": "products/dark-shirt-1_26098e44.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 322,
+    "fields": {
+      "sort_order": 1,
+      "product": 141,
+      "image": "products/beanie-2_2dff9a07.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 323,
+    "fields": {
+      "sort_order": 0,
+      "product": 141,
+      "image": "products/beanie-1_01ef6335.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 324,
+    "fields": {
+      "sort_order": 0,
+      "product": 143,
+      "image": "products/s-mask_9ecddc7d.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 325,
+    "fields": {
+      "sort_order": 0,
+      "product": 144,
+      "image": "products/sunnies_6e8e5022.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 330,
+    "fields": {
+      "sort_order": 0,
+      "product": 150,
+      "image": "products/mighty-mug_5f6863c3.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 331,
+    "fields": {
+      "sort_order": 0,
+      "product": 151,
+      "image": "products/cushion_4795cee5.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 337,
+    "fields": {
+      "sort_order": 0,
+      "product": 152,
+      "image": "products/apple-drink_60641056.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 338,
+    "fields": {
+      "sort_order": 0,
+      "product": 153,
+      "image": "products/bean-drink_f79fcbdc.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 339,
+    "fields": {
+      "sort_order": 0,
+      "product": 154,
+      "image": "products/banana-drink_9b99e517.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 340,
+    "fields": {
+      "sort_order": 0,
+      "product": 155,
+      "image": "products/carrot-drink_3357831d.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 341,
+    "fields": {
+      "sort_order": 0,
+      "product": 156,
+      "image": "products/sunnies-dark_caa11cfa.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 342,
+    "fields": {
+      "sort_order": 1,
+      "product": 157,
+      "image": "products/monotype-white-2_1ee7b6a8.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 343,
+    "fields": {
+      "sort_order": 0,
+      "product": 157,
+      "image": "products/monotype-white-1_7f8e7c5e.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 345,
+    "fields": {
+      "sort_order": 1,
+      "product": 161,
+      "image": "products/white_cubics_tee_back_5517f1bd.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 346,
+    "fields": {
+      "sort_order": 0,
+      "product": 161,
+      "image": "products/white_cubics_tee_76280780.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 354,
+    "fields": {
+      "sort_order": 0,
+      "product": 162,
+      "image": "products/white-parrot-cushion_291431f9.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 355,
+    "fields": {
+      "sort_order": 0,
+      "product": 160,
+      "image": "products/gift-100_db57880e.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 356,
+    "fields": {
+      "sort_order": 0,
+      "product": 163,
+      "image": "products/gift-500_b1f879ef.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 357,
+    "fields": {
+      "sort_order": 0,
+      "product": 164,
+      "image": "products/gift-50_b0ac8b5a.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 358,
+    "fields": {
+      "sort_order": 0,
+      "product": 145,
+      "image": "products/saleor-battle-tested-book_db8bf937.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 359,
+    "fields": {
+      "sort_order": 0,
+      "product": 146,
+      "image": "products/saleor-enterprise-cloud-book_3ac7d9be.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 360,
+    "fields": {
+      "sort_order": 0,
+      "product": 126,
+      "image": "products/saleor-headless-omnichannel-book_f3d9f1b5.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.productmedia",
+    "pk": 361,
+    "fields": {
+      "sort_order": 0,
+      "product": 147,
+      "image": "products/saleor-own-your-stack-and-data-book_2bb5376f.png",
+      "ppoi": "0.5x0.5",
+      "alt": "",
+      "type": "IMAGE",
+      "external_url": null,
+      "oembed_data": {},
+      "to_remove": false
+    }
+  },
+  {
+    "model": "product.collectionproduct",
+    "pk": 9,
+    "fields": { "sort_order": null, "collection": 4, "product": 150 }
+  },
+  {
+    "model": "product.collectionproduct",
+    "pk": 10,
+    "fields": { "sort_order": null, "collection": 4, "product": 134 }
+  },
+  {
+    "model": "product.collectionproduct",
+    "pk": 11,
+    "fields": { "sort_order": null, "collection": 4, "product": 127 }
+  },
+  {
+    "model": "product.collectionproduct",
+    "pk": 12,
+    "fields": { "sort_order": null, "collection": 5, "product": 128 }
+  },
+  {
+    "model": "product.collectionproduct",
+    "pk": 13,
+    "fields": { "sort_order": null, "collection": 5, "product": 136 }
+  },
+  {
+    "model": "product.collectionproduct",
+    "pk": 14,
+    "fields": { "sort_order": null, "collection": 5, "product": 144 }
+  },
+  {
+    "model": "product.collectionproduct",
+    "pk": 15,
+    "fields": { "sort_order": null, "collection": 4, "product": 161 }
+  },
+  {
+    "model": "product.collectionproduct",
+    "pk": 17,
+    "fields": { "sort_order": null, "collection": 5, "product": 161 }
+  },
+  {
+    "model": "product.collection",
+    "pk": 4,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Featured Products",
+      "slug": "featured-products",
+      "background_image": "",
+      "background_image_alt": "",
+      "description": {
+        "time": 1652704228241,
+        "blocks": [
+          {
+            "id": "vSuHF7x1Ph",
+            "data": { "text": "Team's favourites" },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.24.3"
+      }
+    }
+  },
+  {
+    "model": "product.collection",
+    "pk": 5,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "name": "Summer Picks",
+      "slug": "summer-picks",
+      "background_image": "",
+      "background_image_alt": "",
+      "description": {
+        "time": 1652704367895,
+        "blocks": [
+          {
+            "id": "U2Pv1bCoAr",
+            "data": { "text": "Get ready for the summer" },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.24.3"
+      }
+    }
+  },
+  {
+    "model": "product.collectionchannellisting",
+    "pk": 7,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "collection": 4,
+      "channel": 2
+    }
+  },
+  {
+    "model": "product.collectionchannellisting",
+    "pk": 8,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "collection": 4,
+      "channel": 1
+    }
+  },
+  {
+    "model": "product.collectionchannellisting",
+    "pk": 9,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "collection": 5,
+      "channel": 2
+    }
+  },
+  {
+    "model": "product.collectionchannellisting",
+    "pk": 10,
+    "fields": {
+      "published_at": "2022-05-16T00:00:00Z",
+      "is_published": true,
+      "collection": 5,
+      "channel": 1
+    }
+  },
+  {
+    "model": "attribute.attribute",
+    "pk": 36,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "slug": "material",
+      "name": "Material",
+      "type": "product-type",
+      "input_type": "dropdown",
+      "entity_type": null,
+      "unit": null,
+      "value_required": true,
+      "is_variant_only": false,
+      "visible_in_storefront": true,
+      "filterable_in_storefront": true,
+      "filterable_in_dashboard": true,
+      "storefront_search_position": 0,
+      "available_in_grid": true
+    }
+  },
+  {
+    "model": "attribute.attribute",
+    "pk": 37,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "slug": "shoe-size",
+      "name": "Shoe size",
+      "type": "product-type",
+      "input_type": "dropdown",
+      "entity_type": null,
+      "unit": null,
+      "value_required": false,
+      "is_variant_only": false,
+      "visible_in_storefront": true,
+      "filterable_in_storefront": true,
+      "filterable_in_dashboard": true,
+      "storefront_search_position": 0,
+      "available_in_grid": true
+    }
+  },
+  {
+    "model": "attribute.attribute",
+    "pk": 38,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "slug": "size",
+      "name": "Size",
+      "type": "product-type",
+      "input_type": "dropdown",
+      "entity_type": null,
+      "unit": null,
+      "value_required": false,
+      "is_variant_only": false,
+      "visible_in_storefront": true,
+      "filterable_in_storefront": true,
+      "filterable_in_dashboard": true,
+      "storefront_search_position": 0,
+      "available_in_grid": true
+    }
+  },
+  {
+    "model": "attribute.attribute",
+    "pk": 39,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "slug": "volume",
+      "name": "Volume",
+      "type": "product-type",
+      "input_type": "dropdown",
+      "entity_type": null,
+      "unit": null,
+      "value_required": false,
+      "is_variant_only": false,
+      "visible_in_storefront": true,
+      "filterable_in_storefront": true,
+      "filterable_in_dashboard": true,
+      "storefront_search_position": 0,
+      "available_in_grid": true
+    }
+  },
+  {
+    "model": "attribute.attribute",
+    "pk": 40,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "slug": "flavor",
+      "name": "Flavor",
+      "type": "product-type",
+      "input_type": "dropdown",
+      "entity_type": null,
+      "unit": null,
+      "value_required": false,
+      "is_variant_only": false,
+      "visible_in_storefront": true,
+      "filterable_in_storefront": true,
+      "filterable_in_dashboard": true,
+      "storefront_search_position": 0,
+      "available_in_grid": true
+    }
+  },
+  {
+    "model": "attribute.attribute",
+    "pk": 41,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "slug": "ebook-format",
+      "name": "EBook Format",
+      "type": "product-type",
+      "input_type": "dropdown",
+      "entity_type": null,
+      "unit": null,
+      "value_required": true,
+      "is_variant_only": false,
+      "visible_in_storefront": true,
+      "filterable_in_storefront": true,
+      "filterable_in_dashboard": true,
+      "storefront_search_position": 0,
+      "available_in_grid": true
+    }
+  },
+  {
+    "model": "attribute.attribute",
+    "pk": 42,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "slug": "medium",
+      "name": "Medium",
+      "type": "product-type",
+      "input_type": "dropdown",
+      "entity_type": null,
+      "unit": null,
+      "value_required": true,
+      "is_variant_only": false,
+      "visible_in_storefront": true,
+      "filterable_in_storefront": true,
+      "filterable_in_dashboard": true,
+      "storefront_search_position": 0,
+      "available_in_grid": true
+    }
+  },
+  {
+    "model": "attribute.attribute",
+    "pk": 43,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "slug": "publisher",
+      "name": "Publisher",
+      "type": "product-type",
+      "input_type": "dropdown",
+      "entity_type": null,
+      "unit": null,
+      "value_required": true,
+      "is_variant_only": false,
+      "visible_in_storefront": true,
+      "filterable_in_storefront": true,
+      "filterable_in_dashboard": true,
+      "storefront_search_position": 0,
+      "available_in_grid": true
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 105,
+    "fields": {
+      "sort_order": 0,
+      "name": "Cotton",
+      "value": "",
+      "slug": "cotton",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 36,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 106,
+    "fields": {
+      "sort_order": 1,
+      "name": "Elastane",
+      "value": "",
+      "slug": "elastane",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 36,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 107,
+    "fields": {
+      "sort_order": 2,
+      "name": "Polyester",
+      "value": "",
+      "slug": "polyester",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 36,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 108,
+    "fields": {
+      "sort_order": 0,
+      "name": "39",
+      "value": "",
+      "slug": "39",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 37,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 109,
+    "fields": {
+      "sort_order": 1,
+      "name": "40",
+      "value": "",
+      "slug": "40",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 37,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 110,
+    "fields": {
+      "sort_order": 2,
+      "name": "41",
+      "value": "",
+      "slug": "41",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 37,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 111,
+    "fields": {
+      "sort_order": 3,
+      "name": "42",
+      "value": "",
+      "slug": "42",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 37,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 112,
+    "fields": {
+      "sort_order": 4,
+      "name": "43",
+      "value": "",
+      "slug": "43",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 37,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 113,
+    "fields": {
+      "sort_order": 5,
+      "name": "44",
+      "value": "",
+      "slug": "44",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 37,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 114,
+    "fields": {
+      "sort_order": 6,
+      "name": "45",
+      "value": "",
+      "slug": "45",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 37,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 115,
+    "fields": {
+      "sort_order": 0,
+      "name": "S",
+      "value": "",
+      "slug": "s",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 38,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 116,
+    "fields": {
+      "sort_order": 1,
+      "name": "M",
+      "value": "",
+      "slug": "m",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 38,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 117,
+    "fields": {
+      "sort_order": 2,
+      "name": "L",
+      "value": "",
+      "slug": "l",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 38,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 118,
+    "fields": {
+      "sort_order": 3,
+      "name": "XL",
+      "value": "",
+      "slug": "xl",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 38,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 119,
+    "fields": {
+      "sort_order": 4,
+      "name": "XXL",
+      "value": "",
+      "slug": "xxl",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 38,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 120,
+    "fields": {
+      "sort_order": 0,
+      "name": "700ml",
+      "value": "",
+      "slug": "700ml",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 39,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 121,
+    "fields": {
+      "sort_order": 0,
+      "name": "Orange",
+      "value": "",
+      "slug": "orange",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 40,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 122,
+    "fields": {
+      "sort_order": 1,
+      "name": "Banana",
+      "value": "",
+      "slug": "banana",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 40,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 123,
+    "fields": {
+      "sort_order": 2,
+      "name": "Bean",
+      "value": "",
+      "slug": "bean",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 40,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 124,
+    "fields": {
+      "sort_order": 3,
+      "name": "Carrot",
+      "value": "",
+      "slug": "carrot",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 40,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 125,
+    "fields": {
+      "sort_order": 4,
+      "name": "Sprouty",
+      "value": "",
+      "slug": "sprouty",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 40,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 126,
+    "fields": {
+      "sort_order": 5,
+      "name": "Salty, like the tears of your enemy",
+      "value": "",
+      "slug": "salty-like-the-tears-of-your-enemy",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 40,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 127,
+    "fields": {
+      "sort_order": 6,
+      "name": "Pineapple",
+      "value": "",
+      "slug": "pineapple",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 40,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 128,
+    "fields": {
+      "sort_order": 7,
+      "name": "Coconut",
+      "value": "",
+      "slug": "coconut",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 40,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 129,
+    "fields": {
+      "sort_order": 8,
+      "name": "Apple",
+      "value": "",
+      "slug": "apple",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 40,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 130,
+    "fields": {
+      "sort_order": 0,
+      "name": "EPUB",
+      "value": "",
+      "slug": "epub",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 41,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 131,
+    "fields": {
+      "sort_order": 1,
+      "name": "MOBI",
+      "value": "",
+      "slug": "mobi",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 41,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 132,
+    "fields": {
+      "sort_order": 0,
+      "name": "Vinyl",
+      "value": "",
+      "slug": "vinyl",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 42,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 133,
+    "fields": {
+      "sort_order": 1,
+      "name": "DVD",
+      "value": "",
+      "slug": "dvd",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 42,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 134,
+    "fields": {
+      "sort_order": 2,
+      "name": "VHS",
+      "value": "",
+      "slug": "vhs",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 42,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 135,
+    "fields": {
+      "sort_order": 3,
+      "name": "iTunes",
+      "value": "",
+      "slug": "itunes",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 42,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 136,
+    "fields": {
+      "sort_order": 4,
+      "name": "CD",
+      "value": "",
+      "slug": "cd",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 42,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 137,
+    "fields": {
+      "sort_order": 5,
+      "name": "MP3",
+      "value": "",
+      "slug": "mp3",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 42,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 138,
+    "fields": {
+      "sort_order": 0,
+      "name": "Digital Audio",
+      "value": "",
+      "slug": "digital-audio",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 43,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 140,
+    "fields": {
+      "sort_order": 3,
+      "name": "Wool",
+      "value": "",
+      "slug": "wool",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 36,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.attributevalue",
+    "pk": 141,
+    "fields": {
+      "sort_order": 1,
+      "name": "Saleor Publishing",
+      "value": "",
+      "slug": "saleor-publishing",
+      "file_url": null,
+      "content_type": null,
+      "attribute": 43,
+      "rich_text": null,
+      "boolean": null,
+      "date_time": null,
+      "reference_product": null,
+      "reference_page": null
+    }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 193,
+    "fields": { "sort_order": 0, "value": 138, "assignment": 37 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 194,
+    "fields": { "sort_order": 0, "value": 105, "assignment": 38 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 195,
+    "fields": { "sort_order": 0, "value": 107, "assignment": 39 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 196,
+    "fields": { "sort_order": 0, "value": 105, "assignment": 40 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 197,
+    "fields": { "sort_order": 0, "value": 105, "assignment": 41 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 198,
+    "fields": { "sort_order": 0, "value": 106, "assignment": 42 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 199,
+    "fields": { "sort_order": 0, "value": 105, "assignment": 43 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 200,
+    "fields": { "sort_order": 0, "value": 105, "assignment": 44 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 201,
+    "fields": { "sort_order": 0, "value": 105, "assignment": 45 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 204,
+    "fields": { "sort_order": 0, "value": 105, "assignment": 48 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 206,
+    "fields": { "sort_order": 0, "value": 140, "assignment": 50 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 207,
+    "fields": { "sort_order": 0, "value": 141, "assignment": 51 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 208,
+    "fields": { "sort_order": 0, "value": 141, "assignment": 52 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 210,
+    "fields": { "sort_order": 0, "value": 129, "assignment": 54 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 211,
+    "fields": { "sort_order": 0, "value": 123, "assignment": 55 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 212,
+    "fields": { "sort_order": 0, "value": 122, "assignment": 56 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 213,
+    "fields": { "sort_order": 0, "value": 124, "assignment": 57 }
+  },
+  {
+    "model": "attribute.assignedproductattributevalue",
+    "pk": 214,
+    "fields": { "sort_order": 0, "value": 105, "assignment": 58 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 37,
+    "fields": { "product": 126, "assignment": 10 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 38,
+    "fields": { "product": 131, "assignment": 11 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 39,
+    "fields": { "product": 132, "assignment": 11 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 40,
+    "fields": { "product": 133, "assignment": 11 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 41,
+    "fields": { "product": 134, "assignment": 12 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 42,
+    "fields": { "product": 135, "assignment": 12 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 43,
+    "fields": { "product": 136, "assignment": 12 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 44,
+    "fields": { "product": 137, "assignment": 12 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 45,
+    "fields": { "product": 138, "assignment": 12 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 48,
+    "fields": { "product": 141, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 50,
+    "fields": { "product": 143, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 51,
+    "fields": { "product": 146, "assignment": 10 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 52,
+    "fields": { "product": 147, "assignment": 10 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 54,
+    "fields": { "product": 152, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 55,
+    "fields": { "product": 153, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 56,
+    "fields": { "product": 154, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 57,
+    "fields": { "product": 155, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedproductattribute",
+    "pk": 58,
+    "fields": { "product": 161, "assignment": 12 }
+  },
+  {
+    "model": "attribute.attributeproduct",
+    "pk": 10,
+    "fields": { "sort_order": 0, "attribute": 43, "product_type": 17 }
+  },
+  {
+    "model": "attribute.attributeproduct",
+    "pk": 11,
+    "fields": { "sort_order": 0, "attribute": 36, "product_type": 19 }
+  },
+  {
+    "model": "attribute.attributeproduct",
+    "pk": 12,
+    "fields": { "sort_order": 0, "attribute": 36, "product_type": 20 }
+  },
+  {
+    "model": "attribute.attributeproduct",
+    "pk": 13,
+    "fields": { "sort_order": 0, "attribute": 36, "product_type": 21 }
+  },
+  {
+    "model": "attribute.attributeproduct",
+    "pk": 14,
+    "fields": { "sort_order": 0, "attribute": 40, "product_type": 23 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 676,
+    "fields": { "sort_order": 0, "value": 137, "assignment": 136 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 677,
+    "fields": { "sort_order": 0, "value": 108, "assignment": 137 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 678,
+    "fields": { "sort_order": 0, "value": 109, "assignment": 138 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 679,
+    "fields": { "sort_order": 0, "value": 110, "assignment": 139 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 680,
+    "fields": { "sort_order": 0, "value": 111, "assignment": 140 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 681,
+    "fields": { "sort_order": 0, "value": 112, "assignment": 141 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 682,
+    "fields": { "sort_order": 0, "value": 113, "assignment": 142 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 683,
+    "fields": { "sort_order": 0, "value": 114, "assignment": 143 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 684,
+    "fields": { "sort_order": 0, "value": 110, "assignment": 144 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 685,
+    "fields": { "sort_order": 0, "value": 109, "assignment": 145 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 686,
+    "fields": { "sort_order": 0, "value": 111, "assignment": 146 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 687,
+    "fields": { "sort_order": 0, "value": 108, "assignment": 147 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 688,
+    "fields": { "sort_order": 0, "value": 109, "assignment": 148 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 689,
+    "fields": { "sort_order": 0, "value": 110, "assignment": 149 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 690,
+    "fields": { "sort_order": 0, "value": 111, "assignment": 150 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 691,
+    "fields": { "sort_order": 0, "value": 112, "assignment": 151 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 692,
+    "fields": { "sort_order": 0, "value": 108, "assignment": 152 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 693,
+    "fields": { "sort_order": 0, "value": 109, "assignment": 153 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 694,
+    "fields": { "sort_order": 0, "value": 110, "assignment": 154 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 695,
+    "fields": { "sort_order": 0, "value": 111, "assignment": 155 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 696,
+    "fields": { "sort_order": 0, "value": 114, "assignment": 156 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 697,
+    "fields": { "sort_order": 0, "value": 115, "assignment": 157 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 698,
+    "fields": { "sort_order": 0, "value": 116, "assignment": 158 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 699,
+    "fields": { "sort_order": 0, "value": 117, "assignment": 159 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 700,
+    "fields": { "sort_order": 0, "value": 118, "assignment": 160 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 701,
+    "fields": { "sort_order": 0, "value": 119, "assignment": 161 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 702,
+    "fields": { "sort_order": 0, "value": 115, "assignment": 162 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 703,
+    "fields": { "sort_order": 0, "value": 116, "assignment": 163 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 704,
+    "fields": { "sort_order": 0, "value": 117, "assignment": 164 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 705,
+    "fields": { "sort_order": 0, "value": 118, "assignment": 165 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 706,
+    "fields": { "sort_order": 0, "value": 119, "assignment": 166 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 707,
+    "fields": { "sort_order": 0, "value": 115, "assignment": 167 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 708,
+    "fields": { "sort_order": 0, "value": 116, "assignment": 168 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 709,
+    "fields": { "sort_order": 0, "value": 119, "assignment": 169 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 710,
+    "fields": { "sort_order": 0, "value": 116, "assignment": 170 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 711,
+    "fields": { "sort_order": 0, "value": 117, "assignment": 171 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 712,
+    "fields": { "sort_order": 0, "value": 118, "assignment": 172 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 713,
+    "fields": { "sort_order": 0, "value": 115, "assignment": 173 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 714,
+    "fields": { "sort_order": 0, "value": 116, "assignment": 174 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 715,
+    "fields": { "sort_order": 0, "value": 117, "assignment": 175 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 716,
+    "fields": { "sort_order": 0, "value": 133, "assignment": 176 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 717,
+    "fields": { "sort_order": 0, "value": 135, "assignment": 177 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 718,
+    "fields": { "sort_order": 0, "value": 137, "assignment": 178 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 719,
+    "fields": { "sort_order": 0, "value": 132, "assignment": 179 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 720,
+    "fields": { "sort_order": 0, "value": 133, "assignment": 180 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 721,
+    "fields": { "sort_order": 0, "value": 135, "assignment": 181 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 722,
+    "fields": { "sort_order": 0, "value": 136, "assignment": 182 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 723,
+    "fields": { "sort_order": 0, "value": 135, "assignment": 183 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 724,
+    "fields": { "sort_order": 0, "value": 137, "assignment": 184 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 725,
+    "fields": { "sort_order": 0, "value": 118, "assignment": 185 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 726,
+    "fields": { "sort_order": 0, "value": 119, "assignment": 186 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 727,
+    "fields": { "sort_order": 0, "value": 115, "assignment": 187 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 728,
+    "fields": { "sort_order": 0, "value": 116, "assignment": 188 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 729,
+    "fields": { "sort_order": 0, "value": 117, "assignment": 189 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 730,
+    "fields": { "sort_order": 0, "value": 118, "assignment": 190 }
+  },
+  {
+    "model": "attribute.assignedvariantattributevalue",
+    "pk": 731,
+    "fields": { "sort_order": 0, "value": 119, "assignment": 191 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 136,
+    "fields": { "variant": 324, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 137,
+    "fields": { "variant": 325, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 138,
+    "fields": { "variant": 326, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 139,
+    "fields": { "variant": 327, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 140,
+    "fields": { "variant": 328, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 141,
+    "fields": { "variant": 329, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 142,
+    "fields": { "variant": 330, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 143,
+    "fields": { "variant": 331, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 144,
+    "fields": { "variant": 332, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 145,
+    "fields": { "variant": 333, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 146,
+    "fields": { "variant": 334, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 147,
+    "fields": { "variant": 335, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 148,
+    "fields": { "variant": 336, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 149,
+    "fields": { "variant": 337, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 150,
+    "fields": { "variant": 338, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 151,
+    "fields": { "variant": 339, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 152,
+    "fields": { "variant": 340, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 153,
+    "fields": { "variant": 341, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 154,
+    "fields": { "variant": 342, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 155,
+    "fields": { "variant": 343, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 156,
+    "fields": { "variant": 344, "assignment": 14 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 157,
+    "fields": { "variant": 348, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 158,
+    "fields": { "variant": 349, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 159,
+    "fields": { "variant": 350, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 160,
+    "fields": { "variant": 351, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 161,
+    "fields": { "variant": 352, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 162,
+    "fields": { "variant": 353, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 163,
+    "fields": { "variant": 354, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 164,
+    "fields": { "variant": 355, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 165,
+    "fields": { "variant": 356, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 166,
+    "fields": { "variant": 357, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 167,
+    "fields": { "variant": 358, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 168,
+    "fields": { "variant": 359, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 169,
+    "fields": { "variant": 360, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 170,
+    "fields": { "variant": 361, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 171,
+    "fields": { "variant": 362, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 172,
+    "fields": { "variant": 363, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 173,
+    "fields": { "variant": 364, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 174,
+    "fields": { "variant": 365, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 175,
+    "fields": { "variant": 366, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 176,
+    "fields": { "variant": 372, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 177,
+    "fields": { "variant": 373, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 178,
+    "fields": { "variant": 374, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 179,
+    "fields": { "variant": 375, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 180,
+    "fields": { "variant": 376, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 181,
+    "fields": { "variant": 377, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 182,
+    "fields": { "variant": 378, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 183,
+    "fields": { "variant": 379, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 184,
+    "fields": { "variant": 380, "assignment": 13 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 185,
+    "fields": { "variant": 389, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 186,
+    "fields": { "variant": 390, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 187,
+    "fields": { "variant": 394, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 188,
+    "fields": { "variant": 395, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 189,
+    "fields": { "variant": 396, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 190,
+    "fields": { "variant": 397, "assignment": 15 }
+  },
+  {
+    "model": "attribute.assignedvariantattribute",
+    "pk": 191,
+    "fields": { "variant": 398, "assignment": 15 }
+  },
+  {
+    "model": "attribute.attributevariant",
+    "pk": 13,
+    "fields": {
+      "sort_order": 0,
+      "attribute": 42,
+      "product_type": 17,
+      "variant_selection": true
+    }
+  },
+  {
+    "model": "attribute.attributevariant",
+    "pk": 14,
+    "fields": {
+      "sort_order": 0,
+      "attribute": 37,
+      "product_type": 18,
+      "variant_selection": true
+    }
+  },
+  {
+    "model": "attribute.attributevariant",
+    "pk": 15,
+    "fields": {
+      "sort_order": 0,
+      "attribute": 38,
+      "product_type": 20,
+      "variant_selection": true
+    }
+  },
+  {
+    "model": "channel.channel",
+    "pk": 1,
+    "fields": {
+      "name": "Channel-USD",
+      "is_active": true,
+      "slug": "default-channel",
+      "currency_code": "USD",
+      "default_country": "US"
+    }
+  },
+  {
+    "model": "channel.channel",
+    "pk": 2,
+    "fields": {
+      "name": "Channel-PLN",
+      "is_active": true,
+      "slug": "channel-pln",
+      "currency_code": "PLN",
+      "default_country": "PL"
+    }
+  },
+  {
+    "model": "menu.menu",
+    "pk": 1,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "navbar",
+      "slug": "navbar"
+    }
+  },
+  {
+    "model": "menu.menu",
+    "pk": 2,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "footer",
+      "slug": "footer"
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 220,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 2,
+      "name": "Saleor",
+      "parent": null,
+      "url": "/",
+      "category": null,
+      "collection": null,
+      "page": null,
+      "lft": 1,
+      "rght": 8,
+      "tree_id": 55,
+      "level": 0
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 222,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 2,
+      "name": "GraphQL API",
+      "parent": 220,
+      "url": "http://localhost:8000/graphql/",
+      "category": null,
+      "collection": null,
+      "page": null,
+      "lft": 4,
+      "rght": 5,
+      "tree_id": 55,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 223,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Accessories",
+      "parent": null,
+      "url": null,
+      "category": 25,
+      "collection": null,
+      "page": null,
+      "lft": 1,
+      "rght": 8,
+      "tree_id": 56,
+      "level": 0
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 224,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Audiobooks",
+      "parent": 223,
+      "url": null,
+      "category": 26,
+      "collection": null,
+      "page": null,
+      "lft": 2,
+      "rght": 3,
+      "tree_id": 56,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 225,
+    "fields": {
+      "sort_order": 0,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Apparel",
+      "parent": null,
+      "url": null,
+      "category": 27,
+      "collection": null,
+      "page": null,
+      "lft": 1,
+      "rght": 28,
+      "tree_id": 57,
+      "level": 0
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 226,
+    "fields": {
+      "sort_order": 3,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Sneakers",
+      "parent": 225,
+      "url": null,
+      "category": 28,
+      "collection": null,
+      "page": null,
+      "lft": 2,
+      "rght": 3,
+      "tree_id": 57,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 227,
+    "fields": {
+      "sort_order": 4,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Sweatshirts",
+      "parent": 225,
+      "url": null,
+      "category": 29,
+      "collection": null,
+      "page": null,
+      "lft": 4,
+      "rght": 5,
+      "tree_id": 57,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 232,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Headware",
+      "parent": 225,
+      "url": null,
+      "category": 33,
+      "collection": null,
+      "page": null,
+      "lft": 14,
+      "rght": 21,
+      "tree_id": 57,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 233,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Beanies",
+      "parent": 232,
+      "url": null,
+      "category": 35,
+      "collection": null,
+      "page": null,
+      "lft": 19,
+      "rght": 20,
+      "tree_id": 57,
+      "level": 2
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 234,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Scarfs",
+      "parent": 232,
+      "url": null,
+      "category": 36,
+      "collection": null,
+      "page": null,
+      "lft": 17,
+      "rght": 18,
+      "tree_id": 57,
+      "level": 2
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 235,
+    "fields": {
+      "sort_order": 3,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Sunglasses",
+      "parent": 232,
+      "url": null,
+      "category": 37,
+      "collection": null,
+      "page": null,
+      "lft": 15,
+      "rght": 16,
+      "tree_id": 57,
+      "level": 2
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 236,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "T-shirts",
+      "parent": 238,
+      "url": null,
+      "category": 39,
+      "collection": null,
+      "page": null,
+      "lft": 25,
+      "rght": 26,
+      "tree_id": 57,
+      "level": 2
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 237,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Polo shirts",
+      "parent": 238,
+      "url": null,
+      "category": 40,
+      "collection": null,
+      "page": null,
+      "lft": 23,
+      "rght": 24,
+      "tree_id": 57,
+      "level": 2
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 238,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Shirts",
+      "parent": 225,
+      "url": null,
+      "category": 38,
+      "collection": null,
+      "page": null,
+      "lft": 22,
+      "rght": 27,
+      "tree_id": 57,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 239,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 2,
+      "name": "About",
+      "parent": 220,
+      "url": null,
+      "category": null,
+      "collection": null,
+      "page": 3,
+      "lft": 6,
+      "rght": 7,
+      "tree_id": 55,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 240,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Homewares",
+      "parent": 223,
+      "url": null,
+      "category": 41,
+      "collection": null,
+      "page": null,
+      "lft": 4,
+      "rght": 5,
+      "tree_id": 56,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 241,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Groceries",
+      "parent": null,
+      "url": null,
+      "category": 42,
+      "collection": null,
+      "page": null,
+      "lft": 1,
+      "rght": 4,
+      "tree_id": 58,
+      "level": 0
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 242,
+    "fields": {
+      "sort_order": null,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Juices",
+      "parent": 241,
+      "url": null,
+      "category": 43,
+      "collection": null,
+      "page": null,
+      "lft": 2,
+      "rght": 3,
+      "tree_id": 58,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 243,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 2,
+      "name": "Collections",
+      "parent": null,
+      "url": null,
+      "category": null,
+      "collection": 4,
+      "page": null,
+      "lft": 1,
+      "rght": 6,
+      "tree_id": 59,
+      "level": 0
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 244,
+    "fields": {
+      "sort_order": 1,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 2,
+      "name": "Featured Products",
+      "parent": 243,
+      "url": null,
+      "category": null,
+      "collection": 4,
+      "page": null,
+      "lft": 2,
+      "rght": 3,
+      "tree_id": 59,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 245,
+    "fields": {
+      "sort_order": 2,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 2,
+      "name": "Summer Picks",
+      "parent": 243,
+      "url": null,
+      "category": null,
+      "collection": 5,
+      "page": null,
+      "lft": 4,
+      "rght": 5,
+      "tree_id": 59,
+      "level": 1
+    }
+  },
+  {
+    "model": "menu.menuitem",
+    "pk": 246,
+    "fields": {
+      "sort_order": 3,
+      "private_metadata": {},
+      "metadata": {},
+      "menu": 1,
+      "name": "Gift cards",
+      "parent": 223,
+      "url": null,
+      "category": 44,
+      "collection": null,
+      "page": null,
+      "lft": 6,
+      "rght": 7,
+      "tree_id": 56,
+      "level": 1
+    }
+  },
+  {
+    "model": "shipping.shippingzone",
+    "pk": 26,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Default shipping zone",
+      "countries": "US,CA,BR,AR,MX,UY,CL,PE,VE",
+      "default": false,
+      "description": "",
+      "channels": [1]
+    }
+  },
+  {
+    "model": "shipping.shippingmethod",
+    "pk": 267,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Default shipping rate",
+      "type": "price",
+      "shipping_zone": 26,
+      "minimum_order_weight": "0.0:g",
+      "maximum_order_weight": null,
+      "maximum_delivery_days": null,
+      "minimum_delivery_days": null,
+      "description": null,
+      "excluded_products": []
+    }
+  },
+  {
+    "model": "shipping.shippingmethodchannellisting",
+    "pk": 533,
+    "fields": {
+      "shipping_method": 267,
+      "channel": 1,
+      "minimum_order_price_amount": "0.000",
+      "currency": "USD",
+      "maximum_order_price_amount": "200.000",
+      "price_amount": "71.400"
+    }
+  },
+  {
+    "model": "site.sitesettings",
+    "pk": 1,
+    "fields": {
+      "site": 1,
+      "header_text": "Test Saleor - a sample shop!",
+      "description": "",
+      "top_menu": 1,
+      "bottom_menu": 2,
+      "include_taxes_in_prices": true,
+      "display_gross_prices": true,
+      "charge_taxes_on_shipping": true,
+      "track_inventory_by_default": true,
+      "default_weight_unit": "kg",
+      "automatic_fulfillment_digital_products": false,
+      "default_digital_max_downloads": null,
+      "default_digital_url_valid_days": null,
+      "company_address": null,
+      "default_mail_sender_name": "",
+      "default_mail_sender_address": null,
+      "customer_set_password_url": null,
+      "automatically_confirm_all_new_orders": true,
+      "fulfillment_auto_approve": true,
+      "fulfillment_allow_unpaid": true,
+      "reserve_stock_duration_anonymous_user": null,
+      "reserve_stock_duration_authenticated_user": null,
+      "limit_quantity_per_checkout": 50,
+      "gift_card_expiry_type": "never_expire",
+      "gift_card_expiry_period_type": null,
+      "gift_card_expiry_period": null,
+      "automatically_fulfill_non_shippable_gift_card": true
+    }
+  },
+  {
+    "model": "page.page",
+    "pk": 3,
+    "fields": {
+      "published_at": "2022-05-13T00:00:00Z",
+      "is_published": true,
+      "private_metadata": {},
+      "metadata": {},
+      "seo_title": "",
+      "seo_description": "",
+      "slug": "about",
+      "title": "About",
+      "page_type": 4,
+      "content": {
+        "time": 1652791943847,
+        "blocks": [
+          {
+            "id": "1rqw8KEYBR",
+            "data": {
+              "text": "1 Saleor is a rapidly growing all-out commerce API. Saleor is <b>fully open-source, and 100% focused on the GraphQL</b>&nbsp;interface. Our mission is to provide unparalleled extensibility."
+            },
+            "type": "paragraph"
+          },
+          {
+            "id": "Is0DQGyb93",
+            "data": {
+              "text": "2 We make it easy for front-end teams to <b>prototype fast, experiment, and build wonderful, unrestricted storefront experiences</b>."
+            },
+            "type": "paragraph"
+          },
+          {
+            "id": "IwwtFzGF2A",
+            "data": {
+              "text": "3 We enable developers to <a href=\"https://docs.saleor.io/docs/3.x/developer/extending/apps/key-concepts\">extend Saleor</a> easily via [Saleor Apps](https://github.com/saleor/saleor-app-template), a robust tally of async/sync webhooks, and a composable Dashboard. "
+            },
+            "type": "paragraph"
+          },
+          {
+            "id": "lJNRLN33D3",
+            "data": {
+              "text": "4 We allow brands to own their data and go fast while staying fully flexible with <a href=\"https://cloud.saleor.io\">Saleor Cloud</a>."
+            },
+            "type": "paragraph"
+          }
+        ],
+        "version": "2.22.2"
+      },
+      "created_at": "2022-05-13T16:45:57.101Z"
+    }
+  },
+  {
+    "model": "page.pagetype",
+    "pk": 4,
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Simple",
+      "slug": "default-page"
+    }
+  },
+  {
+    "model": "warehouse.warehouse",
+    "pk": "43bea6af-8cea-40cd-9760-cab77416f207",
+    "fields": {
+      "private_metadata": {},
+      "metadata": {},
+      "name": "Global",
+      "slug": "global",
+      "address": 470,
+      "email": "",
+      "click_and_collect_option": "disabled",
+      "is_private": true,
+      "shipping_zones": [26]
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3961,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 324,
+      "quantity": 4560,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3962,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 325,
+      "quantity": 500,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3963,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 326,
+      "quantity": 500,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3964,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 327,
+      "quantity": 500,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3965,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 328,
+      "quantity": 500,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3966,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 329,
+      "quantity": 500,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3967,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 330,
+      "quantity": 500,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3968,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 331,
+      "quantity": 500,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3969,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 332,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3970,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 333,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3971,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 334,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3972,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 335,
+      "quantity": 300,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3973,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 336,
+      "quantity": 300,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3974,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 337,
+      "quantity": 300,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3975,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 338,
+      "quantity": 300,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3976,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 339,
+      "quantity": 300,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3977,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 340,
+      "quantity": 400,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3978,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 341,
+      "quantity": 400,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3979,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 342,
+      "quantity": 400,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3980,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 343,
+      "quantity": 400,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3981,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 344,
+      "quantity": 400,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3982,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 348,
+      "quantity": 200,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3983,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 349,
+      "quantity": 200,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3984,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 350,
+      "quantity": 200,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3985,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 351,
+      "quantity": 200,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3986,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 352,
+      "quantity": 200,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3987,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 353,
+      "quantity": 400,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3988,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 354,
+      "quantity": 400,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3989,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 355,
+      "quantity": 400,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3990,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 356,
+      "quantity": 400,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3991,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 357,
+      "quantity": 400,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3992,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 358,
+      "quantity": 800,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3993,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 359,
+      "quantity": 800,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3994,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 360,
+      "quantity": 800,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3995,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 361,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3996,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 362,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3997,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 363,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3998,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 364,
+      "quantity": 695,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 3999,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 365,
+      "quantity": 695,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4000,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 366,
+      "quantity": 695,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4002,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 372,
+      "quantity": 500,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4003,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 373,
+      "quantity": 700,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4004,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 374,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4005,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 375,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4006,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 376,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4007,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 377,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4008,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 378,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4009,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 379,
+      "quantity": 0,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4010,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 380,
+      "quantity": 0,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4011,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 389,
+      "quantity": 994,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4012,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 390,
+      "quantity": 994,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4013,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 394,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4014,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 395,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4015,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 396,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4016,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 397,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  },
+  {
+    "model": "warehouse.stock",
+    "pk": 4017,
+    "fields": {
+      "warehouse": "43bea6af-8cea-40cd-9760-cab77416f207",
+      "product_variant": 398,
+      "quantity": 1000,
+      "quantity_allocated": 0
+    }
+  }
+]

--- a/saleor/tax/calculations/order.py
+++ b/saleor/tax/calculations/order.py
@@ -87,6 +87,7 @@ def _set_order_totals(
         order.total = quantize_price(default_value, currency)
         order.undiscounted_total = quantize_price(default_value, currency)
         order.subtotal = quantize_price(default_value, currency)
+        order.undiscounted_subtotal = quantize_price(default_value, currency)
         return
 
     subtotal = zero_taxed_money(currency)
@@ -106,6 +107,7 @@ def _set_order_totals(
     order.total = quantize_price(subtotal + order.shipping_price, currency)
     order.undiscounted_total = quantize_price(undiscounted_total, currency)
     order.subtotal = quantize_price(subtotal, currency)
+    order.undiscounted_subtotal = quantize_price(undiscounted_subtotal, currency)
 
 
 def _calculate_order_shipping(


### PR DESCRIPTION
Sum of each order line's undiscounted total price, excluding shipping.

It helps assessing the total lines undiscounted vs discounted value.

# Impact

- [x] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

- [ ] Link to documentation: TBD

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
