### PR TITLE
Add channel stock events

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2051,6 +2051,10 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """A product variant stock is updated"""
   PRODUCT_VARIANT_STOCK_UPDATED
+  PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL
+  PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL
+  PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT
+  PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT
   PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED
 
   """A new checkout is created."""
@@ -2627,6 +2631,10 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """A product variant stock is updated"""
   PRODUCT_VARIANT_STOCK_UPDATED
+  PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL
+  PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL
+  PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT
+  PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT
   PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED
 
   """A new checkout is created."""
@@ -14147,6 +14155,10 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   PRODUCT_VARIANT_OUT_OF_STOCK
   PRODUCT_VARIANT_BACK_IN_STOCK
   PRODUCT_VARIANT_STOCK_UPDATED
+  PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL
+  PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL
+  PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT
+  PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT
   PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED
   CHECKOUT_CREATED
   CHECKOUT_UPDATED
@@ -33770,6 +33782,62 @@ type Subscription @doc(category: "Miscellaneous") {
     """
     channels: [String!]
   ): ProductVariantDiscountedPriceUpdated @doc(category: "Products")
+
+  """
+  Event sent when a product variant becomes out of stock across all non click-and-collect warehouses in a channel.
+  
+  Added in Saleor 3.23.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  productVariantOutOfStockInChannel(
+    """
+    List of channel slugs. The event will be sent only if the object belongs to one of the provided channels. If the channel slug list is empty, objects that belong to any channel will be sent. Maximally 500 items.
+    """
+    channels: [String!]
+  ): ProductVariantOutOfStockInChannel @doc(category: "Products")
+
+  """
+  Event sent when a product variant becomes available again across non click-and-collect warehouses in a channel.
+  
+  Added in Saleor 3.23.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  productVariantBackInStockInChannel(
+    """
+    List of channel slugs. The event will be sent only if the object belongs to one of the provided channels. If the channel slug list is empty, objects that belong to any channel will be sent. Maximally 500 items.
+    """
+    channels: [String!]
+  ): ProductVariantBackInStockInChannel @doc(category: "Products")
+
+  """
+  Event sent when a product variant becomes out of stock across all click-and-collect warehouses in a channel.
+  
+  Added in Saleor 3.23.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  productVariantOutOfStockForClickAndCollect(
+    """
+    List of channel slugs. The event will be sent only if the object belongs to one of the provided channels. If the channel slug list is empty, objects that belong to any channel will be sent. Maximally 500 items.
+    """
+    channels: [String!]
+  ): ProductVariantOutOfStockForClickAndCollect @doc(category: "Products")
+
+  """
+  Event sent when a product variant becomes available again across click-and-collect warehouses in a channel.
+  
+  Added in Saleor 3.23.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  productVariantBackInStockForClickAndCollect(
+    """
+    List of channel slugs. The event will be sent only if the object belongs to one of the provided channels. If the channel slug list is empty, objects that belong to any channel will be sent. Maximally 500 items.
+    """
+    channels: [String!]
+  ): ProductVariantBackInStockForClickAndCollect @doc(category: "Products")
 }
 
 interface Event {
@@ -34187,6 +34255,106 @@ type ProductVariantDiscountedPriceUpdated implements Event @doc(category: "Produ
 
   """The new discounted price."""
   newPrice: Money!
+}
+
+"""
+Event sent when a product variant becomes out of stock across all non click-and-collect warehouses in a channel.
+
+Added in Saleor 3.23.
+"""
+type ProductVariantOutOfStockInChannel implements Event @doc(category: "Products") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The product variant the event relates to."""
+  productVariant: ProductVariant!
+
+  """The channel the stock availability changed in."""
+  channel: Channel!
+}
+
+"""
+Event sent when a product variant becomes available again across non click-and-collect warehouses in a channel.
+
+Added in Saleor 3.23.
+"""
+type ProductVariantBackInStockInChannel implements Event @doc(category: "Products") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The product variant the event relates to."""
+  productVariant: ProductVariant!
+
+  """The channel the stock availability changed in."""
+  channel: Channel!
+}
+
+"""
+Event sent when a product variant becomes out of stock across all click-and-collect warehouses in a channel.
+
+Added in Saleor 3.23.
+"""
+type ProductVariantOutOfStockForClickAndCollect implements Event @doc(category: "Products") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The product variant the event relates to."""
+  productVariant: ProductVariant!
+
+  """The channel the stock availability changed in."""
+  channel: Channel!
+}
+
+"""
+Event sent when a product variant becomes available again across click-and-collect warehouses in a channel.
+
+Added in Saleor 3.23.
+"""
+type ProductVariantBackInStockForClickAndCollect implements Event @doc(category: "Products") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The product variant the event relates to."""
+  productVariant: ProductVariant!
+
+  """The channel the stock availability changed in."""
+  channel: Channel!
 }
 
 enum DistanceUnitsEnum {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2051,9 +2051,25 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """A product variant stock is updated"""
   PRODUCT_VARIANT_STOCK_UPDATED
+
+  """
+  A product variant becomes out of stock across all non click-and-collect warehouses in a channel.
+  """
   PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL
+
+  """
+  A product variant becomes available again across non click-and-collect warehouses in a channel.
+  """
   PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL
+
+  """
+  A product variant becomes out of stock across all click-and-collect warehouses in a channel.
+  """
   PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT
+
+  """
+  A product variant becomes available again across click-and-collect warehouses in a channel.
+  """
   PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT
   PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED
 
@@ -2631,9 +2647,25 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """A product variant stock is updated"""
   PRODUCT_VARIANT_STOCK_UPDATED
+
+  """
+  A product variant becomes out of stock across all non click-and-collect warehouses in a channel.
+  """
   PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL
+
+  """
+  A product variant becomes available again across non click-and-collect warehouses in a channel.
+  """
   PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL
+
+  """
+  A product variant becomes out of stock across all click-and-collect warehouses in a channel.
+  """
   PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT
+
+  """
+  A product variant becomes available again across click-and-collect warehouses in a channel.
+  """
   PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT
   PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED
 

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -174,6 +174,22 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED: (
         "A product variant stock is updated"
     ),
+    WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL: (
+        "A product variant becomes out of stock across all non click-and-collect "
+        "warehouses in a channel."
+    ),
+    WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL: (
+        "A product variant becomes available again across non click-and-collect "
+        "warehouses in a channel."
+    ),
+    WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT: (
+        "A product variant becomes out of stock across all click-and-collect "
+        "warehouses in a channel."
+    ),
+    WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT: (
+        "A product variant becomes available again across click-and-collect "
+        "warehouses in a channel."
+    ),
     WebhookEventAsyncType.PRODUCT_EXPORT_COMPLETED: "A product export is completed.",
     WebhookEventAsyncType.SHIPPING_PRICE_CREATED: "A new shipping price is created.",
     WebhookEventAsyncType.SHIPPING_PRICE_UPDATED: "A shipping price is updated.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -55,6 +55,7 @@ from ..core.descriptions import (
     ADDED_IN_320,
     ADDED_IN_321,
     ADDED_IN_322,
+    ADDED_IN_323,
     DEPRECATED_IN_3X_EVENT,
     PREVIEW_FEATURE,
 )
@@ -86,6 +87,7 @@ from ..warehouse.dataloaders import WarehouseByIdLoader
 if TYPE_CHECKING:
     from ...channel.models import Channel
     from ...product.interface import VariantDiscountedPriceChange
+    from ...warehouse.interface import VariantChannelStockInfo
 
 TRANSLATIONS_TYPES_MAP = {
     ProductTranslation: translation_types.ProductTranslation,
@@ -1125,6 +1127,93 @@ class ProductVariantDiscountedPriceUpdated(SubscriptionObjectType):
     ) -> Money:
         _, price_info = root
         return Money(amount=price_info.new_price_amount, currency=price_info.currency)
+
+
+class ProductVariantChannelStockBase(SubscriptionObjectType):
+    product_variant = graphene.Field(
+        "saleor.graphql.product.types.ProductVariant",
+        description="The product variant the event relates to.",
+        required=True,
+    )
+    channel = graphene.Field(
+        "saleor.graphql.channel.types.Channel",
+        description="The channel the stock availability changed in.",
+        required=True,
+    )
+
+    class Meta:
+        abstract = True
+
+    @staticmethod
+    def resolve_product_variant(
+        root: tuple[str, "VariantChannelStockInfo"],
+        info: ResolveInfo,
+    ) -> Promise["ChannelContext"]:
+        _, stock_info = root
+        channel_slug = stock_info.channel_slug
+        return (
+            ProductVariantByIdLoader(info.context)
+            .load(stock_info.variant_id)
+            .then(
+                lambda variant: ChannelContext(node=variant, channel_slug=channel_slug)
+            )
+        )
+
+    @staticmethod
+    def resolve_channel(
+        root: tuple[str, "VariantChannelStockInfo"],
+        info: ResolveInfo,
+    ) -> Promise["Channel"]:
+        _, stock_info = root
+        return ChannelBySlugLoader(info.context).load(stock_info.channel_slug)
+
+
+class ProductVariantOutOfStockInChannel(ProductVariantChannelStockBase):
+    class Meta:
+        root_type = None
+        enable_dry_run = False
+        interfaces = (Event,)
+        description = (
+            "Event sent when a product variant becomes out of stock across all "
+            "non click-and-collect warehouses in a channel." + ADDED_IN_323
+        )
+        doc_category = DOC_CATEGORY_PRODUCTS
+
+
+class ProductVariantBackInStockInChannel(ProductVariantChannelStockBase):
+    class Meta:
+        root_type = None
+        enable_dry_run = False
+        interfaces = (Event,)
+        description = (
+            "Event sent when a product variant becomes available again across "
+            "non click-and-collect warehouses in a channel." + ADDED_IN_323
+        )
+        doc_category = DOC_CATEGORY_PRODUCTS
+
+
+class ProductVariantOutOfStockForClickAndCollect(ProductVariantChannelStockBase):
+    class Meta:
+        root_type = None
+        enable_dry_run = False
+        interfaces = (Event,)
+        description = (
+            "Event sent when a product variant becomes out of stock across all "
+            "click-and-collect warehouses in a channel." + ADDED_IN_323
+        )
+        doc_category = DOC_CATEGORY_PRODUCTS
+
+
+class ProductVariantBackInStockForClickAndCollect(ProductVariantChannelStockBase):
+    class Meta:
+        root_type = None
+        enable_dry_run = False
+        interfaces = (Event,)
+        description = (
+            "Event sent when a product variant becomes available again across "
+            "click-and-collect warehouses in a channel." + ADDED_IN_323
+        )
+        doc_category = DOC_CATEGORY_PRODUCTS
 
 
 class ProductExportCompleted(SubscriptionObjectType):
@@ -2914,6 +3003,54 @@ class Subscription(SubscriptionObjectType):
         channels=channels_argument,
         doc_category=DOC_CATEGORY_PRODUCTS,
     )
+    product_variant_out_of_stock_in_channel = BaseField(
+        ProductVariantOutOfStockInChannel,
+        description=(
+            "Event sent when a product variant becomes out of stock across all "
+            "non click-and-collect warehouses in a channel."
+            + ADDED_IN_323
+            + PREVIEW_FEATURE
+        ),
+        resolver=default_channel_filterable_resolver,
+        channels=channels_argument,
+        doc_category=DOC_CATEGORY_PRODUCTS,
+    )
+    product_variant_back_in_stock_in_channel = BaseField(
+        ProductVariantBackInStockInChannel,
+        description=(
+            "Event sent when a product variant becomes available again across "
+            "non click-and-collect warehouses in a channel."
+            + ADDED_IN_323
+            + PREVIEW_FEATURE
+        ),
+        resolver=default_channel_filterable_resolver,
+        channels=channels_argument,
+        doc_category=DOC_CATEGORY_PRODUCTS,
+    )
+    product_variant_out_of_stock_for_click_and_collect = BaseField(
+        ProductVariantOutOfStockForClickAndCollect,
+        description=(
+            "Event sent when a product variant becomes out of stock across all "
+            "click-and-collect warehouses in a channel."
+            + ADDED_IN_323
+            + PREVIEW_FEATURE
+        ),
+        resolver=default_channel_filterable_resolver,
+        channels=channels_argument,
+        doc_category=DOC_CATEGORY_PRODUCTS,
+    )
+    product_variant_back_in_stock_for_click_and_collect = BaseField(
+        ProductVariantBackInStockForClickAndCollect,
+        description=(
+            "Event sent when a product variant becomes available again across "
+            "click-and-collect warehouses in a channel."
+            + ADDED_IN_323
+            + PREVIEW_FEATURE
+        ),
+        resolver=default_channel_filterable_resolver,
+        channels=channels_argument,
+        doc_category=DOC_CATEGORY_PRODUCTS,
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_MISC
@@ -3095,6 +3232,10 @@ ASYNC_WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK: ProductVariantBackInStock,
     WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED: ProductVariantStockUpdated,
     WebhookEventAsyncType.PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED: ProductVariantDiscountedPriceUpdated,
+    WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL: ProductVariantOutOfStockInChannel,
+    WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL: ProductVariantBackInStockInChannel,
+    WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT: ProductVariantOutOfStockForClickAndCollect,
+    WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT: ProductVariantBackInStockForClickAndCollect,
     WebhookEventAsyncType.PRODUCT_VARIANT_DELETED: ProductVariantDeleted,
     WebhookEventAsyncType.PRODUCT_VARIANT_METADATA_UPDATED: (
         ProductVariantMetadataUpdated

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -124,7 +124,7 @@ from ...webhook.transport.utils import (
     get_meta_description_key,
     get_sqs_message_group_id,
 )
-from ...webhook.utils import get_webhooks_for_event
+from ...webhook.utils import filter_webhooks_for_channel, get_webhooks_for_event
 from ..base_plugin import BasePlugin
 
 if TYPE_CHECKING:
@@ -780,17 +780,7 @@ class WebhookPlugin(BasePlugin):
         """
         if webhooks is None:
             webhooks = get_webhooks_for_event(event_type)
