### PR TITLE
Block channel stock webhooks when legacy flag is on

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22144,6 +22144,7 @@ enum WebhookErrorCode @doc(category: "Webhooks") {
   MISSING_EVENT
   INVALID_CUSTOM_HEADERS
   INVALID_NOTIFY_WITH_SUBSCRIPTION
+  INVALID_WITH_LEGACY_STOCK_AVAILABILITY
 }
 
 input WebhookCreateInput @doc(category: "Webhooks") {

--- a/saleor/graphql/webhook/mixins.py
+++ b/saleor/graphql/webhook/mixins.py
@@ -1,12 +1,27 @@
+from typing import TYPE_CHECKING
+
 from django.core.exceptions import ValidationError
 
 from ...webhook.error_codes import WebhookErrorCode
 from ...webhook.event_types import WebhookEventAsyncType
 
+if TYPE_CHECKING:
+    from ...site.models import SiteSettings
+
+
+CHANNEL_STOCK_EVENTS = frozenset(
+    {
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+    }
+)
+
 
 class NotifyUserEventValidationMixin:
     @classmethod
-    def validate_events(cls, events):
+    def validate_events(cls, events, site_settings: "SiteSettings"):
         # NOTIFY_USER needs to be the only one event registered per webhook.
         # This solves issue temporarily. NOTIFY_USER will be deprecated in the future.
         if WebhookEventAsyncType.NOTIFY_USER in events and len(events) > 1:
@@ -18,4 +33,20 @@ class NotifyUserEventValidationMixin:
                     )
                 }
             )
+        if (
+            site_settings is not None
+            and site_settings.use_legacy_shipping_zone_stock_availability
+        ):
+            legacy_conflicting = CHANNEL_STOCK_EVENTS.intersection(events)
+            if legacy_conflicting:
+                raise ValidationError(
+                    {
+                        "async_events": ValidationError(
+                            "Channel-scoped stock availability events cannot be "
+                            "used while `useLegacyShippingZoneStockAvailability` "
+                            "is enabled in site settings.",
+                            code=WebhookErrorCode.INVALID_WITH_LEGACY_STOCK_AVAILABILITY.value,
+                        )
+                    }
+                )
         return events

--- a/saleor/graphql/webhook/mutations/webhook_create.py
+++ b/saleor/graphql/webhook/mutations/webhook_create.py
@@ -20,6 +20,7 @@ from ...core.fields import JSONString
 from ...core.mutations import DeprecatedModelMutation
 from ...core.types import BaseInputObjectType, NonNullList, WebhookError
 from ...core.utils import raise_validation_error
+from ...site.dataloaders import get_site_promise
 from .. import enums
 from ..mixins import NotifyUserEventValidationMixin
 from ..subscription_query import SubscriptionQuery
@@ -149,12 +150,18 @@ class WebhookCreate(DeprecatedModelMutation, NotifyUserEventValidationMixin):
                     code=WebhookErrorCode.INVALID_CUSTOM_HEADERS,
                 )
 
-        cls._clean_webhook_events(cleaned_data, subscription_query)
+        site = get_site_promise(info.context).get()
+        cls._clean_webhook_events(cleaned_data, subscription_query, site.settings)
 
         return cleaned_data
 
     @classmethod
-    def _clean_webhook_events(cls, data, subscription_query: SubscriptionQuery | None):
+    def _clean_webhook_events(
+        cls,
+        data,
+        subscription_query: SubscriptionQuery | None,
+        site_settings,
+    ):
         # if `events` field is not empty, use this field. Otherwise get event types
         # from `async_events` and `sync_events`. If the fields are also empty,
         # parse events from `query`.
@@ -165,7 +172,7 @@ class WebhookCreate(DeprecatedModelMutation, NotifyUserEventValidationMixin):
 
         if not events and subscription_query:
             events = subscription_query.events
-        cls.validate_events(events)
+        cls.validate_events(events, site_settings=site_settings)
 
         data["events"] = events
         return data

--- a/saleor/graphql/webhook/mutations/webhook_update.py
+++ b/saleor/graphql/webhook/mutations/webhook_update.py
@@ -12,6 +12,7 @@ from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_WEBHOOKS
 from ...core.fields import JSONString
 from ...core.types import BaseInputObjectType, NonNullList, WebhookError
+from ...site.dataloaders import get_site_promise
 from .. import enums
 from ..mixins import NotifyUserEventValidationMixin
 from ..types import Webhook
@@ -89,10 +90,11 @@ class WebhookUpdate(WebhookCreate, NotifyUserEventValidationMixin):
         error_type_field = "webhook_errors"
 
     @classmethod
