### PR TITLE
Trigger channel stock events helpers

### DIFF
--- a/saleor/warehouse/channel_stock_availability.py
+++ b/saleor/warehouse/channel_stock_availability.py
@@ -1,0 +1,167 @@
+from collections import defaultdict
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from django.db.models import Exists, OuterRef
+
+from . import WarehouseClickAndCollectOption
+from .interface import VariantChannelStockInfo
+from .models import ChannelWarehouse, Stock, Warehouse
+from .webhooks.channel_stock_events import (
+    trigger_product_variant_back_in_stock_for_click_and_collect,
+    trigger_product_variant_back_in_stock_in_channel,
+    trigger_product_variant_out_of_stock_for_click_and_collect,
+    trigger_product_variant_out_of_stock_in_channel,
+)
+
+if TYPE_CHECKING:
+    from django.db.models import QuerySet
+
+    from ..account.models import User
+    from ..app.models import App
+    from ..site.models import SiteSettings
+    from ..webhook.models import Webhook
+
+
+CC_OPTIONS = [
+    WarehouseClickAndCollectOption.LOCAL_STOCK,
+    WarehouseClickAndCollectOption.ALL_WAREHOUSES,
+]
+
+
+def trigger_out_of_stock_in_channel_events(
+    stock: Stock,
+    site_settings: "SiteSettings",
+    requestor: "User | App | None" = None,
+    webhooks: "QuerySet[Webhook] | None" = None,
+) -> None:
+    """Fire channel-scoped OUT_OF_STOCK events for `stock`'s variant.
+
+    For each channel where `stock`'s warehouse belongs, fires
+    OUT_OF_STOCK_IN_CHANNEL (for regular warehouses) or
+    OUT_OF_STOCK_FOR_CLICK_AND_COLLECT (for C&C warehouses) when no other
+    warehouse of the same kind in that channel has remaining availability.
+    Call after `stock` has just reached 0 available.
+    """
+    _trigger_channel_stock_events(
+        stock,
+        site_settings,
+        requestor,
+        webhooks,
+        cc_trigger=trigger_product_variant_out_of_stock_for_click_and_collect,
+        non_cc_trigger=trigger_product_variant_out_of_stock_in_channel,
+    )
+
+
+def trigger_back_in_stock_in_channel_events(
+    stock: Stock,
+    site_settings: "SiteSettings",
+    requestor: "User | App | None" = None,
+    webhooks: "QuerySet[Webhook] | None" = None,
+) -> None:
+    """Fire channel-scoped BACK_IN_STOCK events for `stock`'s variant.
+
+    For each channel where `stock`'s warehouse belongs, fires
+    BACK_IN_STOCK_IN_CHANNEL (for regular warehouses) or
+    BACK_IN_STOCK_FOR_CLICK_AND_COLLECT (for C&C warehouses) when no other
+    warehouse of the same kind in that channel has availability — i.e. `stock`
+    is the first one back. Call after `stock` has just risen above 0 available.
+    """
+    _trigger_channel_stock_events(
+        stock,
+        site_settings,
+        requestor,
+        webhooks,
+        cc_trigger=trigger_product_variant_back_in_stock_for_click_and_collect,
+        non_cc_trigger=trigger_product_variant_back_in_stock_in_channel,
+    )
+
+
+def _trigger_channel_stock_events(
+    stock: Stock,
+    site_settings: "SiteSettings",
+    requestor: "User | App | None",
+    webhooks: "QuerySet[Webhook] | None",
+    cc_trigger,
+    non_cc_trigger,
+) -> None:
+    is_cc = _is_click_and_collect_warehouse(stock)
+    trigger = cc_trigger if is_cc else non_cc_trigger
+    channel_slugs = _get_channels_without_other_available_warehouses(stock, is_cc)
+    for channel_slug in channel_slugs:
+        trigger(
+            VariantChannelStockInfo(
+                variant_id=stock.product_variant_id,
+                channel_slug=channel_slug,
+            ),
+            site_settings,
+            requestor=requestor,
+            webhooks=webhooks,
+        )
+
+
+def _is_click_and_collect_warehouse(stock: Stock) -> bool:
+    return stock.warehouse.click_and_collect_option in CC_OPTIONS
+
+
+def _get_channels_without_other_available_warehouses(
+    stock: Stock, is_cc: bool
+) -> list[str]:
+    """Return slugs of channels with no other warehouse having availability.
+
+    Returns warehouses of the same kind as `stock.warehouse` (C&C when
+    `is_cc` is True, otherwise regular). A channel is included when every such
+    warehouse in it — other than `stock.warehouse` — has zero available quantity
+    for `stock`'s variant.
+    """
+    channel_pairs: list[tuple[int, str]] = list(
+        ChannelWarehouse.objects.filter(warehouse_id=stock.warehouse_id).values_list(
+            "channel_id", "channel__slug"
+        )
+    )
+    if not channel_pairs:
+        return []
+    channel_ids = [channel[0] for channel in channel_pairs]
+
+    cc_options = CC_OPTIONS if is_cc else [WarehouseClickAndCollectOption.DISABLED]
+    channel_warehouses = ChannelWarehouse.objects.filter(
+        channel_id__in=channel_ids,
+    )
+    warehouses = Warehouse.objects.filter(
+        Exists(channel_warehouses.filter(warehouse_id=OuterRef("pk"))),
+        click_and_collect_option__in=cc_options,
+    ).exclude(pk=stock.warehouse_id)
+    available_by_warehouse: dict[UUID, int] = dict(
+        Stock.objects.filter(
+            Exists(warehouses.filter(pk=OuterRef("warehouse_id"))),
+            product_variant_id=stock.product_variant_id,
+        )
+        .annotate_available_quantity()
+        .values_list("warehouse_id", "available_quantity")
+    )
+
+    warehouse_id_to_channel_map = _get_warehouse_id_to_channels_map(
+        channel_ids, list(available_by_warehouse.keys())
+    )
+    available_qty_per_channel: dict[int, int] = defaultdict(int)
+    for warehouse_id, available_quantity in available_by_warehouse.items():
+        for channel_id in warehouse_id_to_channel_map.get(warehouse_id, []):
+            available_qty_per_channel[channel_id] += max(available_quantity, 0)
+
+    return [
+        slug
+        for channel_id, slug in channel_pairs
+        if available_qty_per_channel.get(channel_id, 0) == 0
+    ]
+
+
+def _get_warehouse_id_to_channels_map(
+    channel_ids: list[int], warehouse_ids: list[UUID]
+) -> dict[UUID, list[int]]:
+    warehouse_to_channels: dict[UUID, list[int]] = defaultdict(list)
+    for channel_id, warehouse_id in ChannelWarehouse.objects.filter(
+        warehouse_id__in=warehouse_ids,
+        channel_id__in=channel_ids,
+    ).values_list("channel_id", "warehouse_id"):
+        warehouse_to_channels[warehouse_id].append(channel_id)
+    return warehouse_to_channels

