### PR TITLE
Refactor CheckoutInfo, CheckoutLineInfo & ShippingMethodData __repr__

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -111,6 +111,19 @@ class CheckoutLineInfo(LineInfo):
             return self.variant.get_prior_price_amount(self.channel_listing)
         return self.line.prior_unit_price_amount
 
+    def __repr__(self) -> str:
+        discounts_listed = (
+            [discount.id for discount in self.discounts] if self.discounts else []
+        )
+        return (
+            "<CheckoutLineInfo: "
+            f"line_id={self.line.id}, "
+            f"product_name={self.product.name}, "
+            f"variant={self.variant}, "
+            f"quantity={self.line.quantity}, "
+            f"discount={discounts_listed}>"
+        )
+
 
 @dataclass
 class CheckoutInfo:

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -179,6 +179,20 @@ class CheckoutInfo:
             return self.user.email
         return None
 
+    def __repr__(self) -> str:
+        discounts_listed = (
+            [discount.id for discount in self.discounts] if self.discounts else []
+        )
+        line_ids = [line.line.id for line in self.lines]
+        return (
+            "<CheckoutInfo: "
+            f"token={self.checkout.token}, "
+            f"user_id={self.user.id if self.user else None}, "
+            f"channel_slug={self.channel.slug}, "
+            f"discounts={discounts_listed}, "
+            f"line_ids={line_ids}>"
+        )
+
 
 def fetch_checkout_lines(
     checkout: "Checkout",

--- a/saleor/checkout/tests/test_checkout_repr.py
+++ b/saleor/checkout/tests/test_checkout_repr.py
@@ -1,0 +1,33 @@
+def test_checkout_line_info_repr(checkout_lines_info):
+    line_info = checkout_lines_info[0]
+    line_repr = repr(line_info)
+
+    discounts_listed = (
+        [discount.id for discount in line_info.discounts] if line_info.discounts else []
+    )
+
+    assert f"line_id={line_info.line.id}" in line_repr
+    assert f"product_name={line_info.product.name}" in line_repr
+    assert f"variant={line_info.variant}" in line_repr
+    assert f"quantity={line_info.line.quantity}" in line_repr
+    assert f"discount={discounts_listed}" in line_repr
+
+
+def test_checkout_info_repr(checkout_info):
+    checkout_repr = repr(checkout_info)
+
+    line_ids = [line.line.id for line in checkout_info.lines]
+    discounts_listed = (
+        [discount.id for discount in checkout_info.discounts]
+        if checkout_info.discounts
+        else []
+    )
+
+    assert f"token={checkout_info.checkout.token}" in checkout_repr
+    assert (
+        f"user_id={checkout_info.user.id if checkout_info.user else None}"
+        in checkout_repr
+    )
+    assert f"channel_slug={checkout_info.channel.slug}" in checkout_repr
+    assert f"discounts={discounts_listed}" in checkout_repr
+    assert f"line_ids={line_ids}" in checkout_repr

--- a/saleor/shipping/interface.py
+++ b/saleor/shipping/interface.py
@@ -52,6 +52,15 @@ class ShippingMethodData:
             return self.id
         return graphene.Node.to_global_id("ShippingMethod", self.id)
 
+    def __repr__(self) -> str:
+        return (
+            "<ShippingMethodData: "
+            f"id={self.id}, "
+            f"is_external={self.is_external}, "
+            f"type={self.type}, "
+            f"price={self.price}>"
+        )
+
 
 @dataclass
 class ExcludedShippingMethod:

--- a/saleor/shipping/tests/test_shipping_repr.py
+++ b/saleor/shipping/tests/test_shipping_repr.py
@@ -1,0 +1,7 @@
+def test_shipping_method_data_repr(shipping_method_data):
+    shipping_repr = repr(shipping_method_data)
+
+    assert f"id={shipping_method_data.id}" in shipping_repr
+    assert f"is_external={shipping_method_data.is_external}" in shipping_repr
+    assert f"type={shipping_method_data.type}" in shipping_repr
+    assert f"price={shipping_method_data.price}" in shipping_repr


### PR DESCRIPTION
I want to merge this change because it reduces the amount of data in the `__repr__` of the `CheckoutInfo`, `CheckoutLineInfo` and `ShippingMethodData` dataclasses.
This leads to better Sentry error logging and makes logs more readable while still showing relevant data.

Closes #15123

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

- [ ] Link to documentation: Not required, internal changes only

# Pull Request Checklist

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
