### PR TITLE
fix(accounts): missing validations for accountRegister

### DIFF
--- a/saleor/graphql/account/mutations/account/account_register.py
+++ b/saleor/graphql/account/mutations/account/account_register.py
@@ -114,11 +114,8 @@ class AccountRegister(DeprecatedModelMutation):
             response.user.NEWLY_CREATED_USER = True
         return response
 
-    @classmethod
-    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
-        site = get_site_promise(info.context).get()
-        if not site.settings.enable_account_confirmation_by_email:
-            return super().clean_input(info, instance, data, **kwargs)
+    @staticmethod
+    def clean_redirect_url(data: dict) -> None:
         if not data.get("redirect_url"):
             raise ValidationError(
                 {
@@ -139,9 +136,16 @@ class AccountRegister(DeprecatedModelMutation):
                 }
             ) from e
 
-        data["channel"] = clean_channel(
-            data.get("channel"), error_class=AccountErrorCode, allow_replica=False
-        ).slug
+    @classmethod
+    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
+        site = get_site_promise(info.context).get()
+
+        if site.settings.enable_account_confirmation_by_email:
+            cls.clean_redirect_url(data)
+
+            data["channel"] = clean_channel(
+                data.get("channel"), error_class=AccountErrorCode, allow_replica=False
+            ).slug
 
         data["email"] = data["email"].lower()
 

--- a/saleor/graphql/account/tests/mutations/account/test_account_register.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_register.py
@@ -1,6 +1,7 @@
 from unittest.mock import ANY, patch
 from urllib.parse import urlencode
 
+import pytest
 from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
@@ -14,6 +15,7 @@ from ......core.notify import NotifyEventType
 from ......core.tests.utils import get_site_context_payload
 from ......core.tokens import token_generator
 from ......core.utils.url import prepare_url
+from ......settings import AUTH_PASSWORD_VALIDATORS
 from ......tests import race_condition
 from .....tests.utils import get_graphql_content
 
@@ -538,3 +540,52 @@ def test_customer_register_race_codition(
     mocked_finish_creating_user.delay.assert_called_once_with(
         None, redirect_url, channel_PLN.slug, ANY
     )
+
+
+@pytest.mark.parametrize(("enable_account_confirmation_by_email"), [True, False])
+def test_validates_password_length(
+    api_client,
+    site_settings,
+    enable_account_confirmation_by_email: bool,
+    channel_PLN,
+    settings,
+):
+    """Should validate password length even when account confirmation is disabled."""
+
+    settings.ALLOWED_CLIENT_HOSTS = ["localhost"]
+    settings.AUTH_PASSWORD_VALIDATORS = AUTH_PASSWORD_VALIDATORS  # production values
+
+    site_settings.enable_account_confirmation_by_email = (
+        enable_account_confirmation_by_email
+    )
+    site_settings.save(update_fields=["enable_account_confirmation_by_email"])
+
+    variables = {
+        "input": {
+            "email": "foo@example.com",
+            "password": "a",
+            "redirectUrl": "http://localhost:3000",
+            "firstName": "saleor",
+            "lastName": "rocks",
+            "languageCode": "PL",
+            "channel": channel_PLN.slug,
+        }
+    }
+
+    response = api_client.post_graphql(ACCOUNT_REGISTER_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["accountRegister"]
+    assert data == {
+        "errors": [
+            {
+                "code": "PASSWORD_TOO_SHORT",
+                "field": "password",
+                "message": (
+                    "This password is too short. It must contain at least 8 characters."
+                ),
+            },
+        ],
+        "user": None,
+    }


### PR DESCRIPTION
*Cherry-pick of #19070*

Whenever account confirmations were disabled, the following validations weren't running:

- Password was never validated
- Language code was never set
- Email was never normalized



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