--- a/saleor/warehouse/channel_stock_availability.py
+++ b/saleor/warehouse/channel_stock_availability.py
@@ -41,16 +41,25 @@ def trigger_out_of_stock_in_channel_events(
     OUT_OF_STOCK_IN_CHANNEL (for regular warehouses) or
     OUT_OF_STOCK_FOR_CLICK_AND_COLLECT (for C&C warehouses) when no other
     warehouse of the same kind in that channel has remaining availability.
+
     Call after `stock` has just reached 0 available.
     """
-    _trigger_channel_stock_events(
-        stock,
-        site_settings,
-        requestor,
-        webhooks,
-        cc_trigger=trigger_product_variant_out_of_stock_for_click_and_collect,
-        non_cc_trigger=trigger_product_variant_out_of_stock_in_channel,
-    )
+    is_cc = _is_click_and_collect_warehouse(stock)
+    # trigger for channel where there is no availability in other warehouses of
+    # the same kind (C&C or non-C&C)
+    for channel_slug in _get_channels_without_other_available_warehouses(stock, is_cc):
+        stock_info = VariantChannelStockInfo(
+            variant_id=stock.product_variant_id,
+            channel_slug=channel_slug,
+        )
+        if is_cc:
+            trigger_product_variant_out_of_stock_for_click_and_collect(
+                stock_info, site_settings, requestor=requestor, webhooks=webhooks
+            )
+        else:
+            trigger_product_variant_out_of_stock_in_channel(
+                stock_info, site_settings, requestor=requestor, webhooks=webhooks
+            )
 
 
 def trigger_back_in_stock_in_channel_events(
@@ -65,39 +74,26 @@ def trigger_back_in_stock_in_channel_events(
     BACK_IN_STOCK_IN_CHANNEL (for regular warehouses) or
     BACK_IN_STOCK_FOR_CLICK_AND_COLLECT (for C&C warehouses) when no other
     warehouse of the same kind in that channel has availability — i.e. `stock`
-    is the first one back. Call after `stock` has just risen above 0 available.
+    is the first one back.
+
+    Call after `stock` has just risen above 0 available.
     """
-    _trigger_channel_stock_events(
-        stock,
-        site_settings,
-        requestor,
-        webhooks,
-        cc_trigger=trigger_product_variant_back_in_stock_for_click_and_collect,
-        non_cc_trigger=trigger_product_variant_back_in_stock_in_channel,
-    )
-
-
-def _trigger_channel_stock_events(
-    stock: Stock,
-    site_settings: "SiteSettings",
-    requestor: "User | App | None",
-    webhooks: "QuerySet[Webhook] | None",
-    cc_trigger,
-    non_cc_trigger,
-) -> None:
     is_cc = _is_click_and_collect_warehouse(stock)
-    trigger = cc_trigger if is_cc else non_cc_trigger
-    channel_slugs = _get_channels_without_other_available_warehouses(stock, is_cc)
-    for channel_slug in channel_slugs:
-        trigger(
-            VariantChannelStockInfo(
-                variant_id=stock.product_variant_id,
-                channel_slug=channel_slug,
-            ),
-            site_settings,
-            requestor=requestor,
-            webhooks=webhooks,
+    # when no other warehouse of the same kind (C&C or non-C&C) in that channel
+    # has stock availability is the first one back, and event should be triggered
+    for channel_slug in _get_channels_without_other_available_warehouses(stock, is_cc):
+        stock_info = VariantChannelStockInfo(
+            variant_id=stock.product_variant_id,
+            channel_slug=channel_slug,
         )
+        if is_cc:
+            trigger_product_variant_back_in_stock_for_click_and_collect(
+                stock_info, site_settings, requestor=requestor, webhooks=webhooks
+            )
+        else:
+            trigger_product_variant_back_in_stock_in_channel(
+                stock_info, site_settings, requestor=requestor, webhooks=webhooks
+            )
 
 
 def _is_click_and_collect_warehouse(stock: Stock) -> bool:

--- a/saleor/warehouse/tests/test_channel_stock_availability.py
+++ b/saleor/warehouse/tests/test_channel_stock_availability.py
@@ -1,0 +1,324 @@
+from .. import WarehouseClickAndCollectOption
+from ..channel_stock_availability import (
+    trigger_back_in_stock_in_channel_events,
+    trigger_out_of_stock_in_channel_events,
+)
+from ..interface import VariantChannelStockInfo
+from ..models import Allocation, Stock, Warehouse
+
+OUT_IN_CHANNEL = (
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_in_channel"
+)
+BACK_IN_CHANNEL = (
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_back_in_stock_in_channel"
+)
+OUT_CC = (
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_for_click_and_collect"
+)
+BACK_CC = (
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_back_in_stock_for_click_and_collect"
+)
+
+
+def test_out_of_stock_fires_when_only_warehouse_in_bucket(
+    variant, warehouse, channel_USD, site_settings, mocker
+):
+    # given - single non-C&C warehouse in the channel, stock just hit 0
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_out_cc = mocker.patch(OUT_CC)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=0
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events(stock, site_settings)
+
+    # then
+    info = mocked_out.call_args.args[0]
+    assert info == VariantChannelStockInfo(
+        variant_id=variant.id, channel_slug=channel_USD.slug
+    )
+    mocked_out_cc.assert_not_called()
+
+
+def test_out_of_stock_does_not_fire_when_another_warehouse_has_stock(
+    variant, warehouse, channel_USD, address, site_settings, mocker
+):
+    # given - second non-C&C warehouse in same channel still has availability
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=0
+    )
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=5)
+
+    # when
+    trigger_out_of_stock_in_channel_events(stock, site_settings)
+
+    # then
+    mocked_out.assert_not_called()
+
+
+def test_out_of_stock_fires_even_when_cc_warehouse_in_channel_has_stock(
+    variant, warehouse, channel_USD, address, site_settings, mocker
+):
+    # given - non-C&C stock at 0; C&C warehouse with stock must not block event
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_out_cc = mocker.patch(OUT_CC)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=0
+    )
+    cc_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="cc",
+        slug="cc",
+        click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+    )
+    cc_warehouse.channels.add(channel_USD)
+    Stock.objects.create(product_variant=variant, warehouse=cc_warehouse, quantity=5)
+
+    # when
+    trigger_out_of_stock_in_channel_events(stock, site_settings)
+
+    # then - non-C&C bucket is empty, event fires; C&C event is not raised
+    mocked_out.assert_called_once()
+    mocked_out_cc.assert_not_called()
+
+
+def test_out_of_stock_in_cc_warehouse_fires_click_and_collect_event(
+    variant, channel_USD, address, site_settings, mocker
+):
+    # given - C&C-only warehouse, stock just hit 0
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_out_cc = mocker.patch(OUT_CC)
+    cc_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="cc-only",
+        slug="cc-only",
+        click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+    )
+    cc_warehouse.channels.add(channel_USD)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=cc_warehouse, quantity=0
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events(stock, site_settings)
+
+    # then
+    info = mocked_out_cc.call_args.args[0]
+    assert info.channel_slug == channel_USD.slug
+    mocked_out.assert_not_called()
+
+
+def test_back_in_stock_fires_when_all_other_warehouses_in_bucket_are_empty(
+    variant, warehouse, channel_USD, address, site_settings, mocker
+):
+    # given - other non-C&C warehouse exists but has zero available
+    mocked_back = mocker.patch(BACK_IN_CHANNEL)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=10
+    )
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=0)
+
+    # when
+    trigger_back_in_stock_in_channel_events(stock, site_settings)
+
+    # then
+    mocked_back.assert_called_once()
+
+
+def test_back_in_stock_does_not_fire_when_another_warehouse_already_has_stock(
+    variant, warehouse, channel_USD, address, site_settings, mocker
+):
+    # given - another warehouse already has stock, so this isn't the "first back"
+    mocked_back = mocker.patch(BACK_IN_CHANNEL)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=10
+    )
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=4)
+
+    # when
+    trigger_back_in_stock_in_channel_events(stock, site_settings)
+
+    # then
+    mocked_back.assert_not_called()
+
+
+def test_does_not_fire_when_warehouse_belongs_to_no_channels(
+    variant, address, site_settings, mocker
+):
+    # given - warehouse not attached to any channel
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    orphan = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="orphan",
+        slug="orphan",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    stock = Stock.objects.create(product_variant=variant, warehouse=orphan, quantity=0)
+
+    # when
+    trigger_out_of_stock_in_channel_events(stock, site_settings)
+
+    # then
+    mocked_out.assert_not_called()
+
+
+def test_fires_only_for_channels_whose_bucket_is_empty(
+    variant, warehouse, channel_USD, channel_PLN, address, site_settings, mocker
+):
+    # given - warehouse belongs to two channels; only one has another warehouse
+    # with remaining stock
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    warehouse.channels.add(channel_PLN)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=0
+    )
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other-usd",
+        slug="other-usd",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=5)
+
+    # when
+    trigger_out_of_stock_in_channel_events(stock, site_settings)
+
+    # then - PLN bucket is empty (only `warehouse`), USD has another with stock
+    mocked_out.assert_called_once()
+    info = mocked_out.call_args.args[0]
+    assert info.channel_slug == channel_PLN.slug
+
+
+def test_out_of_stock_fires_when_other_warehouse_has_only_fully_allocated_stock(
+    variant, warehouse, channel_USD, address, site_settings, order_line, mocker
+):
+    # given - other warehouse has quantity but everything is allocated
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=0
+    )
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    other_stock = Stock.objects.create(
+        product_variant=variant, warehouse=other_warehouse, quantity=5
+    )
+    Allocation.objects.create(
+        order_line=order_line, stock=other_stock, quantity_allocated=5
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events(stock, site_settings)
+
+    # then - other stock has 0 available -> event fires
+    mocked_out.assert_called_once()
+
+
+def test_out_of_stock_ignores_stocks_of_other_variants_in_same_bucket(
+    variant,
+    product_with_two_variants,
+    warehouse,
+    channel_USD,
+    address,
+    site_settings,
+    mocker,
+):
+    # given - other warehouse has stock for a *different* variant
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=0
+    )
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    other_variant = product_with_two_variants.variants.first()
+    Stock.objects.create(
+        product_variant=other_variant, warehouse=other_warehouse, quantity=10
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events(stock, site_settings)
+
+    # then - other variant's stock is irrelevant; bucket is empty for tested variant
+    mocked_out.assert_called_once()
+
+
+def test_out_of_stock_ignores_warehouse_stock_attached_to_different_channel(
+    variant, warehouse, channel_USD, channel_PLN, address, site_settings, mocker
+):
+    # given - other warehouse with stock exists, but only in a different channel
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=0
+    )
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="pln-only",
+        slug="pln-only",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_PLN)
+    Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=5)
+
+    # when
+    trigger_out_of_stock_in_channel_events(stock, site_settings)
+
+    # then - the USD bucket has no other warehouses, event fires
+    mocked_out.assert_called_once()
+    info = mocked_out.call_args.args[0]
+    assert info.channel_slug == channel_USD.slug
+
+
+def test_trigger_forwards_site_settings_requestor_and_webhooks(
+    variant, warehouse, channel_USD, site_settings, mocker
+):
+    # given
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=0
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events(stock, site_settings)
+
+    # then
+    args, kwargs = mocked_out.call_args
+    assert args[1] is site_settings
+    assert kwargs["requestor"] is None
+    assert kwargs["webhooks"] is None


### PR DESCRIPTION
Add helpers for out of stock channel events.

[Explain](https://explain.dalibo.com/plan/3dgb61274e79c312) for `available_by_warehouse` query.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
