### PR TITLE
Drop external shipping identifier from checkout metadata

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -41,6 +41,7 @@ from ..graphql.checkout.utils import (
     prepare_insufficient_stock_checkout_validation_error,
 )
 from ..order import OrderOrigin, OrderStatus
+from ..order import delivery_context as order_delivery_context
 from ..order.actions import order_created
 from ..order.fetch import OrderInfo, OrderLineInfo
 from ..order.models import Order, OrderLine
@@ -80,7 +81,6 @@ from .checkout_cleaner import (
     clean_checkout_payment,
     clean_checkout_shipping,
 )
-from .delivery_context import PRIVATE_META_APP_SHIPPING_ID
 from .fetch import (
     CheckoutInfo,
     CheckoutLineInfo,
@@ -219,7 +219,7 @@ def _process_shipping_data_for_order(
         # method.
         checkout_metadata = get_or_create_checkout_metadata(checkout_info.checkout)
         checkout_metadata.store_value_in_private_metadata(
-            {PRIVATE_META_APP_SHIPPING_ID: shipping_method.id}
+            {order_delivery_context.PRIVATE_META_APP_SHIPPING_ID: shipping_method.id}
         )
         checkout_metadata.save()
 

--- a/saleor/checkout/delivery_context.py
+++ b/saleor/checkout/delivery_context.py
@@ -37,9 +37,6 @@ if TYPE_CHECKING:
     from .fetch import CheckoutInfo, CheckoutLineInfo
 
 
-PRIVATE_META_APP_SHIPPING_ID = "external_app_shipping_id"
-
-
 @dataclass(frozen=True)
 class DeliveryMethodBase:
     delivery_method: Union["ShippingMethodData", "Warehouse"] | None = None
@@ -252,20 +249,6 @@ def get_valid_collection_points_for_checkout(
     )
 
 
-def _remove_external_shipping_from_metadata(checkout: Checkout):
-    from .utils import get_checkout_metadata
-
-    metadata = get_checkout_metadata(checkout)
-    if not metadata:
-        return
-
-    field_deleted = metadata.delete_value_from_private_metadata(
-        PRIVATE_META_APP_SHIPPING_ID
-    )
-    if field_deleted:
-        metadata.save(update_fields=["private_metadata"])
-
-
 def _remove_undiscounted_base_shipping_price(checkout: Checkout):
     if checkout.undiscounted_base_shipping_price_amount:
         checkout.undiscounted_base_shipping_price_amount = Decimal(0)
@@ -297,10 +280,6 @@ def assign_shipping_method_to_checkout(
     if checkout.assigned_delivery_id != checkout_delivery.id:
         checkout.assigned_delivery = checkout_delivery
         fields_to_update.append("assigned_delivery_id")
-
-    # make sure that we don't have obsolete data for shipping methods stored in
-    # private metadata
-    _remove_external_shipping_from_metadata(checkout=checkout)
 
     if checkout.shipping_method_name != checkout_delivery.name:
         checkout.shipping_method_name = checkout_delivery.name

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -13,7 +13,6 @@ from django.utils import timezone
 from .....account.models import Address
 from .....checkout import calculations
 from .....checkout.delivery_context import (
-    PRIVATE_META_APP_SHIPPING_ID,
     fetch_shipping_methods_for_checkout,
     get_or_fetch_checkout_deliveries,
 )
@@ -30,6 +29,7 @@ from .....discount.models import CheckoutLineDiscount, OrderLineDiscount, Promot
 from .....giftcard import GiftCardEvents
 from .....giftcard.models import GiftCard, GiftCardEvent
 from .....order import OrderOrigin, OrderStatus
+from .....order.delivery_context import PRIVATE_META_APP_SHIPPING_ID
 from .....order.models import Fulfillment, Order
 from .....payment import ChargeStatus, PaymentError, TransactionKind
 from .....payment.error_codes import PaymentErrorCode

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -15,7 +15,6 @@ from .....account.models import Address
 from .....channel import MarkAsPaidStrategy
 from .....checkout import calculations
 from .....checkout.delivery_context import (
-    PRIVATE_META_APP_SHIPPING_ID,
     fetch_shipping_methods_for_checkout,
     get_or_fetch_checkout_deliveries,
 )
@@ -38,6 +37,7 @@ from .....discount.models import (
 from .....giftcard import GiftCardEvents
 from .....giftcard.models import GiftCard, GiftCardEvent
 from .....order import OrderAuthorizeStatus, OrderChargeStatus, OrderOrigin, OrderStatus
+from .....order.delivery_context import PRIVATE_META_APP_SHIPPING_ID
 from .....order.models import Fulfillment, Order
 from .....payment import TransactionEventType
 from .....payment.model_helpers import get_subtotal

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -12,10 +12,7 @@ from promise import Promise
 from .....account.models import Address
 from .....checkout.actions import call_checkout_info_event
 from .....checkout.calculations import fetch_checkout_data
-from .....checkout.delivery_context import (
-    PRIVATE_META_APP_SHIPPING_ID,
-    get_or_fetch_checkout_deliveries,
-)
+from .....checkout.delivery_context import get_or_fetch_checkout_deliveries
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import (
     fetch_checkout_info,
@@ -215,65 +212,6 @@ def test_checkout_shipping_method_update_external_shipping_method(
     assert checkout.assigned_delivery.shipping_method_id == method_id
     assert checkout.undiscounted_base_shipping_price_amount == method_price
     assert checkout.shipping_method_name == method_name
-    assert (
-        PRIVATE_META_APP_SHIPPING_ID not in checkout.metadata_storage.private_metadata
-    )
-
-
-@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
-def test_checkout_shipping_method_update_deletes_external_shipping_when_not_valid(
-    mock_send_request,
-    staff_api_client,
-    address,
-    checkout_with_item,
-    shipping_app,
-    channel_USD,
-    settings,
-    shipping_method,
-):
-    # given
-    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    response_method_id = "abcd"
-    mock_json_response = [
-        {
-            "id": response_method_id,
-            "name": "Provider - Economy",
-            "amount": "10",
-            "currency": "USD",
-            "maximum_delivery_days": "7",
-        }
-    ]
-    mock_send_request.return_value = mock_json_response
-
-    checkout = checkout_with_item
-    checkout.shipping_address = address
-    checkout.save(update_fields=["shipping_address"])
-
-    method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
-
-    checkout.metadata_storage.private_metadata = {
-        PRIVATE_META_APP_SHIPPING_ID: graphene.Node.to_global_id(
-            "app", f"{shipping_app.id}:{response_method_id}"
-        )
-    }
-    checkout.metadata_storage.save()
-
-    # when
-    response = staff_api_client.post_graphql(
-        MUTATION_UPDATE_SHIPPING_METHOD,
-        {"id": to_global_id_or_none(checkout_with_item), "shippingMethodId": method_id},
-    )
-
-    # then
-    data = get_graphql_content(response)["data"]["checkoutShippingMethodUpdate"]
-    checkout.refresh_from_db()
-
-    errors = data["errors"]
-    assert not errors
-    assert data["checkout"]["token"] == str(checkout_with_item.token)
-    assert (
-        PRIVATE_META_APP_SHIPPING_ID not in checkout.metadata_storage.private_metadata
-    )
 
 
 @mock.patch(

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -14,7 +14,6 @@ from prices import Money, TaxedMoney
 from .....channel import MarkAsPaidStrategy
 from .....checkout import calculations
 from .....checkout.delivery_context import (
-    PRIVATE_META_APP_SHIPPING_ID,
     fetch_shipping_methods_for_checkout,
     get_or_fetch_checkout_deliveries,
 )
@@ -31,6 +30,7 @@ from .....discount.models import CheckoutLineDiscount, OrderLineDiscount
 from .....giftcard import GiftCardEvents
 from .....giftcard.models import GiftCard, GiftCardEvent
 from .....order import OrderOrigin, OrderStatus
+from .....order.delivery_context import PRIVATE_META_APP_SHIPPING_ID
 from .....order.models import Fulfillment, Order
 from .....payment.model_helpers import get_subtotal
 from .....plugins.manager import PluginsManager, get_plugins_manager

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -26,7 +26,6 @@ from ....checkout.checkout_cleaner import (
     clean_checkout_payment,
     clean_checkout_shipping,
 )
-from ....checkout.delivery_context import PRIVATE_META_APP_SHIPPING_ID
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.models import Checkout
@@ -494,10 +493,6 @@ def test_query_checkout_empty_address_with_shipping_method_without_exclude_webho
 ):
     # given checkout without address
     # and checkout in channel with available shipping methods
-
-    checkout_with_item.metadata_storage.private_metadata = {
-        PRIVATE_META_APP_SHIPPING_ID: "TEST_METHOD"
-    }
     checkout_with_item.shipping_address = None
     checkout_with_item.billing_address = None
 
@@ -525,10 +520,6 @@ def test_query_checkout_with_address_with_shipping_method_without_exclude_webhoo
 ):
     # GIVEN checkout with address
     # AND checkout in channel with available shipping methods
-
-    checkout_with_item.metadata_storage.private_metadata = {
-        PRIVATE_META_APP_SHIPPING_ID: "TEST_METHOD"
-    }
     checkout_with_item.shipping_address = address
     checkout_with_item.billing_address = address
 

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -5,13 +5,13 @@ import pytest
 from django.utils import timezone
 from prices import Money, TaxedMoney
 
-from .....checkout.delivery_context import PRIVATE_META_APP_SHIPPING_ID
 from .....core.prices import quantize_price
 from .....core.taxes import zero_taxed_money
 from .....discount import DiscountType
 from .....giftcard import GiftCardEvents, events
 from .....giftcard.models import GiftCardEvent
 from .....order import FulfillmentStatus, OrderOrigin, OrderStatus
+from .....order.delivery_context import PRIVATE_META_APP_SHIPPING_ID
 from .....order.events import transaction_event
 from .....order.models import Order, OrderGrantedRefund
 from .....order.utils import (


### PR DESCRIPTION
I want to merge this change because it drops the logic responsible for handling the external shipping method id stored in checkout's metadata. As Checkout has own `CheckoutDelviery` model, the previous flow is not used any more. This PR just drops this logic

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