-        filtered_webhooks = []
-        for webhook in webhooks:
-            if not webhook.subscription_query:
-                filtered_webhooks.append(webhook)
-                continue
-            filterable_channel_slugs = list(webhook.filterable_channel_slugs)
-            if not filterable_channel_slugs:
-                filtered_webhooks.append(webhook)
-                continue
-            if channel_slug in filterable_channel_slugs:
-                filtered_webhooks.append(webhook)
+        filtered_webhooks = filter_webhooks_for_channel(webhooks, channel_slug)
         return filtered_webhooks
 
     def order_created(

--- a/saleor/warehouse/interface.py
+++ b/saleor/warehouse/interface.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class VariantChannelStockInfo:
+    variant_id: int
+    channel_slug: str
+
+    @property
+    def pk(self) -> tuple[int, str]:
+        """Required by deferred payload mechanism to group deliveries per object.
+
+        Uses (variant_id, channel_slug) because the same variant can have
+        separate stock-availability events per channel.
+        """
+        return (self.variant_id, self.channel_slug)

--- a/saleor/warehouse/tests/webhooks/subscriptions/test_channel_stock_events.py
+++ b/saleor/warehouse/tests/webhooks/subscriptions/test_channel_stock_events.py
@@ -1,10 +1,93 @@
 import json
 
 import graphene
+import pytest
 
-from ....warehouse.interface import VariantChannelStockInfo
-from ...event_types import WebhookEventAsyncType
-from ...transport.asynchronous.transport import create_deliveries_for_subscriptions
+from .....webhook.event_types import WebhookEventAsyncType
+from .....webhook.transport.asynchronous.transport import (
+    create_deliveries_for_subscriptions,
+)
+from ....interface import VariantChannelStockInfo
+
+PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL = """
+    subscription{
+      event{
+        ...on ProductVariantOutOfStockInChannel{
+          productVariant{ id }
+          channel{ slug }
+        }
+      }
+    }
+"""
+
+PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL = """
+    subscription{
+      event{
+        ...on ProductVariantBackInStockInChannel{
+          productVariant{ id }
+          channel{ slug }
+        }
+      }
+    }
+"""
+
+PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT = """
+    subscription{
+      event{
+        ...on ProductVariantOutOfStockForClickAndCollect{
+          productVariant{ id }
+          channel{ slug }
+        }
+      }
+    }
+"""
+
+PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT = """
+    subscription{
+      event{
+        ...on ProductVariantBackInStockForClickAndCollect{
+          productVariant{ id }
+          channel{ slug }
+        }
+      }
+    }
+"""
+
+
+@pytest.fixture
+def subscription_product_variant_out_of_stock_in_channel_webhook(subscription_webhook):
+    return subscription_webhook(
+        PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+    )
+
+
+@pytest.fixture
+def subscription_product_variant_back_in_stock_in_channel_webhook(subscription_webhook):
+    return subscription_webhook(
+        PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+    )
+
+
+@pytest.fixture
+def subscription_product_variant_out_of_stock_for_click_and_collect_webhook(
+    subscription_webhook,
+):
+    return subscription_webhook(
+        PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+    )
+
+
+@pytest.fixture
+def subscription_product_variant_back_in_stock_for_click_and_collect_webhook(
+    subscription_webhook,
+):
+    return subscription_webhook(
+        PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+    )
 
 
 def test_product_variant_out_of_stock_in_channel(

--- a/saleor/warehouse/tests/webhooks/test_channel_stock_events.py
+++ b/saleor/warehouse/tests/webhooks/test_channel_stock_events.py
@@ -1,5 +1,7 @@
+import json
 from unittest import mock
 
+import graphene
 import pytest
 
 from ....webhook.event_types import WebhookEventAsyncType
@@ -65,6 +67,13 @@ def test_trigger_dispatches(
     assert args[2] == [any_webhook]
     assert kwargs["subscribable_object"] is stock_info
     assert kwargs["requestor"] is None
+    legacy_payload = json.loads(kwargs["legacy_data_generator"]())
+    assert legacy_payload == {
+        "product_variant_id": graphene.Node.to_global_id(
+            "ProductVariant", stock_info.variant_id
+        ),
+        "channel": {"slug": stock_info.channel_slug},
+    }
 
 
 @mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")

--- a/saleor/warehouse/tests/webhooks/test_channel_stock_events.py
+++ b/saleor/warehouse/tests/webhooks/test_channel_stock_events.py
@@ -1,0 +1,188 @@
+from unittest import mock
+
+import pytest
+
+from ....webhook.event_types import WebhookEventAsyncType
+from ...interface import VariantChannelStockInfo
+from ...webhooks.channel_stock_events import (
+    _trigger,
+    trigger_product_variant_back_in_stock_for_click_and_collect,
+    trigger_product_variant_back_in_stock_in_channel,
+    trigger_product_variant_out_of_stock_for_click_and_collect,
+    trigger_product_variant_out_of_stock_in_channel,
+)
+
+
+@pytest.fixture
+def stock_info():
+    return VariantChannelStockInfo(variant_id=42, channel_slug="default")
+
+
+@pytest.mark.parametrize(
+    ("trigger_fn", "event_type"),
+    [
+        (
+            trigger_product_variant_out_of_stock_in_channel,
+            WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        ),
+        (
+            trigger_product_variant_back_in_stock_in_channel,
+            WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+        ),
+        (
+            trigger_product_variant_out_of_stock_for_click_and_collect,
+            WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+        ),
+        (
+            trigger_product_variant_back_in_stock_for_click_and_collect,
+            WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+        ),
+    ],
+)
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+def test_trigger_dispatches(
+    mocked_get_webhooks,
+    mocked_trigger,
+    any_webhook,
+    stock_info,
+    site_settings,
+    trigger_fn,
+    event_type,
+):
+    # given
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    mocked_get_webhooks.return_value = [any_webhook]
+
+    # when
+    trigger_fn(stock_info, site_settings)
+
+    # then
+    mocked_get_webhooks.assert_called_once_with(event_type)
+    mocked_trigger.assert_called_once()
+    args, kwargs = mocked_trigger.call_args
+    assert args[1] == event_type
+    assert args[2] == [any_webhook]
+    assert kwargs["subscribable_object"] is stock_info
+    assert kwargs["requestor"] is None
+
+
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+def test_trigger_skipped_when_legacy_flag_on(
+    mocked_get_webhooks, mocked_trigger, stock_info, site_settings
+):
+    # given
+    site_settings.use_legacy_shipping_zone_stock_availability = True
+
+    # when
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        stock_info,
+        site_settings,
+        None,
+        None,
+    )
+
+    # then
+    mocked_get_webhooks.assert_not_called()
+    mocked_trigger.assert_not_called()
+
+
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+def test_trigger_no_webhooks_skips(
+    mocked_get_webhooks, mocked_trigger, stock_info, site_settings
+):
+    # given
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    mocked_get_webhooks.return_value = []
+
+    # when
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        stock_info,
+        site_settings,
+        None,
+        None,
+    )
+
+    # then
+    mocked_trigger.assert_not_called()
+
+
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+def test_trigger_uses_passed_webhooks(
+    mocked_get_webhooks,
+    mocked_trigger,
+    any_webhook,
+    stock_info,
+    site_settings,
+):
+    # given
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+
+    # when
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        stock_info,
+        site_settings,
+        None,
+        [any_webhook],
+    )
+
+    # then
+    mocked_get_webhooks.assert_not_called()
+    assert mocked_trigger.call_args.args[2] == [any_webhook]
+
+
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+def test_trigger_filters_webhooks_by_channel_slug(
+    mocked_get_webhooks, mocked_trigger, stock_info, site_settings
+):
+    # given - webhook subscription only allows a different channel
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    webhook = mock.Mock()
+    webhook.subscription_query = "subscription { event { ... } }"
+    webhook.filterable_channel_slugs = ["other-channel"]
+    mocked_get_webhooks.return_value = [webhook]
+
+    # when
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        stock_info,
+        site_settings,
+        None,
+        None,
+    )
+
+    # then
+    mocked_trigger.assert_not_called()
+
+
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
+@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+def test_trigger_passes_through_when_subscription_has_no_channel_filter(
+    mocked_get_webhooks, mocked_trigger, stock_info, site_settings
+):
+    # given
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    webhook = mock.Mock()
+    webhook.subscription_query = "subscription { event { ... } }"
+    webhook.filterable_channel_slugs = []
+    mocked_get_webhooks.return_value = [webhook]
+
+    # when
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        stock_info,
+        site_settings,
+        None,
+        None,
+    )
+
+    # then
+    mocked_trigger.assert_called_once()
+    assert mocked_trigger.call_args.args[2] == [webhook]

