### PR TITLE
Fix failed request handler in AvataxPlugin

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -610,7 +610,7 @@ def get_checkout_tax_data(
         data, str(checkout_info.checkout.token), config
     )
 
-    if response is None:
+    if not response:
         return response
 
     # Convert `lines` to dict as we can send multiple lines with the same itemCode

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -301,7 +301,7 @@ class DeprecatedAvataxPlugin(BasePlugin):
         if response is None:
             return previous_value
 
-        currency = str(response.get("currencyCode"))
+        currency = response.get("currencyCode") or checkout_info.checkout.currency
         return self._calculate_checkout_shipping(
             checkout_info, currency, response.get("lines", {}), base_shipping_price.net
         )
@@ -502,7 +502,9 @@ class DeprecatedAvataxPlugin(BasePlugin):
         if not taxes_data or "error" in taxes_data:
             return base_value
 
-        currency = taxes_data.get("currencyCode")
+        currency = (
+            taxes_data.get("currencyCode") or base_value.price_with_discounts.currency
+        )
         line_price_with_discounts = None
 
         line = taxes_data.get("lines", {}).get(order_line_id)
@@ -601,7 +603,7 @@ class DeprecatedAvataxPlugin(BasePlugin):
 
     def _calculate_order_shipping(self, order, taxes_data) -> TaxedMoney:
         prices_entered_with_tax = partial(_get_prices_entered_with_tax_for_order, order)
-        currency = taxes_data.get("currencyCode")
+        currency = taxes_data.get("currencyCode") or order.currency
         line = taxes_data.get("lines", {}).get(SHIPPING_ITEM_CODE)
         if line:
             tax = Decimal(line.get("tax", 0.0))

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -2126,6 +2126,45 @@ def test_calculate_checkout_shipping(
     )
 
 
+@patch("saleor.plugins.avatax.get_cached_response_or_fetch")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.DeprecatedAvataxPlugin"])
+def test_calculate_checkout_shipping_when_failed_to_deliver_request(
+    mocked_get_cached_response_or_fetch,
+    checkout_with_item_on_promotion,
+    shipping_zone,
+    address,
+    ship_to_pl_address,
+    site_settings,
+    monkeypatch,
+    plugin_configuration,
+):
+    # given
+    plugin_configuration()
+    monkeypatch.setattr(
+        "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
+        lambda _: {"PC040156": "desc"},
+    )
+    manager = get_plugins_manager(allow_replica=False)
+    site_settings.company_address = address
+    site_settings.save()
+
+    mocked_get_cached_response_or_fetch.return_value = {}
+
+    checkout = checkout_with_item_on_promotion
+    checkout.shipping_address = ship_to_pl_address
+    checkout.shipping_method = shipping_zone.shipping_methods.get()
+    checkout.save()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    # when
+    shipping_price = manager.calculate_checkout_shipping(checkout_info, lines, address)
+
+    # then
+    shipping_price = quantize_price(shipping_price, shipping_price.currency)
+    assert shipping_price == TaxedMoney(net=Money(10, "USD"), gross=Money(10, "USD"))
+
+
 @pytest.mark.vcr
 @pytest.mark.parametrize(
     ("expected_net", "expected_gross", "prices_entered_with_tax"),


### PR DESCRIPTION
I want to merge this change because it fixes the issue where a failed Avatax request was being processed as a correct one. In that case, we were returning the response as an empty dict. The empty dict was treated as a correct response, and later we were incorrectly calling `str(response.get("currencyCode"))`, which produced `"None"` as the currency value.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
