### PR TITLE
Release 3.22.48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.47",
+  "version": "3.22.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.47",
+      "version": "3.22.48",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.47",
+  "version": "3.22.48",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.22.47"
+version = "3.22.48"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.47"
+__version__ = "3.22.48"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2544,7 +2544,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.22.47"
+version = "3.22.48"
 source = { virtual = "." }
 dependencies = [
     { name = "adyen", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
* Release 3.22.48 (a66a1fd3f3)
* Introduce maximum file size limit for uploaded images (#19088) (92584be3c1)
* fix(graphql): increase mutation limit to 4 (#19097) (9dfe6f21f4)
* fix(graphql): missing error handling when no channel in DB (#19082) (de34a8bc63)
* fix(accounts): missing validations for accountRegister (#19083) (d6824a1953)
* Fix a possible crash that could happen when channel would be deleted (#19015) (#19041) (c5af6d858f)
* feat(graphql): add additional metrics (#19063) (f12f7b7f2f)
* feat(graphql): mark slow spans as errored (#19059) (ccdfb07cad)