--- a/saleor/warehouse/webhooks/channel_stock_events.py
+++ b/saleor/warehouse/webhooks/channel_stock_events.py
@@ -1,4 +1,7 @@
+import json
 from typing import TYPE_CHECKING
+
+import graphene
 
 from ...account.models import User
 from ...app.models import App
@@ -15,6 +18,17 @@ if TYPE_CHECKING:
 
 
 T_REQUESTOR = User | App | None
+
+
+def _build_legacy_payload(stock_info: VariantChannelStockInfo) -> str:
+    return json.dumps(
+        {
+            "product_variant_id": graphene.Node.to_global_id(
+                "ProductVariant", stock_info.variant_id
+            ),
+            "channel": {"slug": stock_info.channel_slug},
+        }
+    )
 
 
 def _trigger(
@@ -39,6 +53,7 @@ def _trigger(
         channel_webhooks,
         subscribable_object=stock_info,
         requestor=requestor,
+        legacy_data_generator=lambda: _build_legacy_payload(stock_info),
     )
 
 

--- a/saleor/warehouse/webhooks/channel_stock_events.py
+++ b/saleor/warehouse/webhooks/channel_stock_events.py
@@ -1,0 +1,102 @@
+from typing import TYPE_CHECKING
+
+from ...account.models import User
+from ...app.models import App
+from ...webhook.event_types import WebhookEventAsyncType
+from ...webhook.transport.asynchronous.transport import trigger_webhooks_async
+from ...webhook.utils import filter_webhooks_for_channel, get_webhooks_for_event
+from ..interface import VariantChannelStockInfo
+
+if TYPE_CHECKING:
+    from django.db.models import QuerySet
+
+    from ...site.models import SiteSettings
+    from ...webhook.models import Webhook
+
+
+T_REQUESTOR = User | App | None
+
+
+def _trigger(
+    event_type: str,
+    stock_info: VariantChannelStockInfo,
+    site_settings: "SiteSettings",
+    requestor: T_REQUESTOR,
+    webhooks: "QuerySet[Webhook] | None",
+) -> None:
+    # channel stock availability are only triggered when legacy shipping zone
+    # stock availability is disabled
+    if site_settings.use_legacy_shipping_zone_stock_availability:
+        return
+    if webhooks is None:
+        webhooks = get_webhooks_for_event(event_type)
+    channel_webhooks = filter_webhooks_for_channel(webhooks, stock_info.channel_slug)
+    if not channel_webhooks:
+        return
+    trigger_webhooks_async(
+        None,
+        event_type,
+        channel_webhooks,
+        subscribable_object=stock_info,
+        requestor=requestor,
+    )
+
+
+def trigger_product_variant_out_of_stock_in_channel(
+    stock_info: VariantChannelStockInfo,
+    site_settings: "SiteSettings",
+    requestor: T_REQUESTOR = None,
+    webhooks: "QuerySet[Webhook] | None" = None,
+) -> None:
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        stock_info,
+        site_settings,
+        requestor,
+        webhooks,
+    )
+
+
+def trigger_product_variant_back_in_stock_in_channel(
+    stock_info: VariantChannelStockInfo,
+    site_settings: "SiteSettings",
+    requestor: T_REQUESTOR = None,
+    webhooks: "QuerySet[Webhook] | None" = None,
+) -> None:
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+        stock_info,
+        site_settings,
+        requestor,
+        webhooks,
+    )
+
+
+def trigger_product_variant_out_of_stock_for_click_and_collect(
+    stock_info: VariantChannelStockInfo,
+    site_settings: "SiteSettings",
+    requestor: T_REQUESTOR = None,
+    webhooks: "QuerySet[Webhook] | None" = None,
+) -> None:
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+        stock_info,
+        site_settings,
+        requestor,
+        webhooks,
+    )
+
+
+def trigger_product_variant_back_in_stock_for_click_and_collect(
+    stock_info: VariantChannelStockInfo,
+    site_settings: "SiteSettings",
+    requestor: T_REQUESTOR = None,
+    webhooks: "QuerySet[Webhook] | None" = None,
+) -> None:
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+        stock_info,
+        site_settings,
+        requestor,
+        webhooks,
+    )

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -138,12 +138,22 @@ class WebhookEventAsyncType:
     PRODUCT_VARIANT_UPDATED = "product_variant_updated"
     PRODUCT_VARIANT_DELETED = "product_variant_deleted"
     PRODUCT_VARIANT_METADATA_UPDATED = "product_variant_metadata_updated"
