### PR TITLE
Remove 3.20 from supported versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,5 +47,5 @@ The following releases of Saleor are currently supported.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| ≥ 3.20  | :white_check_mark: |
+| ≥ 3.21  | :white_check_mark: |
 | < 3.21  | :x:                |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,4 +48,4 @@ The following releases of Saleor are currently supported.
 | Version | Supported          |
 | ------- | ------------------ |
 | ≥ 3.20  | :white_check_mark: |
-| < 3.20  | :x:                |
+| < 3.21  | :x:                |


### PR DESCRIPTION
Saleor v3.20 is no longer supported, instead we recommend to upgrade to later versions (3.22 or 3.23 are recommended due to v3.21 being planned for removal)



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
