### PR TITLE
Allow metadata crud for STAFF for apps

### DIFF
--- a/saleor/graphql/csv/tests/queries/test_export_file.py
+++ b/saleor/graphql/csv/tests/queries/test_export_file.py
@@ -276,3 +276,36 @@ def test_query_export_file_with_invalid_object_type(
     )
     content = get_graphql_content(response)
     assert content["data"]["exportFile"] is None
+
+
+def test_query_export_file_user_field_denied_for_app_with_only_manage_staff(
+    app_api_client,
+    user_export_file,
+    user_export_event,
+    permission_manage_products,
+    permission_manage_staff,
+):
+    # given
+    # MANAGE_STAFF must NOT grant an app access to the user fields on
+    # ExportFile/ExportEvent. Only MANAGE_STAFF + MANAGE_USERS scopes for apps
+    # are allowed for staff metadata mutations; this guard prevents app
+    # callers from leaking the staff user identity through CSV export records.
+    query = EXPORT_FILE_QUERY
+    variables = {"id": graphene.Node.to_global_id("ExportFile", user_export_file.pk)}
+
+    # when
+    response = app_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_staff],
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    data = content["data"]["exportFile"]
+    assert data["user"] is None
+    assert len(data["events"]) == 1
+    assert data["events"][0]["user"] is None
+    error_paths = {tuple(error["path"]) for error in content["errors"]}
+    assert ("exportFile", "user") in error_paths
+    assert ("exportFile", "events", 0, "user") in error_paths

