### PR TITLE
fix(graphql): increase mutation limit to 4

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -878,7 +878,7 @@ GRAPHQL_MIDDLEWARE: list[str] = []
 GRAPHQL_BATCH_MAX_COUNT: int = int(os.environ.get("GRAPHQL_BATCH_MAX_COUNT", 1))
 GRAPHQL_ALIAS_COUNT_LIMIT: int = int(os.environ.get("GRAPHQL_ALIAS_COUNT_LIMIT", 100))
 GRAPHQL_MUTATION_COUNT_LIMIT: int = int(
-    os.environ.get("GRAPHQL_MUTATION_COUNT_LIMIT", 3)
+    os.environ.get("GRAPHQL_MUTATION_COUNT_LIMIT", 4)
 )
 
 # Set GRAPHQL_QUERY_MAX_COMPLEXITY=0 in env to disable (not recommended)


### PR DESCRIPTION
Temporarily increases the mutation limit from 3 to 4 due to Saleor Dashboard [sending 4 mutations when updating stocks](https://github.com/saleor/saleor-dashboard/blob/cb8679df28f82f2f8d2ae8f15ca2959781096ba2/src/products/mutations.ts#L95-L163)

We expect this to remain in place until Saleor v3.24 where the cost limiter will dynamically adjust the number of mutations allowed (as not all mutations are equal in terms of their actual cost).

## Verification process

To verify that 4 is the correct limit, I created the following scripts (disclaimer: they are quick & dirty scripts):


<details>

<summary>extract_gql_blocks.py (AI generated script) - this dumps all GraphQL mutations/query blocks inside Saleor Dashboard for every `mutations.ts` file</summary>

```py
import argparse
import json
from dataclasses import dataclass
from datetime import datetime, timezone
from pathlib import Path
from typing import Optional


@dataclass
class GqlBlock:
    content: str
    start_index: int
    end_index: int


def find_matching_backtick(source: str, start_tick_index: int) -> Optional[int]:
    i = start_tick_index + 1
    in_expr = False
    expr_brace_depth = 0
    string_delimiter: Optional[str] = None
    escape_next = False

    while i < len(source):
        char = source[i]

        if in_expr:
            if string_delimiter:
                if escape_next:
                    escape_next = False
                elif char == "\\":
                    escape_next = True
                elif char == string_delimiter:
                    string_delimiter = None
            else:
                if char in {"'", '"', "`"}:
                    string_delimiter = char
                elif char == "{":
                    expr_brace_depth += 1
                elif char == "}":
                    if expr_brace_depth == 0:
                        in_expr = False
                    else:
                        expr_brace_depth -= 1
        else:
            if char == "\\":
                i += 2
                continue

            if char == "`":
                return i

            if char == "$" and i + 1 < len(source) and source[i + 1] == "{":
                in_expr = True
                expr_brace_depth = 0
                i += 1

        i += 1

    return None


def extract_gql_blocks(source: str) -> list[GqlBlock]:
    blocks: list[GqlBlock] = []
    i = 0

    while i < len(source):
        gql_index = source.find("gql", i)

        if gql_index == -1:
            break

        if gql_index > 0 and (
            source[gql_index - 1].isalnum() or source[gql_index - 1] in {"_", "$"}
        ):
            i = gql_index + 3
            continue

        j = gql_index + 3
        while j < len(source) and source[j] in {" ", "\t", "\r", "\n"}:
            j += 1

        if j >= len(source) or source[j] != "`":
            i = gql_index + 3
            continue

        closing_tick_index = find_matching_backtick(source, j)

        if closing_tick_index is None:
            i = j + 1
            continue

        blocks.append(
            GqlBlock(
                content=source[j + 1 : closing_tick_index],
                start_index=j + 1,
                end_index=closing_tick_index,
            )
        )
        i = closing_tick_index + 1

    return blocks


def line_number_for_index(source: str, index: int) -> int:
    return source.count("\n", 0, index) + 1


def infer_const_name(source: str, gql_start_index: int) -> Optional[str]:
    prefix = source[max(0, gql_start_index - 400) : gql_start_index]
    lines = prefix.splitlines()

    for line in reversed(lines):
        stripped = line.strip()

        if not stripped:
            continue

        if "=" not in stripped:
            continue

        left_side = stripped.split("=", maxsplit=1)[0].strip()

        if left_side.startswith("export const "):
            return left_side.removeprefix("export const ").strip()

        if left_side.startswith("const "):
            return left_side.removeprefix("const ").strip()

        return None

    return None


def main():
    mutation_files = sorted(root.rglob("mutations.ts"))
    files_payload = []

    for file_path in mutation_files:
        source = file_path.read_text(encoding="utf-8")
        gql_blocks = extract_gql_blocks(source)

        if not gql_blocks:
            continue

        file_blocks_payload = []
        for index, block in enumerate(gql_blocks, start=1):
            gql_start_index = block.start_index - 1
            file_blocks_payload.append(
                {
                    "index": index,
                    "name": infer_const_name(source, gql_start_index),
                    "startLine": line_number_for_index(source, block.start_index),
                    "endLine": line_number_for_index(source, block.end_index),
                    "gql": block.content,
                }
            )

        files_payload.append(
            {
                "path": str(file_path.relative_to(root)),
                "blockCount": len(file_blocks_payload),
                "blocks": file_blocks_payload,
            }
        )

    payload = {
        "files": files_payload,
    }

    print(json.dumps(payload))


if __name__ == "__main__":
    main()
```

</details>

<details>

<summary>scan_mutation_limits.py (not AI generated) - runs all Saleor Dashboard queries/mutations against Saleor's GraphQL validator to check whether the number of mutations exceeds the limit</summary>

```py
import django, os

os.environ["DJANGO_SETTINGS_MODULE"] = "saleor.settings"
django.setup()

import json
import sys
import logging
from pathlib import Path
from saleor.graphql.views import GraphQLView
from saleor.graphql.api import backend, schema
import graphql.validation
from saleor.graphql.core.validators import MutationCountLimitRule

logger = logging.getLogger(__name__)


def analyze_query(query: str) -> list:
    doc, _ = GraphQLView(backend=backend, schema=schema).parse_query(query)
    if doc is None:
        logger.error("Invalid query: %s", query)
        return []
    errors = graphql.validation.validate(
        schema, doc.document_ast, [MutationCountLimitRule]
    )
    return errors


def main():
    data = json.loads(Path(sys.argv[1]).read_text())

    for file_data in data["files"]:
        logger.info("Scanning %s", file_data["path"])
        for block in file_data["blocks"]:
            gql = block["gql"]
            errs = analyze_query(gql)

            if errs:
                logger.error("Query %r: %r", gql, errs)


if __name__ == "__main__":
    logging.basicConfig(level=logging.INFO)
    main()
```

</details>

Steps:

1. For every minor Saleor version (3.20, 3.21, 3.22, 3.23 + main), I ran in dashboard's git repo `python3 extract_gql_blocks.py > v320.json`
2. Then, I scan them using Core: `GRAPHQL_MUTATION_COUNT_LIMIT=3 python3 scan_mutation_limits.py v320.json` and I checked the errors
3. Then, I reran it but using `GRAPHQL_MUTATION_COUNT_LIMIT=4` to fix all `Number of mutations exceed the limit of 3` errors

I confirmed that there is no known queries in Dashboard that use more than 4 mutations per API call. (assumes that all mutations used are indeed inside `mutations.ts`)

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
