### PR TITLE
fix(graphql): missing error handling when no channel in DB

### DIFF
--- a/saleor/graphql/account/tests/mutations/account/test_request_email_change.py
+++ b/saleor/graphql/account/tests/mutations/account/test_request_email_change.py
@@ -242,3 +242,23 @@ def test_request_email_change_send_event(
     account_change_email_requested_mock.assert_called_once_with(
         customer_user, channel_PLN.slug, "token", change_email_url, new_email
     )
+
+
+def test_request_email_change_but_no_channels_exist(user_api_client, customer_user):
+    """It should return an error when no channel exist in DB."""
+    variables = {
+        "password": "password",
+        "new_email": "new_email@example.com",
+        "redirect_url": "http://www.example.com",
+    }
+    response = user_api_client.post_graphql(REQUEST_EMAIL_CHANGE_QUERY, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["requestEmailChange"]
+    assert not data["user"]
+    assert data["errors"] == [
+        {
+            "code": "MISSING_CHANNEL_SLUG",
+            "message": "You need to provide channel slug.",
+            "field": "channel",
+        }
+    ]

--- a/saleor/graphql/channel/utils.py
+++ b/saleor/graphql/channel/utils.py
@@ -70,7 +70,7 @@ def clean_channel(
     else:
         try:
             channel = get_default_channel(allow_replica)
-        except ChannelNotDefined as e:
+        except (ChannelNotDefined, NoDefaultChannel) as e:
             raise ValidationError(
                 {
                     "channel": ValidationError(


### PR DESCRIPTION
This fixes a crash (HTTP 500) in mutations when no channel exists in DB. Affected mutations: `customerCreate`, `accountRequestDeletion`, `requestPasswordReset`, `accountRegister`, `confirmEmailChange`, `checkoutCreated`.

Should be ported to 3.20+

<i> Closes https://linear.app/saleor/issue/ENG-1432/ </i>

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
