### PR TITLE
feat(devcontainer): allow accessing uvicorn via host

### DIFF
--- a/.devcontainer/backend.env
+++ b/.devcontainer/backend.env
@@ -6,3 +6,4 @@ CELERY_BROKER_URL=redis://cache:6379/1
 SECRET_KEY=changeme
 # Mailpit
 EMAIL_URL=smtp://mailpit:1025
+ALLOWED_HOSTS="localhost,127.0.0.1,host.docker.internal,host.containers.internal"


### PR DESCRIPTION
This tweaks the default `ALLOWED_HOSTS` to allow both `host.docker.internal` and `host.containers.internal` out of the box which is very handy in local development (when trying to make multiple containers inside different network talk to each other). As this is a development environment, this should be safe to enable this by default.



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
