### PR TITLE
feat(graphql): mark slow spans as errored

### DIFF
--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -7,14 +7,17 @@ import pytest
 from django.test import override_settings
 from freezegun import freeze_time
 from graphql.execution.base import ExecutionResult
-from opentelemetry.trace import StatusCode
+from opentracing.mocktracer import MockTracer
 
 from .... import __version__ as saleor_version
 from ....graphql.api import backend, schema
 from ....graphql.utils import INTERNAL_ERROR_MESSAGE
-from ....tests.utils import get_span_by_name
 from ...tests.fixtures import API_PATH
-from ...tests.utils import get_graphql_content, get_graphql_content_from_response
+from ...tests.utils import (
+    get_first_span_by_tag,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 from ...views import GraphQLView, generate_cache_key
 
 
@@ -433,7 +436,11 @@ def test_graphql_view_clears_context(rf, staff_user, product, channel_USD):
     assert request.dataloaders == {}
 
 
-def test_marks_slow_queries(rf, get_test_spans):
+@mock.patch("saleor.graphql.views.opentracing.global_tracer")
+def test_marks_slow_queries(tracing_mock, rf):
+    tracer = MockTracer()
+    tracing_mock.return_value = tracer
+
     request = rf.post(
         path="/graphql/",
         data={"query": "{__typename}"},
@@ -454,16 +461,18 @@ def test_marks_slow_queries(rf, get_test_spans):
             frozen_time.tick(delta=31.0)
             return original_handle_query(*args, **kwargs)
 
-        with patch.object(
+        with mock.patch.object(
             view, "_handle_query", wraps=_inner_handle_query
         ) as mocked_handle_query:
             view.handle_query(request)
 
     # Sanity check: should have ticked the time
     mocked_handle_query.assert_called_once()
-    span = get_span_by_name(get_test_spans(), "/graphql/")
+    span = get_first_span_by_tag(tracer.finished_spans(), "resource.name", "/graphql/")
 
-    assert span.status.status_code == StatusCode.ERROR
-    assert (
-        span.status.description == "Slow request. Exceeded time limit of 30.0 seconds."
-    )
+    assert span.tags["error"] is True
+    assert len(span.logs) == 1
+    assert span.logs[0].key_values == {
+        "event": "error",
+        "message": "Slow request. Exceeded time limit of 30.0 seconds.",
+    }

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -5,11 +5,14 @@ from unittest import mock
 import graphene
 import pytest
 from django.test import override_settings
+from freezegun import freeze_time
 from graphql.execution.base import ExecutionResult
+from opentelemetry.trace import StatusCode
 
 from .... import __version__ as saleor_version
 from ....graphql.api import backend, schema
 from ....graphql.utils import INTERNAL_ERROR_MESSAGE
+from ....tests.utils import get_span_by_name
 from ...tests.fixtures import API_PATH
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
 from ...views import GraphQLView, generate_cache_key
@@ -428,3 +431,39 @@ def test_graphql_view_clears_context(rf, staff_user, product, channel_USD):
     assert json_data["data"]["product"]["category"]["name"] == product.category.name
     assert response.status_code == 200
     assert request.dataloaders == {}
+
+
+def test_marks_slow_queries(rf, get_test_spans):
+    request = rf.post(
+        path="/graphql/",
+        data={"query": "{__typename}"},
+        content_type="application/json",
+    )
+    view = GraphQLView(backend=backend, schema=schema)
+
+    with freeze_time("2025-10-13 12:00:00") as frozen_time:
+        original_handle_query = view._handle_query
+
+        def _inner_handle_query(*args, **kwargs):
+            """Artificially increases the current time by 31 seconds.
+
+            Executes once the GraphQL query is executed so that it
+            is incremented in the middle of the HTTP request (rather than
+            too soon or too late as otherwise it will not measure the duration properly).
+            """
+            frozen_time.tick(delta=31.0)
+            return original_handle_query(*args, **kwargs)
+
+        with patch.object(
+            view, "_handle_query", wraps=_inner_handle_query
+        ) as mocked_handle_query:
+            view.handle_query(request)
+
+    # Sanity check: should have ticked the time
+    mocked_handle_query.assert_called_once()
+    span = get_span_by_name(get_test_spans(), "/graphql/")
+
+    assert span.status.status_code == StatusCode.ERROR
+    assert (
+        span.status.description == "Slow request. Exceeded time limit of 30.0 seconds."
+    )

--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -5,13 +5,7 @@ import graphene
 import pytest
 from opentracing.mocktracer import MockTracer
 
-
-def _get_graphql_span(spans):
-    return next(_get_graphql_spans(spans))
-
-
-def _get_graphql_spans(spans):
-    return filter(lambda item: item.tags.get("graphql.query_fingerprint"), spans)
+from .utils import get_graphql_span, get_graphql_spans
 
 
 @patch("saleor.graphql.views.opentracing.global_tracer")
@@ -39,7 +33,7 @@ def test_tracing_query_hashing(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     hash = hashlib.md5(span.tags["graphql.query"].encode("utf-8")).hexdigest()
@@ -77,7 +71,7 @@ def test_tracing_query_hashing_with_fragment(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     hash = hashlib.md5(span.tags["graphql.query"].encode("utf-8")).hexdigest()
@@ -116,7 +110,7 @@ def test_tracing_query_hashing_different_vars_same_checksum(
     fingerprints = list(
         map(
             lambda span: span.tags["graphql.query_fingerprint"],
-            _get_graphql_spans(tracer.finished_spans()),
+            get_graphql_spans(tracer.finished_spans()),
         )
     )
     assert len(fingerprints) == QUERIES
@@ -148,7 +142,7 @@ def test_tracing_query_hashing_unnamed_query(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     hash = hashlib.md5(span.tags["graphql.query"].encode("utf-8")).hexdigest()
@@ -180,7 +174,7 @@ def test_tracing_query_hashing_unnamed_query_no_query_spec(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     hash = hashlib.md5(span.tags["graphql.query"].encode("utf-8")).hexdigest()
@@ -218,7 +212,7 @@ def test_tracing_mutation_hashing(
     staff_api_client.post_graphql(
         mutation, variables, permissions=[permission_manage_orders]
     )
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     hash = hashlib.md5(span.tags["graphql.query"].encode("utf-8")).hexdigest()
@@ -257,7 +251,7 @@ def test_tracing_query_identifier_for_query(
     """
     staff_api_client.user.user_permissions.add(permission_manage_products)
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
     assert span.tags["graphql.query_identifier"] == "me, products"
 
 
@@ -291,7 +285,7 @@ def test_tracing_query_identifier_with_fragment(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     assert span.tags["graphql.query_identifier"] == "products"
@@ -315,7 +309,7 @@ def test_tracing_query_identifier_for_unnamed_mutation(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     assert span.tags["graphql.query_identifier"] == "tokenCreate"
@@ -339,7 +333,7 @@ def test_tracing_query_identifier_for_named_mutation(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     assert span.tags["graphql.query_identifier"] == "tokenCreate"
@@ -370,7 +364,7 @@ def test_tracing_query_identifier_for_many_mutations(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     assert span.tags["graphql.query_identifier"] == "deleteWarehouse, tokenCreate"
@@ -394,7 +388,7 @@ def test_tracing_query_identifier_undefined(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     assert span.tags["graphql.query_identifier"] == "undefined"
@@ -425,7 +419,7 @@ def test_tracing_dont_have_app_data_staff_as_requestor(
 
     # when
     staff_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     assert "app.name" not in span.tags
@@ -458,7 +452,7 @@ def test_tracing_have_app_data_app_as_requestor(
 
     # when
     app_api_client.post_graphql(query)
-    span = _get_graphql_span(tracer.finished_spans())
+    span = get_graphql_span(tracer.finished_spans())
 
     # then
     assert span.tags["app.name"] == app.name

--- a/saleor/graphql/tests/utils.py
+++ b/saleor/graphql/tests/utils.py
@@ -70,3 +70,19 @@ def get_multipart_request_body_with_multiple_files(query, variables, files, map_
         "map": json.dumps(map_dict, cls=DjangoJSONEncoder),
         **{index: file for index, file in enumerate(files)},
     }
+
+
+def get_graphql_span(spans):
+    return next(get_graphql_spans(spans))
+
+
+def get_graphql_spans(spans):
+    return filter(lambda item: item.tags.get("graphql.query_fingerprint"), spans)
+
+
+def get_spans_by_tag(spans, tag_name: str, value: str):
+    return filter(lambda item: item.tags.get(tag_name) == value, spans)
+
+
+def get_first_span_by_tag(spans, tag_name: str, value: str):
+    return next(get_spans_by_tag(spans, tag_name, value))

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -1,6 +1,7 @@
 import hashlib
 import importlib
 import json
+import time
 from inspect import isclass
 from typing import Any, Optional, Union
 
@@ -181,6 +182,7 @@ class GraphQLView(View):
         # We should:
         # Add `from opentracing.propagation import Format` to imports
         # Add `child_of=span_ontext` to `start_active_span`
+        request_start_time = time.monotonic()
         with tracer.start_active_span("http") as scope:
             span = scope.span
             span.set_tag("resource.name", request.path)
@@ -223,6 +225,18 @@ class GraphQLView(View):
             with observability.report_api_call(request) as api_call:
                 api_call.response = response
                 api_call.report()
+
+            request_duration = time.monotonic() - request_start_time
+
+            if request_duration > settings.GRAPHQL_SPANS_MARK_SLOW_AFTER:
+                error_description = f"Slow request. Exceeded time limit of {settings.GRAPHQL_SPANS_MARK_SLOW_AFTER} seconds."
+                error = RuntimeError(error_description)
+                # We want to mark this span as an error to indicate that the user may
+                # have received an HTTP 504 or a poor experience. This increases the
+                # chance of the trace being retained as it is less likely to be dropped
+                # by sampling.
+                span.set_status(status=StatusCode.ERROR, description=error_description)
+                span.record_exception(error)
             return response
 
     def get_response(

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -230,13 +230,17 @@ class GraphQLView(View):
 
             if request_duration > settings.GRAPHQL_SPANS_MARK_SLOW_AFTER:
                 error_description = f"Slow request. Exceeded time limit of {settings.GRAPHQL_SPANS_MARK_SLOW_AFTER} seconds."
-                error = RuntimeError(error_description)
                 # We want to mark this span as an error to indicate that the user may
                 # have received an HTTP 504 or a poor experience. This increases the
                 # chance of the trace being retained as it is less likely to be dropped
                 # by sampling.
-                span.set_status(status=StatusCode.ERROR, description=error_description)
-                span.record_exception(error)
+                span.set_tag(opentracing.tags.ERROR, True)
+                span.log_kv(
+                    {
+                        "event": "error",
+                        "message": error_description,
+                    }
+                )
             return response
 
     def get_response(

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -791,6 +791,10 @@ def SENTRY_INIT(dsn: str, sentry_opts: dict):
     ignore_logger("graphql.execution.executor")
 
 
+# Number of seconds after which GraphQL requests will marked
+# as slow (error status)
+GRAPHQL_SPANS_MARK_SLOW_AFTER: float = 30.0
+
 GRAPHQL_PAGINATION_LIMIT = 100
 GRAPHQL_MIDDLEWARE: list[str] = []
 GRAPHQL_ALIAS_COUNT_LIMIT: int = int(os.environ.get("GRAPHQL_ALIAS_COUNT_LIMIT", 100))


### PR DESCRIPTION
Cherry-picks #19056 but adds support for legacy OpenTracing instead of OpenTelemetry

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