+    PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED = (
+        "product_variant_discounted_price_updated"
+    )
 
     PRODUCT_VARIANT_OUT_OF_STOCK = "product_variant_out_of_stock"
     PRODUCT_VARIANT_BACK_IN_STOCK = "product_variant_back_in_stock"
     PRODUCT_VARIANT_STOCK_UPDATED = "product_variant_stock_updated"
-    PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED = (
-        "product_variant_discounted_price_updated"
+    PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL = "product_variant_out_of_stock_in_channel"
+    PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL = (
+        "product_variant_back_in_stock_in_channel"
+    )
+    PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT = (
+        "product_variant_out_of_stock_for_click_and_collect"
+    )
+    PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT = (
+        "product_variant_back_in_stock_for_click_and_collect"
     )
 
     CHECKOUT_CREATED = "checkout_created"
@@ -616,6 +626,26 @@ class WebhookEventAsyncType:
         PRODUCT_VARIANT_STOCK_UPDATED: {
             "name": "Product variant stock updated",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
+        },
+        PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL: {
+            "name": "Product variant out of stock in channel",
+            "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
+        },
+        PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL: {
+            "name": "Product variant back in stock in channel",
+            "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
+        },
+        PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT: {
+            "name": "Product variant out of stock for click and collect",
+            "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
+        },
+        PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT: {
+            "name": "Product variant back in stock for click and collect",
+            "permission": ProductPermissions.MANAGE_PRODUCTS,
+            "is_deferred_payload": True,
         },
         PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED: {
             "name": "Product variant discounted price updated",

--- a/saleor/webhook/tests/fixtures/subscription_webhooks.py
+++ b/saleor/webhook/tests/fixtures/subscription_webhooks.py
@@ -489,6 +489,42 @@ def subscription_product_variant_discounted_price_updated_webhook(subscription_w
 
 
 @pytest.fixture
+def subscription_product_variant_out_of_stock_in_channel_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+    )
+
+
+@pytest.fixture
+def subscription_product_variant_back_in_stock_in_channel_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+    )
+
+
+@pytest.fixture
+def subscription_product_variant_out_of_stock_for_click_and_collect_webhook(
+    subscription_webhook,
+):
+    return subscription_webhook(
+        queries.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+    )
+
+
+@pytest.fixture
+def subscription_product_variant_back_in_stock_for_click_and_collect_webhook(
+    subscription_webhook,
+):
+    return subscription_webhook(
+        queries.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+    )
+
+
+@pytest.fixture
 def subscription_order_created_webhook(subscription_webhook):
     return subscription_webhook(
         queries.ORDER_CREATED, WebhookEventAsyncType.ORDER_CREATED

--- a/saleor/webhook/tests/fixtures/subscription_webhooks.py
+++ b/saleor/webhook/tests/fixtures/subscription_webhooks.py
@@ -489,42 +489,6 @@ def subscription_product_variant_discounted_price_updated_webhook(subscription_w
 
 
 @pytest.fixture
-def subscription_product_variant_out_of_stock_in_channel_webhook(subscription_webhook):
-    return subscription_webhook(
-        queries.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
-        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
-    )
-
-
-@pytest.fixture
-def subscription_product_variant_back_in_stock_in_channel_webhook(subscription_webhook):
-    return subscription_webhook(
-        queries.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
-        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
-    )
-
-
-@pytest.fixture
-def subscription_product_variant_out_of_stock_for_click_and_collect_webhook(
-    subscription_webhook,
-):
-    return subscription_webhook(
-        queries.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
-        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
-    )
-
-
-@pytest.fixture
-def subscription_product_variant_back_in_stock_for_click_and_collect_webhook(
-    subscription_webhook,
-):
-    return subscription_webhook(
-        queries.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
-        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
-    )
-
-
-@pytest.fixture
 def subscription_order_created_webhook(subscription_webhook):
     return subscription_webhook(
         queries.ORDER_CREATED, WebhookEventAsyncType.ORDER_CREATED

--- a/saleor/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1324,6 +1324,50 @@ PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED = """
     }
 """
 
+PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL = """
+    subscription{
+      event{
+        ...on ProductVariantOutOfStockInChannel{
+          productVariant{ id }
+          channel{ slug }
+        }
+      }
+    }
+"""
+
+PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL = """
+    subscription{
+      event{
+        ...on ProductVariantBackInStockInChannel{
+          productVariant{ id }
+          channel{ slug }
+        }
+      }
+    }
+"""
+
+PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT = """
+    subscription{
+      event{
+        ...on ProductVariantOutOfStockForClickAndCollect{
+          productVariant{ id }
+          channel{ slug }
+        }
+      }
+    }
+"""
+
+PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT = """
+    subscription{
+      event{
+        ...on ProductVariantBackInStockForClickAndCollect{
+          productVariant{ id }
+          channel{ slug }
+        }
+      }
+    }
+"""
+
 ORDER_CREATED = """
     subscription{
       event{

--- a/saleor/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1324,50 +1324,6 @@ PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED = """
     }
 """
 
-PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL = """
-    subscription{
-      event{
-        ...on ProductVariantOutOfStockInChannel{
-          productVariant{ id }
-          channel{ slug }
-        }
-      }
-    }
-"""
-
-PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL = """
-    subscription{
-      event{
-        ...on ProductVariantBackInStockInChannel{
-          productVariant{ id }
-          channel{ slug }
-        }
-      }
-    }
-"""
-
-PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT = """
-    subscription{
-      event{
-        ...on ProductVariantOutOfStockForClickAndCollect{
-          productVariant{ id }
-          channel{ slug }
-        }
-      }
-    }
-"""
-
-PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT = """
-    subscription{
-      event{
-        ...on ProductVariantBackInStockForClickAndCollect{
-          productVariant{ id }
-          channel{ slug }
-        }
-      }
-    }
-"""
-
 ORDER_CREATED = """
     subscription{
       event{

--- a/saleor/webhook/tests/subscription_webhooks/test_subscriptions_product_variant_channel_stock.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_subscriptions_product_variant_channel_stock.py
@@ -1,0 +1,117 @@
+import json
+
+import graphene
+
+from ....warehouse.interface import VariantChannelStockInfo
+from ...event_types import WebhookEventAsyncType
+from ...transport.asynchronous.transport import create_deliveries_for_subscriptions
+
+
+def test_product_variant_out_of_stock_in_channel(
+    variant,
+    channel_USD,
+    subscription_product_variant_out_of_stock_in_channel_webhook,
+):
+    # given
+    webhooks = [subscription_product_variant_out_of_stock_in_channel_webhook]
+    event_type = WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    stock_info = VariantChannelStockInfo(
+        variant_id=variant.id, channel_slug=channel_USD.slug
+    )
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, stock_info, webhooks)
+
+    # then
+    payload = json.loads(deliveries[0].payload.get_payload())
+    assert payload == {
+        "productVariant": {"id": variant_id},
+        "channel": {"slug": channel_USD.slug},
+    }
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_product_variant_back_in_stock_in_channel(
+    variant,
+    channel_USD,
+    subscription_product_variant_back_in_stock_in_channel_webhook,
+):
+    # given
+    webhooks = [subscription_product_variant_back_in_stock_in_channel_webhook]
+    event_type = WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    stock_info = VariantChannelStockInfo(
+        variant_id=variant.id, channel_slug=channel_USD.slug
+    )
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, stock_info, webhooks)
+
+    # then
+    payload = json.loads(deliveries[0].payload.get_payload())
+    assert payload == {
+        "productVariant": {"id": variant_id},
+        "channel": {"slug": channel_USD.slug},
+    }
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_product_variant_out_of_stock_for_click_and_collect(
+    variant,
+    channel_USD,
+    subscription_product_variant_out_of_stock_for_click_and_collect_webhook,
+):
+    # given
+    webhooks = [subscription_product_variant_out_of_stock_for_click_and_collect_webhook]
+    event_type = (
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT
+    )
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    stock_info = VariantChannelStockInfo(
+        variant_id=variant.id, channel_slug=channel_USD.slug
+    )
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, stock_info, webhooks)
+
+    # then
+    payload = json.loads(deliveries[0].payload.get_payload())
+    assert payload == {
+        "productVariant": {"id": variant_id},
+        "channel": {"slug": channel_USD.slug},
+    }
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_product_variant_back_in_stock_for_click_and_collect(
+    variant,
+    channel_USD,
+    subscription_product_variant_back_in_stock_for_click_and_collect_webhook,
+):
+    # given
+    webhooks = [
+        subscription_product_variant_back_in_stock_for_click_and_collect_webhook
+    ]
+    event_type = (
+        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT
+    )
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    stock_info = VariantChannelStockInfo(
+        variant_id=variant.id, channel_slug=channel_USD.slug
+    )
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, stock_info, webhooks)
+
+    # then
+    payload = json.loads(deliveries[0].payload.get_payload())
+    assert payload == {
+        "productVariant": {"id": variant_id},
+        "channel": {"slug": channel_USD.slug},
+    }
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]

