### PR TITLE
Allow to CRUD public metadata for STAFF by APPs

### DIFF
--- a/saleor/graphql/meta/mutations/base.py
+++ b/saleor/graphql/meta/mutations/base.py
@@ -20,7 +20,6 @@ from ...core.context import BaseContext, ChannelContext, SyncWebhookControlConte
 from ...core.mutations import BaseMutation
 from ...core.utils import from_global_id_or_error
 from ..extra_methods import TYPE_EXTRA_METHODS
-from ..permissions import AccountPermissions
 from ..types import ObjectWithMetadata
 from .utils import get_valid_metadata_instance
 
@@ -151,15 +150,6 @@ class BaseMetadataMutation(BaseMutation):
             return graphene_type.get_model()
 
         return graphene_type._meta.model
-
-    @classmethod
-    def check_permissions(cls, context, permissions=None, **data):  # type: ignore[override]
-        is_app = bool(getattr(context, "app", None))
-        if is_app and permissions and AccountPermissions.MANAGE_STAFF in permissions:
-            raise PermissionDenied(
-                message="Apps are not allowed to perform this mutation."
-            )
-        return super().check_permissions(context, permissions)
 
     @classmethod
     @allow_writer()

--- a/saleor/graphql/meta/mutations/delete_private_metadata.py
+++ b/saleor/graphql/meta/mutations/delete_private_metadata.py
@@ -1,5 +1,7 @@
 import graphene
 
+from ....core.exceptions import PermissionDenied
+from ....permission.enums import AccountPermissions
 from ...core import ResolveInfo
 from ...core.types import MetadataError, NonNullList
 from ..permissions import PRIVATE_META_PERMISSION_MAP
@@ -27,6 +29,15 @@ class DeletePrivateMetadata(BaseMetadataMutation):
             description="Metadata keys to delete.",
             required=True,
         )
+
+    @classmethod
+    def check_permissions(cls, context, permissions=None, **data):  # type: ignore[override]
+        is_app = bool(getattr(context, "app", None))
+        if is_app and permissions and AccountPermissions.MANAGE_STAFF in permissions:
+            raise PermissionDenied(
+                message="Apps are not allowed to perform this mutation."
+            )
+        return super().check_permissions(context, permissions)
 
     @classmethod
     def perform_mutation(  # type: ignore[override]

--- a/saleor/graphql/meta/mutations/update_private_metadata.py
+++ b/saleor/graphql/meta/mutations/update_private_metadata.py
@@ -1,5 +1,7 @@
 import graphene
 
+from ....core.exceptions import PermissionDenied
+from ....permission.enums import AccountPermissions
 from ...core import ResolveInfo
 from ...core.types import MetadataError, NonNullList
 from ..inputs import MetadataInput, MetadataInputDescription
@@ -28,6 +30,15 @@ class UpdatePrivateMetadata(BaseMetadataMutation):
             description="Fields required to update the object's metadata.",
             required=True,
         )
+
+    @classmethod
+    def check_permissions(cls, context, permissions=None, **data):  # type: ignore[override]
+        is_app = bool(getattr(context, "app", None))
+        if is_app and permissions and AccountPermissions.MANAGE_STAFF in permissions:
+            raise PermissionDenied(
+                message="Apps are not allowed to perform this mutation."
+            )
+        return super().check_permissions(context, permissions)
 
     @classmethod
     def perform_mutation(cls, _root, info: ResolveInfo, /, **data):