--- a/saleor/graphql/csv/tests/queries/test_export_file.py
+++ b/saleor/graphql/csv/tests/queries/test_export_file.py
@@ -306,6 +306,14 @@ def test_query_export_file_user_field_denied_for_app_with_only_manage_staff(
     assert data["user"] is None
     assert len(data["events"]) == 1
     assert data["events"][0]["user"] is None
-    error_paths = {tuple(error["path"]) for error in content["errors"]}
-    assert ("exportFile", "user") in error_paths
-    assert ("exportFile", "events", 0, "user") in error_paths
+
+    permission_denied_msg = (
+        "To access this path, you need one of the following permissions: "
+        "MANAGE_STAFF, OWNER"
+    )
+    errors = content["errors"]
+    user_errors = [e for e in errors if e["path"][-1] == "user"]
+    assert len(user_errors) == 2
+    for error in user_errors:
+        assert error["extensions"]["exception"]["code"] == "PermissionDenied"
+        assert error["message"] == permission_denied_msg

--- a/saleor/graphql/discount/tests/queries/test_promotion.py
+++ b/saleor/graphql/discount/tests/queries/test_promotion.py
@@ -407,3 +407,32 @@ def test_query_promotion_events(
             event_data["ruleId"] = db_event.parameters.get("rule_id")
 
         assert event_data in events
+
+
+def test_query_promotion_event_created_by_hidden_for_app_with_only_manage_staff(
+    promotion_events,
+    app_api_client,
+    permission_manage_discounts,
+    permission_manage_staff,
+):
+    # given
+    # MANAGE_STAFF must NOT, on its own, expose a PromotionEvent's createdBy
+    # user to an app caller. The resolver returns None when the requestor is
+    # not the owner and lacks an effective MANAGE_STAFF scope (apps cannot
+    # use MANAGE_STAFF as a general-purpose pass-through).
+    promotion = promotion_events[0].promotion
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    variables = {"id": promotion_id}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_PROMOTION_BY_ID_WITH_EVENTS,
+        variables,
+        permissions=(permission_manage_discounts, permission_manage_staff),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    events = content["data"]["promotion"]["events"]
+    assert len(events) == promotion.events.count()
+    assert all(event["createdBy"] is None for event in events)

--- a/saleor/graphql/giftcard/tests/queries/test_gift_card.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_card.py
@@ -549,11 +549,16 @@ def test_query_gift_card_event_user_field_denied_for_app_with_only_manage_staff(
     events_data = content["data"]["giftCard"]["events"]
     assert len(events_data) == gift_card.events.count()
     assert all(event["user"] is None for event in events_data)
-    error_paths = {tuple(error["path"]) for error in content["errors"]}
-    assert any(
-        path[:2] == ("giftCard", "events") and path[-1] == "user"
-        for path in error_paths
+
+    permission_denied_msg = (
+        "To access this path, you need one of the following permissions: "
+        "MANAGE_USERS, MANAGE_STAFF, OWNER"
     )
+    user_errors = [e for e in content["errors"] if e["path"][-1] == "user"]
+    assert len(user_errors) == len(events_data)
+    for error in user_errors:
+        assert error["extensions"]["exception"]["code"] == "PermissionDenied"
+        assert error["message"] == permission_denied_msg
 
 
 def test_query_gift_card_event_with_removed_app(

--- a/saleor/graphql/giftcard/tests/queries/test_gift_card.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_card.py
@@ -518,6 +518,44 @@ def test_query_gift_card_events(
     assert events_data[1]["oldExpiryDate"] == parameters["old_expiry_date"].isoformat()
 
 
+def test_query_gift_card_event_user_field_denied_for_app_with_only_manage_staff(
+    app_api_client,
+    gift_card,
+    gift_card_event,
+    permission_manage_gift_card,
+    permission_manage_apps,
+    permission_manage_staff,
+):
+    # given
+    # MANAGE_STAFF must NOT, on its own, grant an app access to the user field
+    # on a GiftCardEvent. Only MANAGE_USERS (or being the owner) does.
+    # Without this guard, an app holding MANAGE_STAFF would leak the staff
+    # user that triggered the event.
+    variables = {"id": graphene.Node.to_global_id("GiftCard", gift_card.pk)}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_GIFT_CARD_EVENTS,
+        variables,
+        permissions=[
+            permission_manage_gift_card,
+            permission_manage_apps,
+            permission_manage_staff,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    events_data = content["data"]["giftCard"]["events"]
+    assert len(events_data) == gift_card.events.count()
+    assert all(event["user"] is None for event in events_data)
+    error_paths = {tuple(error["path"]) for error in content["errors"]}
+    assert any(
+        path[:2] == ("giftCard", "events") and path[-1] == "user"
+        for path in error_paths
+    )
+
+
 def test_query_gift_card_event_with_removed_app(
     staff_api_client,
     removed_app,

--- a/saleor/graphql/meta/mutations/base.py
+++ b/saleor/graphql/meta/mutations/base.py
@@ -20,7 +20,6 @@ from ...core.context import BaseContext, ChannelContext, SyncWebhookControlConte
 from ...core.mutations import BaseMutation
 from ...core.utils import from_global_id_or_error
 from ..extra_methods import TYPE_EXTRA_METHODS
-from ..permissions import AccountPermissions
 from ..types import ObjectWithMetadata
 from .utils import get_valid_metadata_instance
 
@@ -154,11 +153,6 @@ class BaseMetadataMutation(BaseMutation):
 
     @classmethod
     def check_permissions(cls, context, permissions=None, **data):  # type: ignore[override]
-        is_app = bool(getattr(context, "app", None))
-        if is_app and permissions and AccountPermissions.MANAGE_STAFF in permissions:
-            raise PermissionDenied(
-                message="Apps are not allowed to perform this mutation."
-            )
         return super().check_permissions(context, permissions)
 
     @classmethod

--- a/saleor/graphql/meta/mutations/base.py
+++ b/saleor/graphql/meta/mutations/base.py
@@ -152,10 +152,6 @@ class BaseMetadataMutation(BaseMutation):
         return graphene_type._meta.model
 
     @classmethod
-    def check_permissions(cls, context, permissions=None, **data):  # type: ignore[override]
-        return super().check_permissions(context, permissions)
-
-    @classmethod
     @allow_writer()
     def mutate(cls, root, info: ResolveInfo, **data):
         try:

--- a/saleor/graphql/meta/tests/mutations/test_account.py
+++ b/saleor/graphql/meta/tests/mutations/test_account.py
@@ -6,7 +6,7 @@ import pytest
 from .....account.error_codes import AccountErrorCode
 from .....account.models import User
 from .....core.error_codes import MetadataErrorCode
-from ....tests.utils import assert_no_permission
+from ....tests.utils import assert_no_permission, get_graphql_content
 from . import (
     PRIVATE_KEY,
     PRIVATE_VALUE,
@@ -1334,6 +1334,106 @@ def test_add_private_metadata_for_staff_as_app_no_permission(
 
     # then
     assert_no_permission(response)
+
+
+def test_add_public_metadata_for_staff_as_app(
+    app_api_client, permission_manage_staff, admin_user
+):
+    # given
+    app_api_client.app.permissions.add(permission_manage_staff)
+    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "input": [{"key": PUBLIC_KEY, "value": PUBLIC_VALUE}],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        UPDATE_PUBLIC_METADATA_MUTATION % "User",
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    item = content["data"]["updateMetadata"]["item"]
+    assert item["id"] == admin_id
+    assert {"key": PUBLIC_KEY, "value": PUBLIC_VALUE} in item["metadata"]
+
+
+def test_add_private_metadata_for_staff_as_app(
+    app_api_client, permission_manage_staff, admin_user
+):
+    # given
+    app_api_client.app.permissions.add(permission_manage_staff)
+    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "input": [{"key": PRIVATE_KEY, "value": PRIVATE_VALUE}],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        UPDATE_PRIVATE_METADATA_MUTATION % "User",
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    item = content["data"]["updatePrivateMetadata"]["item"]
+    assert item["id"] == admin_id
+    assert {"key": PRIVATE_KEY, "value": PRIVATE_VALUE} in item["privateMetadata"]
+
+
+def test_delete_public_metadata_for_staff_as_app(
+    app_api_client, permission_manage_staff, admin_user
+):
+    # given
+    app_api_client.app.permissions.add(permission_manage_staff)
+    admin_user.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
+    admin_user.save(update_fields=["metadata"])
+    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "keys": [PUBLIC_KEY],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        DELETE_PUBLIC_METADATA_MUTATION % "User",
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    item = content["data"]["deleteMetadata"]["item"]
+    assert item["id"] == admin_id
+    assert not any(m["key"] == PUBLIC_KEY for m in item["metadata"])
+
+
+def test_delete_private_metadata_for_staff_as_app(
+    app_api_client, permission_manage_staff, admin_user
+):
+    # given
+    app_api_client.app.permissions.add(permission_manage_staff)
+    admin_user.store_value_in_private_metadata({PRIVATE_KEY: PRIVATE_VALUE})
+    admin_user.save(update_fields=["private_metadata"])
+    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "keys": [PRIVATE_KEY],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        DELETE_PRIVATE_METADATA_MUTATION % "User",
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    item = content["data"]["deletePrivateMetadata"]["item"]
+    assert item["id"] == admin_id
+    assert not any(m["key"] == PRIVATE_KEY for m in item["privateMetadata"])
 
 
 def test_add_private_metadata_for_myself_as_customer_no_permission(user_api_client):

--- a/saleor/graphql/meta/tests/mutations/test_account.py
+++ b/saleor/graphql/meta/tests/mutations/test_account.py
@@ -1282,6 +1282,24 @@ def test_add_public_metadata_for_staff_as_app(
     assert {"key": PUBLIC_KEY, "value": PUBLIC_VALUE} in item["metadata"]
 
 
+def test_add_public_metadata_for_staff_as_app_no_permission(app_api_client, admin_user):
+    # given
+    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "input": [{"key": PUBLIC_KEY, "value": PUBLIC_VALUE}],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        UPDATE_PUBLIC_METADATA_MUTATION % "User",
+        variables,
+    )
+
+    # then
+    assert_no_permission(response)
+
+
 def test_add_private_metadata_for_staff_as_app(
     app_api_client, permission_manage_staff, admin_user
 ):
@@ -1304,6 +1322,26 @@ def test_add_private_metadata_for_staff_as_app(
     item = content["data"]["updatePrivateMetadata"]["item"]
     assert item["id"] == admin_id
     assert {"key": PRIVATE_KEY, "value": PRIVATE_VALUE} in item["privateMetadata"]
+
+
+def test_add_private_metadata_for_staff_as_app_no_permission(
+    app_api_client, admin_user
+):
+    # given
+    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "input": [{"key": PRIVATE_KEY, "value": PRIVATE_VALUE}],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        UPDATE_PRIVATE_METADATA_MUTATION % "User",
+        variables,
+    )
+
+    # then
+    assert_no_permission(response)
 
 
 def test_delete_public_metadata_for_staff_as_app(
@@ -1332,6 +1370,28 @@ def test_delete_public_metadata_for_staff_as_app(
     assert not any(m["key"] == PUBLIC_KEY for m in item["metadata"])
 
 
+def test_delete_public_metadata_for_staff_as_app_no_permission(
+    app_api_client, admin_user
+):
+    # given
+    admin_user.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
+    admin_user.save(update_fields=["metadata"])
+    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "keys": [PUBLIC_KEY],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        DELETE_PUBLIC_METADATA_MUTATION % "User",
+        variables,
+    )
+
+    # then
+    assert_no_permission(response)
+
+
 def test_delete_private_metadata_for_staff_as_app(
     app_api_client, permission_manage_staff, admin_user
 ):
@@ -1356,6 +1416,28 @@ def test_delete_private_metadata_for_staff_as_app(
     item = content["data"]["deletePrivateMetadata"]["item"]
     assert item["id"] == admin_id
     assert not any(m["key"] == PRIVATE_KEY for m in item["privateMetadata"])
+
+
+def test_delete_private_metadata_for_staff_as_app_no_permission(
+    app_api_client, admin_user
+):
+    # given
+    admin_user.store_value_in_private_metadata({PRIVATE_KEY: PRIVATE_VALUE})
+    admin_user.save(update_fields=["private_metadata"])
+    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "keys": [PRIVATE_KEY],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        DELETE_PRIVATE_METADATA_MUTATION % "User",
+        variables,
+    )
+
+    # then
+    assert_no_permission(response)
 
 
 def test_add_private_metadata_for_myself_as_customer_no_permission(user_api_client):

--- a/saleor/graphql/meta/tests/mutations/test_account.py
+++ b/saleor/graphql/meta/tests/mutations/test_account.py
@@ -129,11 +129,13 @@ def test_delete_public_metadata_for_staff_address_as_app(
     app_api_client, staff_user, address, permission_manage_staff
 ):
     # given
+    app_api_client.app.permissions.add(permission_manage_staff)
     staff_user.addresses.add(address)
     address.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
     address.save(update_fields=["metadata"])
+    address_id = graphene.Node.to_global_id("Address", address.pk)
     variables = {
-        "id": graphene.Node.to_global_id("Address", address.pk),
+        "id": address_id,
         "keys": [PUBLIC_KEY],
     }
 
@@ -141,11 +143,13 @@ def test_delete_public_metadata_for_staff_address_as_app(
     response = app_api_client.post_graphql(
         DELETE_PUBLIC_METADATA_MUTATION % "Address",
         variables,
-        permissions=[permission_manage_staff],
     )
+    content = get_graphql_content(response)
 
     # then
-    assert_no_permission(response)
+    item = content["data"]["deleteMetadata"]["item"]
+    assert item["id"] == address_id
+    assert not any(m["key"] == PUBLIC_KEY for m in item["metadata"])
 
 
 def test_delete_public_metadata_for_myself_address(staff_api_client, address):
@@ -255,29 +259,6 @@ def test_delete_private_metadata_for_other_staff_as_staff(
     assert admin_user.updated_at > old_updated_at
 
 
-def test_delete_private_metadata_for_staff_as_app_no_permission(
-    app_api_client, permission_manage_staff, admin_user
-):
-    # given
-    admin_user.store_value_in_private_metadata({PRIVATE_KEY: PRIVATE_VALUE})
-    admin_user.save(update_fields=["private_metadata"])
-    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
-    variables = {
-        "id": admin_id,
-        "keys": [PRIVATE_KEY],
-    }
-
-    # when
-    response = app_api_client.post_graphql(
-        DELETE_PRIVATE_METADATA_MUTATION % "User",
-        variables,
-        permissions=[permission_manage_staff],
-    )
-
-    # then
-    assert_no_permission(response)
-
-
 def test_delete_private_metadata_for_myself_as_customer_no_permission(user_api_client):
     # given
     customer = user_api_client.user
@@ -385,11 +366,13 @@ def test_delete_private_metadata_for_staff_address_as_app(
     app_api_client, staff_user, address, permission_manage_staff
 ):
     # given
+    app_api_client.app.permissions.add(permission_manage_staff)
     staff_user.addresses.add(address)
     address.store_value_in_private_metadata({PRIVATE_KEY: PRIVATE_VALUE})
     address.save(update_fields=["private_metadata"])
+    address_id = graphene.Node.to_global_id("Address", address.pk)
     variables = {
-        "id": graphene.Node.to_global_id("Address", address.pk),
+        "id": address_id,
         "keys": [PRIVATE_KEY],
     }
 
@@ -397,11 +380,13 @@ def test_delete_private_metadata_for_staff_address_as_app(
     response = app_api_client.post_graphql(
         DELETE_PRIVATE_METADATA_MUTATION % "Address",
         variables,
-        permissions=[permission_manage_staff],
     )
+    content = get_graphql_content(response)
 
     # then
-    assert_no_permission(response)
+    item = content["data"]["deletePrivateMetadata"]["item"]
+    assert item["id"] == address_id
+    assert not any(m["key"] == PRIVATE_KEY for m in item["privateMetadata"])
 
 
 def test_delete_private_metadata_for_myself_address_as_staff_no_permission(
@@ -514,29 +499,6 @@ def test_delete_public_metadata_for_other_staff_as_staff(
     )
     admin_user.refresh_from_db()
     assert admin_user.updated_at > old_updated_at
-
-
-def test_delete_public_metadata_for_staff_as_app_no_permission(
-    app_api_client, permission_manage_staff, admin_user
-):
-    # given
-    admin_user.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
-    admin_user.save(update_fields=["metadata"])
-    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
-    variables = {
-        "id": admin_id,
-        "keys": [PRIVATE_KEY],
-    }
-
-    # when
-    response = app_api_client.post_graphql(
-        DELETE_PUBLIC_METADATA_MUTATION % "User",
-        variables,
-        permissions=[permission_manage_staff],
-    )
-
-    # then
-    assert_no_permission(response)
 
 
 def test_delete_public_metadata_for_myself_as_customer(user_api_client):
@@ -970,23 +932,26 @@ def test_update_public_metadata_for_staff_address_by_app_with_perm(
     app_api_client, staff_user, address, permission_manage_staff
 ):
     # given
+    app_api_client.app.permissions.add(permission_manage_staff)
     staff_user.addresses.add(address)
     address_id = graphene.Node.to_global_id("Address", address.pk)
-
+    new_value = "NewMetaValue"
     variables = {
         "id": address_id,
-        "input": [{"key": PUBLIC_KEY, "value": "NewMetaValue"}],
+        "input": [{"key": PUBLIC_KEY, "value": new_value}],
     }
 
     # when
     response = app_api_client.post_graphql(
         UPDATE_PUBLIC_METADATA_MUTATION % "Address",
         variables,
-        permissions=[permission_manage_staff],
     )
+    content = get_graphql_content(response)
 
     # then
-    assert_no_permission(response)
+    item = content["data"]["updateMetadata"]["item"]
+    assert item["id"] == address_id
+    assert {"key": PUBLIC_KEY, "value": new_value} in item["metadata"]
 
 
 def test_update_public_metadata_for_staff_address_by_app_without_perm(
@@ -1291,49 +1256,6 @@ def test_add_private_metadata_for_other_staff_as_staff(
     assert item_contains_proper_private_metadata(
         response["data"]["updatePrivateMetadata"]["item"], admin_user, admin_id
     )
-
-
-def test_add_public_metadata_for_staff_as_app_no_permission(
-    app_api_client, permission_manage_staff, admin_user
-):
-    # given
-    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
-    variables = {
-        "id": admin_id,
-        "input": [{"key": PUBLIC_KEY, "value": PUBLIC_VALUE}],
-    }
-
-    # when
-
-    response = app_api_client.post_graphql(
-        UPDATE_PRIVATE_METADATA_MUTATION % "User",
-        variables,
-        permissions=[permission_manage_staff],
-    )
-
-    # then
-    assert_no_permission(response)
-
-
-def test_add_private_metadata_for_staff_as_app_no_permission(
-    app_api_client, permission_manage_staff, admin_user
-):
-    # given
-    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
-    variables = {
-        "id": admin_id,
-        "input": [{"key": PRIVATE_KEY, "value": PRIVATE_VALUE}],
-    }
-
-    # when
-    response = app_api_client.post_graphql(
-        UPDATE_PRIVATE_METADATA_MUTATION % "User",
-        variables,
-        permissions=[permission_manage_staff],
-    )
-
-    # then
-    assert_no_permission(response)
 
 
 def test_add_public_metadata_for_staff_as_app(
@@ -1691,23 +1613,26 @@ def test_update_private_metadata_for_staff_address_by_app_with_perm(
     app_api_client, staff_user, address, permission_manage_staff
 ):
     # given
+    app_api_client.app.permissions.add(permission_manage_staff)
     staff_user.addresses.add(address)
     address_id = graphene.Node.to_global_id("Address", address.pk)
-
+    new_value = "NewMetaValue"
     variables = {
         "id": address_id,
-        "input": [{"key": PRIVATE_KEY, "value": "NewMetaValue"}],
+        "input": [{"key": PRIVATE_KEY, "value": new_value}],
     }
 
     # when
     response = app_api_client.post_graphql(
         UPDATE_PRIVATE_METADATA_MUTATION % "Address",
         variables,
-        permissions=[permission_manage_staff],
     )
+    content = get_graphql_content(response)
 
     # then
-    assert_no_permission(response)
+    item = content["data"]["updatePrivateMetadata"]["item"]
+    assert item["id"] == address_id
+    assert {"key": PRIVATE_KEY, "value": new_value} in item["privateMetadata"]
 
 
 def test_update_private_metadata_for_staff_address_by_app_without_perm(

--- a/saleor/permission/utils.py
+++ b/saleor/permission/utils.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Union
 
 from .auth_filters import AuthorizationFilters, resolve_authorization_filter_fn
-from .enums import BasePermissionEnum
+from .enums import AccountPermissions, BasePermissionEnum
 
 if TYPE_CHECKING:
     from ..account.models import User
@@ -87,6 +87,9 @@ def permission_required(
     if isinstance(requestor, User):
         return requestor.has_perms(perms)
     if requestor:
+        # for now MANAGE_STAFF permission for app is not supported
+        if AccountPermissions.MANAGE_STAFF in perms:
+            return False
         return requestor.has_perms(perms)
     return False
 

--- a/saleor/permission/utils.py
+++ b/saleor/permission/utils.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Union
 
 from .auth_filters import AuthorizationFilters, resolve_authorization_filter_fn
-from .enums import AccountPermissions, BasePermissionEnum
+from .enums import BasePermissionEnum
 
 if TYPE_CHECKING:
     from ..account.models import User
@@ -87,9 +87,6 @@ def permission_required(
     if isinstance(requestor, User):
         return requestor.has_perms(perms)
     if requestor:
-        # for now MANAGE_STAFF permission for app is not supported
-        if AccountPermissions.MANAGE_STAFF in perms:
-            return False
         return requestor.has_perms(perms)
     return False
 


### PR DESCRIPTION
Prior to this change, *all* metadata operations were prohibited for combination of APP (requestor) and STAFF USER (object adding metadata to). Even with `MANAGE_APPS` permission, there was a custom rule to ignore this permission and prevent writing this data.

While the concept is correct in general for staff mutations (e.g. app should not be able to create staff user, because it can extend given permissions), for metadata there is no such risk.

Adding possibility to mutate metadata was a requested feature, that improves building around Saleor.

This PR allows to add/update/delete both public & privata metadata for apps with `MANAGE_STAFF` permission. Essentially, it makes permission model for this mutations *the same* as for user requestors

Port to 3.23 https://github.com/saleor/saleor/pull/19116