--- a/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
@@ -16,11 +16,13 @@ from .....core import EventDeliveryStatus
 from .....core.models import EventDelivery
 from .....core.telemetry import get_task_context
 from .....product.interface import VariantDiscountedPriceChange
-from .....warehouse.webhooks.channel_stock_events import VariantChannelStockInfo
+from .....warehouse.interface import VariantChannelStockInfo
+from .....warehouse.tests.webhooks.subscriptions.test_channel_stock_events import (
+    PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+)
 from ....event_types import WebhookEventAsyncType
 from ....tests.subscription_webhooks.subscription_queries import (
     PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED,
-    PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
 )
 from ....utils import get_webhooks_for_event
 from ..transport import (

--- a/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_deferred_payload.py
@@ -16,9 +16,11 @@ from .....core import EventDeliveryStatus
 from .....core.models import EventDelivery
 from .....core.telemetry import get_task_context
 from .....product.interface import VariantDiscountedPriceChange
+from .....warehouse.webhooks.channel_stock_events import VariantChannelStockInfo
 from ....event_types import WebhookEventAsyncType
 from ....tests.subscription_webhooks.subscription_queries import (
     PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED,
+    PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
 )
 from ....utils import get_webhooks_for_event
 from ..transport import (
@@ -464,6 +466,109 @@ def test_generate_deferred_payload_with_dataclass(
     assert payload["newPrice"] == {
         "amount": float(new_price),
         "currency": currency,
+    }
+
+    assert mocked_send_webhook_request_async.call_count == 1
+    call_kwargs = mocked_send_webhook_request_async.call_args.kwargs
+    assert call_kwargs["kwargs"]["event_delivery_id"] == delivery.pk
+
+
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport"
+    ".generate_deferred_payloads.apply_async"
+)
+def test_call_trigger_webhook_async_deferred_payload_with_variant_channel_stock_info(
+    mocked_generate_deferred_payloads,
+    variant,
+    channel_USD,
+    subscription_webhook,
+    staff_user,
+):
+    # given
+    event_type = WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL
+    webhook = subscription_webhook(PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL, event_type)
+    webhooks = get_webhooks_for_event(event_type)
+
+    stock_info = VariantChannelStockInfo(
+        variant_id=variant.id, channel_slug=channel_USD.slug
+    )
+
+    # when
+    trigger_webhooks_async(
+        data=None,
+        event_type=event_type,
+        webhooks=webhooks,
+        subscribable_object=stock_info,
+        requestor=staff_user,
+    )
+
+    # then
+    delivery = webhook.eventdelivery_set.first()
+    call_kwargs = mocked_generate_deferred_payloads.call_args.kwargs
+    deferred_payload_data = call_kwargs["kwargs"]["deferred_payload_data"]
+
+    assert deferred_payload_data["model_name"] is None
+    assert deferred_payload_data["object_id"] is None
+    assert deferred_payload_data["subscribable_object_data"] == {
+        "variant_id": variant.id,
+        "channel_slug": channel_USD.slug,
+    }
+    assert deferred_payload_data["requestor_model_name"] == "account.user"
+    assert deferred_payload_data["requestor_object_id"] == staff_user.pk
+    assert call_kwargs["kwargs"]["event_delivery_ids"] == [delivery.id]
+
+    assert delivery.event_type == event_type
+    assert delivery.payload is None
+    assert delivery.webhook == webhook
+
+
+@mock.patch(
+    "saleor.webhook.transport.asynchronous.transport"
+    ".send_webhook_request_async.apply_async"
+)
+def test_generate_deferred_payload_with_variant_channel_stock_info(
+    mocked_send_webhook_request_async,
+    variant,
+    channel_USD,
+    subscription_webhook,
+    staff_user,
+):
+    # given
+    variant_global_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    event_type = WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL
+
+    webhook = subscription_webhook(PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL, event_type)
+
+    deferred_payload_data = DeferredPayloadData(
+        subscribable_object_data={
+            "variant_id": variant.id,
+            "channel_slug": channel_USD.slug,
+        },
+        requestor_model_name="account.user",
+        requestor_object_id=staff_user.pk,
+        request_time=None,
+    )
+    delivery = EventDelivery(
+        event_type=event_type,
+        webhook=webhook,
+        status=EventDeliveryStatus.PENDING,
+    )
+    delivery.save()
+
+    # when
+    generate_deferred_payloads(
+        event_delivery_ids=[delivery.pk],
+        deferred_payload_data=asdict(deferred_payload_data),
+    )
+
+    # then
+    delivery.refresh_from_db()
+    assert delivery.payload
+
+    payload = json.loads(delivery.payload.get_payload())
+    assert payload == {
+        "productVariant": {"id": variant_global_id},
+        "channel": {"slug": channel_USD.slug},
     }
 
     assert mocked_send_webhook_request_async.call_count == 1

--- a/saleor/webhook/transport/utils.py
+++ b/saleor/webhook/transport/utils.py
@@ -41,6 +41,7 @@ from ...core.utils import build_absolute_uri
 from ...core.utils.json_serializer import CustomJsonEncoder
 from ...core.utils.url import sanitize_url_for_logging
 from ...product.interface import VariantDiscountedPriceChange
+from ...warehouse.interface import VariantChannelStockInfo
 from .. import observability
 from ..const import APP_ID_PREFIX
 from ..event_types import WebhookEventAsyncType
@@ -107,6 +108,18 @@ class DeferredPayloadData:
 DEFERRED_SUBSCRIBABLE_OBJECT_MAP: dict[str, type] = {
     WebhookEventAsyncType.PRODUCT_VARIANT_DISCOUNTED_PRICE_UPDATED: (
         VariantDiscountedPriceChange
+    ),
+    WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL: (
+        VariantChannelStockInfo
+    ),
+    WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL: (
+        VariantChannelStockInfo
+    ),
+    WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT: (
+        VariantChannelStockInfo
+    ),
+    WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT: (
+        VariantChannelStockInfo
     ),
 }
 

--- a/saleor/webhook/utils.py
+++ b/saleor/webhook/utils.py
@@ -152,3 +152,26 @@ def calculate_webhooks_for_multiple_events(
         if event not in active_event_map:
             active_event_map[event] = set()
     return active_event_map
+
+
+def filter_webhooks_for_channel(
+    webhooks: Iterable[Webhook],
+    channel_slug: str,
+) -> list[Webhook]:
+    """Return webhooks whose subscription query allows the given channel.
+
+    Webhooks without a subscription query, or whose subscription query has no
+    channel filter, are passed through unchanged.
+    """
+    filtered: list[Webhook] = []
+    for webhook in webhooks:
+        if not webhook.subscription_query:
+            filtered.append(webhook)
+            continue
+        filterable_channel_slugs = list(webhook.filterable_channel_slugs)
+        if not filterable_channel_slugs:
+            filtered.append(webhook)
+            continue
+        if channel_slug in filterable_channel_slugs:
+            filtered.append(webhook)
+    return filtered


### PR DESCRIPTION
Define 4 new events:
- `PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL`
- `PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL`
- `PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT`
- `PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT`

💡 
This PR is only adding the webhooks,  
The events will be called in case the stock for given variant changed.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