--- a/saleor/graphql/meta/tests/mutations/test_account.py
+++ b/saleor/graphql/meta/tests/mutations/test_account.py
@@ -16,7 +16,6 @@ from . import (
     PUBLIC_VALUE2,
 )
 from .test_delete_metadata import (
-    DELETE_PUBLIC_METADATA_MUTATION,
     execute_clear_public_metadata_for_item,
     execute_clear_public_metadata_for_multiple_items,
     item_without_multiple_public_metadata,
@@ -132,20 +131,17 @@ def test_delete_public_metadata_for_staff_address_as_app(
     staff_user.addresses.add(address)
     address.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
     address.save(update_fields=["metadata"])
-    variables = {
-        "id": graphene.Node.to_global_id("Address", address.pk),
-        "keys": [PUBLIC_KEY],
-    }
+    address_id = graphene.Node.to_global_id("Address", address.pk)
 
     # when
-    response = app_api_client.post_graphql(
-        DELETE_PUBLIC_METADATA_MUTATION % "Address",
-        variables,
-        permissions=[permission_manage_staff],
+    response = execute_clear_public_metadata_for_item(
+        app_api_client, permission_manage_staff, address_id, "Address"
     )
 
     # then
-    assert_no_permission(response)
+    assert item_without_public_metadata(
+        response["data"]["deleteMetadata"]["item"], address, address_id
+    )
 
 
 def test_delete_public_metadata_for_myself_address(staff_api_client, address):
@@ -516,27 +512,23 @@ def test_delete_public_metadata_for_other_staff_as_staff(
     assert admin_user.updated_at > old_updated_at
 
 
-def test_delete_public_metadata_for_staff_as_app_no_permission(
+def test_delete_public_metadata_for_staff_as_app(
     app_api_client, permission_manage_staff, admin_user
 ):
     # given
     admin_user.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
     admin_user.save(update_fields=["metadata"])
     admin_id = graphene.Node.to_global_id("User", admin_user.pk)
-    variables = {
-        "id": admin_id,
-        "keys": [PRIVATE_KEY],
-    }
 
     # when
-    response = app_api_client.post_graphql(
-        DELETE_PUBLIC_METADATA_MUTATION % "User",
-        variables,
-        permissions=[permission_manage_staff],
+    response = execute_clear_public_metadata_for_item(
+        app_api_client, permission_manage_staff, admin_id, "User"
     )
 
     # then
-    assert_no_permission(response)
+    assert item_without_public_metadata(
+        response["data"]["deleteMetadata"]["item"], admin_user, admin_id
+    )
 
 
 def test_delete_public_metadata_for_myself_as_customer(user_api_client):
@@ -973,20 +965,15 @@ def test_update_public_metadata_for_staff_address_by_app_with_perm(
     staff_user.addresses.add(address)
     address_id = graphene.Node.to_global_id("Address", address.pk)
 
-    variables = {
-        "id": address_id,
-        "input": [{"key": PUBLIC_KEY, "value": "NewMetaValue"}],
-    }
-
     # when
-    response = app_api_client.post_graphql(
-        UPDATE_PUBLIC_METADATA_MUTATION % "Address",
-        variables,
-        permissions=[permission_manage_staff],
+    response = execute_update_public_metadata_for_item(
+        app_api_client, permission_manage_staff, address_id, "Address"
     )
 
     # then
-    assert_no_permission(response)
+    assert item_contains_proper_public_metadata(
+        response["data"]["updateMetadata"]["item"], address, address_id
+    )
 
 
 def test_update_public_metadata_for_staff_address_by_app_without_perm(
@@ -1293,26 +1280,21 @@ def test_add_private_metadata_for_other_staff_as_staff(
     )
 
 
-def test_add_public_metadata_for_staff_as_app_no_permission(
+def test_add_public_metadata_for_staff_as_app(
     app_api_client, permission_manage_staff, admin_user
 ):
     # given
     admin_id = graphene.Node.to_global_id("User", admin_user.pk)
-    variables = {
-        "id": admin_id,
-        "input": [{"key": PUBLIC_KEY, "value": PUBLIC_VALUE}],
-    }
 
     # when
-
-    response = app_api_client.post_graphql(
-        UPDATE_PRIVATE_METADATA_MUTATION % "User",
-        variables,
-        permissions=[permission_manage_staff],
+    response = execute_update_public_metadata_for_item(
+        app_api_client, permission_manage_staff, admin_id, "User"
     )
 
     # then
-    assert_no_permission(response)
+    assert item_contains_proper_public_metadata(
+        response["data"]["updateMetadata"]["item"], admin_user, admin_id
+    )
 
 
 def test_add_private_metadata_for_staff_as_app_no_permission(


### PR DESCRIPTION
Similar to other entities, public metadata should not be protected. Previously we had a protection that App's can't do metadata update even if MANAGE_STAFF permission is attached. This stays true to private metadata, but public metadata check was removed.

This enables automations that require apps to persist state on staff users