### PR TITLE
Release 3.21.56-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.21.55",
+  "version": "3.21.56-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.21.55",
+      "version": "3.21.56-rc.1",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.21.55",
+  "version": "3.21.56-rc.1",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ help = "Run tests with db reuse to speed up testing time"
 
 [tool.poetry]
 name = "saleor"
-version = "3.21.55"
+version = "3.21.56-rc.1"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.21.55"
+__version__ = "3.21.56-rc.1"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
This creates a release candidate for Django 5.2 upgraded (as 4.2 is EOL)

Allows to perform in-depth regression testing before marking it as final/stable.

<i> Part of https://linear.app/saleor/issue/ENG-1439/ </i>


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