-    def save(cls, _info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
+    def save(cls, info: ResolveInfo, instance, cleaned_input, instance_tracker=None):
         instance.save()
         events = set(cleaned_input.get("events", []))
-        cls.validate_events(events)
+        site = get_site_promise(info.context).get()
+        cls.validate_events(events, site_settings=site.settings)
         if events:
             instance.events.all().delete()
             models.WebhookEvent.objects.bulk_create(

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_create.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_create.py
@@ -385,6 +385,159 @@ def test_webhook_create_notify_user_with_another_event(app_api_client):
     assert error["code"] == WebhookErrorCode.INVALID_NOTIFY_WITH_SUBSCRIPTION.name
 
 
+CHANNEL_STOCK_EVENT_CASES = pytest.mark.parametrize(
+    "event_enum",
+    [
+        WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+        WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+        WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+    ],
+)
+
+
+@CHANNEL_STOCK_EVENT_CASES
+def test_webhook_create_channel_stock_event_rejected_with_legacy_flag(
+    event_enum, app_api_client, site_settings
+):
+    # given - legacy stock availability is enabled
+    site_settings.use_legacy_shipping_zone_stock_availability = True
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    variables = {
+        "input": {
+            "name": "channel stock event",
+            "targetUrl": "https://www.example.com",
+            "asyncEvents": [event_enum.name],
+        }
+    }
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_CREATE, variables=variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["webhookCreate"]
+    assert data["webhook"] is None
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "asyncEvents"
+    assert error["code"] == WebhookErrorCode.INVALID_WITH_LEGACY_STOCK_AVAILABILITY.name
+    assert not Webhook.objects.exists()
+
+
+@CHANNEL_STOCK_EVENT_CASES
+def test_webhook_create_channel_stock_event_allowed_without_legacy_flag(
+    event_enum, app_api_client, site_settings
+):
+    # given - legacy stock availability is disabled
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    variables = {
+        "input": {
+            "name": "channel stock event",
+            "targetUrl": "https://www.example.com",
+            "asyncEvents": [event_enum.name],
+        }
+    }
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_CREATE, variables=variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["webhookCreate"]
+    assert data["errors"] == []
+    webhook = Webhook.objects.get()
+    events = webhook.events.all()
+    assert len(events) == 1
+    assert events[0].event_type == event_enum.value
+
+
+CHANNEL_STOCK_SUBSCRIPTION_EVENTS = pytest.mark.parametrize(
+    ("subscription_field", "event_enum"),
+    [
+        (
+            "productVariantOutOfStockInChannel",
+            WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        ),
+        (
+            "productVariantBackInStockInChannel",
+            WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+        ),
+        (
+            "productVariantOutOfStockForClickAndCollect",
+            WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+        ),
+        (
+            "productVariantBackInStockForClickAndCollect",
+            WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+        ),
+    ],
+)
+
+
+def _channel_stock_subscription_query(field: str) -> str:
+    return (
+        f"subscription {{ {field} {{ productVariant {{ id }} channel {{ slug }} }} }}"
+    )
+
+
+@CHANNEL_STOCK_SUBSCRIPTION_EVENTS
+def test_webhook_create_channel_stock_event_via_subscription_rejected_with_legacy_flag(
+    subscription_field, event_enum, app_api_client, site_settings
+):
+    # given - legacy stock availability enabled; event declared via query only
+    site_settings.use_legacy_shipping_zone_stock_availability = True
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    variables = {
+        "input": {
+            "name": "from subscription",
+            "targetUrl": "https://www.example.com",
+            "query": _channel_stock_subscription_query(subscription_field),
+        }
+    }
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_CREATE, variables=variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["webhookCreate"]
+    assert data["webhook"] is None
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["code"] == WebhookErrorCode.INVALID_WITH_LEGACY_STOCK_AVAILABILITY.name
+    assert not Webhook.objects.exists()
+
+
+@CHANNEL_STOCK_SUBSCRIPTION_EVENTS
+def test_webhook_create_channel_stock_event_via_subscription_allowed_without_legacy_flag(
+    subscription_field, event_enum, app_api_client, site_settings
+):
+    # given - legacy stock availability disabled; event declared via query only
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    variables = {
+        "input": {
+            "name": "from subscription",
+            "targetUrl": "https://www.example.com",
+            "query": _channel_stock_subscription_query(subscription_field),
+        }
+    }
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_CREATE, variables=variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["webhookCreate"]
+    assert data["errors"] == []
+    webhook = Webhook.objects.get()
+    events = webhook.events.all()
+    assert len(events) == 1
+    assert events[0].event_type == event_enum.value
+
+
 FILTERABLE_SUBSCRIPTION = """
 subscription {
   orderCreated(channels: [%s]) {

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_update.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_update.py
@@ -338,6 +338,152 @@ def test_webhook_update_notify_user_with_another_event(app_api_client, webhook):
     assert error["code"] == WebhookErrorCode.INVALID_NOTIFY_WITH_SUBSCRIPTION.name
 
 
+CHANNEL_STOCK_EVENT_CASES = pytest.mark.parametrize(
+    "event_enum",
+    [
+        WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+        WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+        WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+    ],
+)
+
+
+@CHANNEL_STOCK_EVENT_CASES
+def test_webhook_update_channel_stock_event_rejected_with_legacy_flag(
+    event_enum, app_api_client, webhook, site_settings
+):
+    # given - legacy stock availability enabled
+    site_settings.use_legacy_shipping_zone_stock_availability = True
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {
+        "id": webhook_id,
+        "input": {"asyncEvents": [event_enum.name]},
+    }
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_UPDATE, variables=variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["webhookUpdate"]
+    assert data["webhook"] is None
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "asyncEvents"
+    assert error["code"] == WebhookErrorCode.INVALID_WITH_LEGACY_STOCK_AVAILABILITY.name
+
+
+@CHANNEL_STOCK_EVENT_CASES
+def test_webhook_update_channel_stock_event_allowed_without_legacy_flag(
+    event_enum, app_api_client, webhook, site_settings
+):
+    # given - legacy stock availability disabled
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {
+        "id": webhook_id,
+        "input": {"asyncEvents": [event_enum.name]},
+    }
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_UPDATE, variables=variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["webhookUpdate"]
+    assert data["errors"] == []
+    webhook.refresh_from_db()
+    events = webhook.events.all()
+    assert len(events) == 1
+    assert events[0].event_type == event_enum.value
+
+
+CHANNEL_STOCK_SUBSCRIPTION_EVENTS = pytest.mark.parametrize(
+    ("subscription_field", "event_enum"),
+    [
+        (
+            "productVariantOutOfStockInChannel",
+            WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        ),
+        (
+            "productVariantBackInStockInChannel",
+            WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
+        ),
+        (
+            "productVariantOutOfStockForClickAndCollect",
+            WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
+        ),
+        (
+            "productVariantBackInStockForClickAndCollect",
+            WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
+        ),
+    ],
+)
+
+
+def _channel_stock_subscription_query(field: str) -> str:
+    return (
+        f"subscription {{ {field} {{ productVariant {{ id }} channel {{ slug }} }} }}"
+    )
+
+
+@CHANNEL_STOCK_SUBSCRIPTION_EVENTS
+def test_webhook_update_channel_stock_event_via_subscription_rejected_with_legacy_flag(
+    subscription_field, event_enum, app_api_client, webhook, site_settings
+):
+    # given - legacy stock availability enabled
+    site_settings.use_legacy_shipping_zone_stock_availability = True
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    previous_events = {event.event_type for event in webhook.events.all()}
+    variables = {
+        "id": webhook_id,
+        "input": {"query": _channel_stock_subscription_query(subscription_field)},
+    }
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_UPDATE, variables=variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["webhookUpdate"]
+    assert data["webhook"] is None
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["code"] == WebhookErrorCode.INVALID_WITH_LEGACY_STOCK_AVAILABILITY.name
+    webhook.refresh_from_db()
+    assert {event.event_type for event in webhook.events.all()} == previous_events
+
+
+@CHANNEL_STOCK_SUBSCRIPTION_EVENTS
+def test_webhook_update_channel_stock_event_via_subscription_allowed_without_legacy_flag(
+    subscription_field, event_enum, app_api_client, webhook, site_settings
+):
+    # given - legacy stock availability disabled
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {
+        "id": webhook_id,
+        "input": {"query": _channel_stock_subscription_query(subscription_field)},
+    }
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_UPDATE, variables=variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["webhookUpdate"]
+    assert data["errors"] == []
+    webhook.refresh_from_db()
+    events = webhook.events.all()
+    assert len(events) == 1
+    assert events[0].event_type == event_enum.value
+
+
 FILTERABLE_SUBSCRIPTION = """
 subscription {
   orderCreated(channels: [%s]) {

--- a/saleor/webhook/error_codes.py
+++ b/saleor/webhook/error_codes.py
@@ -14,6 +14,7 @@ class WebhookErrorCode(Enum):
     MISSING_EVENT = "missing_event"
     INVALID_CUSTOM_HEADERS = "invalid_custom_headers"
     INVALID_NOTIFY_WITH_SUBSCRIPTION = "invalid_notify_with_subscription"
+    INVALID_WITH_LEGACY_STOCK_AVAILABILITY = "invalid_with_legacy_stock_availability"
 
 
 class WebhookDryRunErrorCode(Enum):


### PR DESCRIPTION
Reject webhook create/update requests that subscribe to any of the channel related out and in stock events when settings `use_legacy_shipping_zone_stock_availability` is `True`                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                         

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
