### PR TITLE
Add missing mock to deferred payload test

### DIFF
--- a/saleor/webhook/tests/fixtures/webhook.py
+++ b/saleor/webhook/tests/fixtures/webhook.py
@@ -191,25 +191,25 @@ def setup_checkout_webhooks(
                 Webhook(
                     name="Tax webhook",
                     app=tax_app,
-                    target_url="http://127.0.0.1/test",
+                    target_url="http://tax.app/test",
                     subscription_query="subscription{ event{ ...on CalculateTaxes{ __typename } } }",
                 ),
                 Webhook(
                     name="Shipping webhook",
                     app=shipping_app,
-                    target_url="http://127.0.0.1/test",
+                    target_url="http://shipping.app/test",
                     subscription_query="subscription { event { ... on ShippingListMethodsForCheckout { __typename } } }",
                 ),
                 Webhook(
                     name="Shipping webhook",
                     app=shipping_app,
-                    target_url="http://127.0.0.1/test",
+                    target_url="http://shipping.app/test",
                     subscription_query="subscription { event { ... on CheckoutFilterShippingMethods { __typename } } }",
                 ),
                 Webhook(
                     name="Checkout additional webhook",
                     app=additional_app,
-                    target_url="http://127.0.0.1/test",
+                    target_url="http://checkout.app/test",
                     subscription_query=subscription_async_webhooks,
                 ),
             ]

--- a/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
@@ -81,11 +81,13 @@ def test_call_trigger_webhook_async_deferred_payload(
     assert delivery.webhook == checkout_updated_webhook
 
 
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
 @mock.patch(
     "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
 )
 def test_generate_deferred_payload(
     mocked_send_webhook_request_async,
+    mocked_send_sync_webhook,
     checkout_with_item,
     setup_checkout_webhooks,
     staff_user,
@@ -97,7 +99,9 @@ def test_generate_deferred_payload(
     deferred_request_time = datetime.datetime(2020, 10, 5, tzinfo=datetime.UTC)
 
     event_type = WebhookEventAsyncType.CHECKOUT_UPDATED
-    _, _, _, checkout_updated_webhook = setup_checkout_webhooks(event_type)
+    _, shipping_webhook, _, checkout_updated_webhook = setup_checkout_webhooks(
+        event_type
+    )
     deferred_payload_data = DeferredPayloadData(
         model_name="checkout.checkout",
         object_id=checkout.pk,
@@ -111,6 +115,8 @@ def test_generate_deferred_payload(
         status=EventDeliveryStatus.PENDING,
     )
     delivery.save()
+
+    mocked_send_sync_webhook.return_value = []
 
     # when
     generate_deferred_payloads.delay(
@@ -132,9 +138,13 @@ def test_generate_deferred_payload(
         data["checkout"]["totalPrice"]["gross"]["amount"] == checkout.total_gross_amount
     )
 
-    assert mocked_send_webhook_request_async.call_count == 1
     call_kwargs = mocked_send_webhook_request_async.call_args.kwargs
     assert call_kwargs["kwargs"]["event_delivery_id"] == delivery.pk
+
+    assert mocked_send_webhook_request_async.call_count == 1
+    shipping_methods_call = mocked_send_sync_webhook.mock_calls[0]
+    shipping_methods_delivery = shipping_methods_call.args[0]
+    assert shipping_methods_delivery.webhook_id == shipping_webhook.id
 
 
 @mock.patch(


### PR DESCRIPTION
I want to merge this change because the test triggers the webhook for fetching the shipping methods. As the 127.0.0.1 was used, we were missing that.
This PR changes the url for dummy webhooks, and also adds missing mock, to confirm that we triggered the sync webhook while building the payload.

Port of changes: #19071
<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
