### PR TITLE
Adjust stock mutations

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_variant_stocks_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_stocks_create.py
@@ -4,7 +4,11 @@ import graphene
 from django.core.exceptions import ValidationError
 
 from ....core.tracing import traced_atomic_transaction
+from ....core.utils.events import call_event
 from ....permission.enums import ProductPermissions
+from ....warehouse.channel_stock_availability import (
+    trigger_back_in_stock_in_channel_events_for_stocks,
+)
 from ....warehouse.error_codes import StockErrorCode
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
@@ -14,6 +18,7 @@ from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.mutations import BaseMutation
 from ...core.types import BulkStockError, NonNullList
 from ...plugins.dataloaders import get_plugin_manager_promise
+from ...site.dataloaders import get_site_promise
 from ...warehouse.dataloaders import StocksByProductVariantIdLoader
 from ...warehouse.types import Warehouse
 from ..mutations.product.product_create import StockInput
@@ -65,6 +70,14 @@ class ProductVariantStocksCreate(BaseMutation):
             for stock in new_stocks:
                 cls.call_event(
                     manager.product_variant_back_in_stock, stock, webhooks=webhooks
+                )
+
+            site_settings = get_site_promise(info.context).get().settings
+            if not site_settings.use_legacy_shipping_zone_stock_availability:
+                call_event(
+                    trigger_back_in_stock_in_channel_events_for_stocks,
+                    new_stocks,
+                    site_settings,
                 )
 
         StocksByProductVariantIdLoader(info.context).clear(variant.id)

--- a/saleor/graphql/product/bulk_mutations/product_variant_stocks_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_stocks_delete.py
@@ -2,9 +2,13 @@ import graphene
 from django.core.exceptions import ValidationError
 
 from ....core.tracing import traced_atomic_transaction
+from ....core.utils.events import call_event
 from ....permission.enums import ProductPermissions
 from ....product import models
 from ....warehouse import models as warehouse_models
+from ....warehouse.channel_stock_availability import (
+    trigger_out_of_stock_in_channel_events_for_stocks,
+)
 from ....warehouse.management import delete_stocks
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
@@ -15,6 +19,7 @@ from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, StockError
 from ...core.validators import validate_one_of_args_is_in_mutation
 from ...plugins.dataloaders import get_plugin_manager_promise
+from ...site.dataloaders import get_site_promise
 from ...warehouse.dataloaders import StocksByProductVariantIdLoader
 from ...warehouse.types import Warehouse
 from ..types import ProductVariant
@@ -77,11 +82,22 @@ class ProductVariantStocksDelete(BaseMutation):
         webhooks = get_webhooks_for_event(
             WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK
         )
-        for stock in stocks_to_delete:
+        stocks_to_delete_list = list(stocks_to_delete)
+        for stock in stocks_to_delete_list:
             cls.call_event(
                 manager.product_variant_out_of_stock, stock, webhooks=webhooks
             )
-        delete_stocks([stock.id for stock in stocks_to_delete])
+
+        site_settings = get_site_promise(info.context).get().settings
+        if not site_settings.use_legacy_shipping_zone_stock_availability:
+            # Channel-event queries run on_commit after the deletion is applied,
+            # but the in-memory stock objects are still safe to pass.
+            call_event(
+                trigger_out_of_stock_in_channel_events_for_stocks,
+                stocks_to_delete_list,
+                site_settings,
+            )
+        delete_stocks([stock.id for stock in stocks_to_delete_list])
 
         StocksByProductVariantIdLoader(info.context).clear(variant.id)
 

--- a/saleor/graphql/product/bulk_mutations/product_variant_stocks_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_stocks_update.py
@@ -4,9 +4,14 @@ import graphene
 from django.core.exceptions import ValidationError
 
 from ....core.tracing import traced_atomic_transaction
+from ....core.utils.events import call_event
 from ....permission.enums import ProductPermissions
 from ....product import models
 from ....warehouse import models as warehouse_models
+from ....warehouse.channel_stock_availability import (
+    trigger_back_in_stock_in_channel_events_for_stocks,
+    trigger_out_of_stock_in_channel_events_for_stocks,
+)
 from ....warehouse.management import stock_bulk_update
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
@@ -16,6 +21,7 @@ from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.types import BulkStockError, NonNullList
 from ...core.validators import validate_one_of_args_is_in_mutation
 from ...plugins.dataloaders import get_plugin_manager_promise
+from ...site.dataloaders import get_site_promise
 from ...warehouse.dataloaders import StocksByProductVariantIdLoader
 from ...warehouse.types import Warehouse
 from ..mutations.product.product_create import StockInput
@@ -78,7 +84,10 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
             )
 
             manager = get_plugin_manager_promise(info.context).get()
-            cls.update_or_create_variant_stocks(variant, stocks, warehouses, manager)
+            site_settings = get_site_promise(info.context).get().settings
+            cls.update_or_create_variant_stocks(
+                variant, stocks, warehouses, manager, site_settings
+            )
 
         StocksByProductVariantIdLoader(info.context).clear(variant.id)
 
@@ -87,8 +96,12 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
 
     @classmethod
     @traced_atomic_transaction()
-    def update_or_create_variant_stocks(cls, variant, stocks_data, warehouses, manager):
+    def update_or_create_variant_stocks(
+        cls, variant, stocks_data, warehouses, manager, site_settings
+    ):
         stocks = []
+        back_in_stock_stocks: list[warehouse_models.Stock] = []
+        out_of_stock_stocks: list[warehouse_models.Stock] = []
         webhooks_stock_in = get_webhooks_for_event(
             WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK
         )
@@ -97,6 +110,9 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
         )
         webhooks_stock_update = get_webhooks_for_event(
             WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED
+        )
+        use_legacy_stock_availability = (
+            site_settings.use_legacy_shipping_zone_stock_availability
         )
         for stock_data, warehouse in zip(stocks_data, warehouses, strict=False):
             stock, is_created = warehouse_models.Stock.objects.get_or_create(
@@ -112,6 +128,7 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
                     stock,
                     webhooks=webhooks_stock_in,
                 )
+                back_in_stock_stocks.append(stock)
 
             if stock_data["quantity"] <= 0 or (
                 stock_data["quantity"] - stock.quantity_allocated <= 0
@@ -121,6 +138,7 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
                     stock,
                     webhooks=webhooks_stock_out,
                 )
+                out_of_stock_stocks.append(stock)
 
             stock.quantity = stock_data["quantity"]
             stocks.append(stock)
@@ -131,3 +149,17 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
         )
 
         stock_bulk_update(stocks, ["quantity"])
+
+        if not use_legacy_stock_availability:
+            if back_in_stock_stocks:
+                call_event(
+                    trigger_back_in_stock_in_channel_events_for_stocks,
+                    back_in_stock_stocks,
+                    site_settings,
+                )
+            if out_of_stock_stocks:
+                call_event(
+                    trigger_out_of_stock_in_channel_events_for_stocks,
+                    out_of_stock_stocks,
+                    site_settings,
+                )

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_create.py
@@ -1,5 +1,8 @@
+from unittest import mock
+
 import graphene
 
+from .....warehouse import WarehouseClickAndCollectOption
 from .....warehouse.error_codes import StockErrorCode
 from .....warehouse.models import Stock, Warehouse
 from ....tests.utils import get_graphql_content
@@ -277,3 +280,157 @@ def test_invalidate_stocks_dataloader_on_create_stocks(
 
     # stocks are returned in the second mutation, after dataloader invalidation
     assert len(create_stocks_data["stocks"]) == len(warehouse_ids)
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_back_in_stock_in_channel"
+)
+def test_create_stocks_triggers_back_in_stock_in_channel_for_non_cc_warehouses(
+    mocked_trigger,
+    staff_api_client,
+    variant,
+    warehouses,
+    channel_USD,
+    site_settings,
+    permission_manage_products,
+):
+    # given - creating stocks in two non-C&C warehouses
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    warehouses[0].channels.add(channel_USD)
+    warehouses[1].channels.add(channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    warehouse_ids = [
+        graphene.Node.to_global_id("Warehouse", warehouse.pk)
+        for warehouse in warehouses
+    ]
+    variables = {
+        "variantId": variant_id,
+        "stocks": [
+            {"warehouse": warehouse_ids[0], "quantity": 10},
+            {"warehouse": warehouse_ids[1], "quantity": 5},
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_CREATE_MUTATION,
+        variables=variables,
+        permissions=[permission_manage_products],
+    )
+    get_graphql_content(response)
+
+    # then - fires once per (variant, channel), dedup across the two warehouses
+    mocked_trigger.assert_called_once()
+    stock_info = mocked_trigger.call_args.args[0]
+    assert stock_info.variant_id == variant.id
+    assert stock_info.channel_slug == channel_USD.slug
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_back_in_stock_for_click_and_collect"
+)
+def test_create_stocks_triggers_back_in_stock_for_click_and_collect(
+    mocked_trigger,
+    staff_api_client,
+    variant,
+    channel_USD,
+    address,
+    site_settings,
+    permission_manage_products,
+):
+    # given - creating stocks in two C&C warehouses
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    cc_warehouses = Warehouse.objects.bulk_create(
+        [
+            Warehouse(
+                address=address.get_copy(),
+                name="cc-1",
+                slug="cc-1",
+                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+            ),
+            Warehouse(
+                address=address.get_copy(),
+                name="cc-2",
+                slug="cc-2",
+                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+            ),
+        ]
+    )
+    for warehouse in cc_warehouses:
+        warehouse.channels.add(channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    warehouse_ids = [
+        graphene.Node.to_global_id("Warehouse", warehouse.pk)
+        for warehouse in cc_warehouses
+    ]
+    variables = {
+        "variantId": variant_id,
+        "stocks": [
+            {"warehouse": warehouse_ids[0], "quantity": 10},
+            {"warehouse": warehouse_ids[1], "quantity": 5},
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_CREATE_MUTATION,
+        variables=variables,
+        permissions=[permission_manage_products],
+    )
+    get_graphql_content(response)
+
+    # then
+    mocked_trigger.assert_called_once()
+    stock_info = mocked_trigger.call_args.args[0]
+    assert stock_info.variant_id == variant.id
+    assert stock_info.channel_slug == channel_USD.slug
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_back_in_stock_in_channel"
+)
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_back_in_stock_for_click_and_collect"
+)
+def test_create_stocks_skips_channel_events_when_legacy_flag_enabled(
+    mocked_back_cc,
+    mocked_back,
+    staff_api_client,
+    variant,
+    warehouses,
+    site_settings,
+    permission_manage_products,
+):
+    # given - legacy flag is on; creating stocks in two warehouses
+    site_settings.use_legacy_shipping_zone_stock_availability = True
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    warehouse_ids = [
+        graphene.Node.to_global_id("Warehouse", warehouse.pk)
+        for warehouse in warehouses
+    ]
+    variables = {
+        "variantId": variant_id,
+        "stocks": [
+            {"warehouse": warehouse_ids[0], "quantity": 10},
+            {"warehouse": warehouse_ids[1], "quantity": 5},
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_CREATE_MUTATION,
+        variables=variables,
+        permissions=[permission_manage_products],
+    )
+    get_graphql_content(response)
+
+    # then
+    mocked_back.assert_not_called()
+    mocked_back_cc.assert_not_called()

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_delete.py
@@ -186,9 +186,6 @@ def test_invalidate_stocks_dataloader_on_removing_stocks(
     assert remove_stocks_data["stocks"] == []
 
 
-# --- Channel stock event tests ---
-
-
 @mock.patch(
     "saleor.warehouse.channel_stock_availability"
     ".trigger_product_variant_out_of_stock_in_channel"

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_delete.py
@@ -1,6 +1,9 @@
+from unittest import mock
+
 import graphene
 
 from .....product.error_codes import ProductErrorCode
+from .....warehouse import WarehouseClickAndCollectOption
 from .....warehouse.models import Stock, Warehouse
 from ....tests.utils import get_graphql_content
 
@@ -181,3 +184,148 @@ def test_invalidate_stocks_dataloader_on_removing_stocks(
 
     # stocks are empty in the second mutation
     assert remove_stocks_data["stocks"] == []
+
+
+# --- Channel stock event tests ---
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_in_channel"
+)
+def test_delete_stocks_triggers_out_of_stock_in_channel_for_non_cc_warehouses(
+    mocked_trigger,
+    staff_api_client,
+    variant_with_many_stocks,
+    channel_USD,
+    site_settings,
+    permission_manage_products,
+):
+    # given - `variant_with_many_stocks` has stocks in non-C&C warehouses
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    variant = variant_with_many_stocks
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    stocks = list(variant.stocks.all())
+    for stock in stocks:
+        stock.warehouse.channels.add(channel_USD)
+    warehouse_ids = [
+        graphene.Node.to_global_id("Warehouse", stock.warehouse_id) for stock in stocks
+    ]
+    variables = {"variantId": variant_id, "warehouseIds": warehouse_ids}
+
+    # when
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_DELETE_MUTATION,
+        variables=variables,
+        permissions=[permission_manage_products],
+    )
+    get_graphql_content(response)
+
+    # then - fires once per (variant, channel), dedup across warehouses
+    mocked_trigger.assert_called_once()
+    stock_info = mocked_trigger.call_args.args[0]
+    assert stock_info.variant_id == variant.id
+    assert stock_info.channel_slug == channel_USD.slug
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_for_click_and_collect"
+)
+def test_delete_stocks_triggers_out_of_stock_for_click_and_collect(
+    mocked_trigger,
+    staff_api_client,
+    variant,
+    channel_USD,
+    address,
+    site_settings,
+    permission_manage_products,
+):
+    # given - two C&C warehouses with stocks
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    cc_warehouses = Warehouse.objects.bulk_create(
+        [
+            Warehouse(
+                address=address.get_copy(),
+                name="cc-1",
+                slug="cc-1",
+                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+            ),
+            Warehouse(
+                address=address.get_copy(),
+                name="cc-2",
+                slug="cc-2",
+                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+            ),
+        ]
+    )
+    for warehouse in cc_warehouses:
+        warehouse.channels.add(channel_USD)
+    Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=cc_warehouses[0], quantity=10),
+            Stock(product_variant=variant, warehouse=cc_warehouses[1], quantity=5),
+        ]
+    )
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    warehouse_ids = [
+        graphene.Node.to_global_id("Warehouse", warehouse.pk)
+        for warehouse in cc_warehouses
+    ]
+    variables = {"variantId": variant_id, "warehouseIds": warehouse_ids}
+
+    # when
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_DELETE_MUTATION,
+        variables=variables,
+        permissions=[permission_manage_products],
+    )
+    get_graphql_content(response)
+
+    # then
+    mocked_trigger.assert_called_once()
+    stock_info = mocked_trigger.call_args.args[0]
+    assert stock_info.variant_id == variant.id
+    assert stock_info.channel_slug == channel_USD.slug
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_in_channel"
+)
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_for_click_and_collect"
+)
+def test_delete_stocks_skips_channel_events_when_legacy_flag_enabled(
+    mocked_out_cc,
+    mocked_out,
+    staff_api_client,
+    variant_with_many_stocks,
+    site_settings,
+    permission_manage_products,
+):
+    # given - legacy flag is on
+    site_settings.use_legacy_shipping_zone_stock_availability = True
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    variant = variant_with_many_stocks
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    stocks = list(variant.stocks.all())
+    warehouse_ids = [
+        graphene.Node.to_global_id("Warehouse", stock.warehouse_id) for stock in stocks
+    ]
+    variables = {"variantId": variant_id, "warehouseIds": warehouse_ids}
+
+    # when
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_DELETE_MUTATION,
+        variables=variables,
+        permissions=[permission_manage_products],
+    )
+    get_graphql_content(response)
+
+    # then
+    mocked_out.assert_not_called()
+    mocked_out_cc.assert_not_called()

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
@@ -1,4 +1,3 @@
-from unittest import mock
 from unittest.mock import patch
 
 import graphene
@@ -7,7 +6,6 @@ from django.core.exceptions import ValidationError
 from django.db.models import Sum
 
 from .....plugins.manager import get_plugins_manager
-from .....warehouse import WarehouseClickAndCollectOption
 from .....warehouse.error_codes import StockErrorCode
 from .....warehouse.models import Stock, Warehouse
 from ....tests.utils import get_graphql_content
@@ -638,246 +636,124 @@ def test_invalidate_stocks_dataloader_on_update_stocks(
     assert update_stocks_data["stocks"][0]["quantity"] == new_quantity
 
 
-# --- Channel stock event tests ---
-
-
-@mock.patch(
-    "saleor.warehouse.channel_stock_availability"
-    ".trigger_product_variant_back_in_stock_in_channel"
+@patch(
+    "saleor.graphql.product.bulk_mutations.product_variant_stocks_update"
+    ".trigger_back_in_stock_in_channel_events_for_stocks"
 )
-def test_update_stocks_triggers_back_in_stock_in_channel_for_non_cc_warehouses(
+def test_update_stocks_triggers_back_in_stock_channel_events(
     mocked_trigger,
+    staff_api_client,
     variant,
     warehouses,
-    channel_USD,
     site_settings,
-    django_capture_on_commit_callbacks,
+    permission_manage_products,
 ):
-    # given - two stocks in non-C&C warehouses, both at 0; update sets positive
+    # given - two stocks at 0; update sets both positive
     site_settings.use_legacy_shipping_zone_stock_availability = False
     site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
-    Stock.objects.bulk_create(
+    stocks = Stock.objects.bulk_create(
         [
             Stock(product_variant=variant, warehouse=warehouses[0], quantity=0),
             Stock(product_variant=variant, warehouse=warehouses[1], quantity=0),
         ]
     )
-    warehouses[0].channels.add(channel_USD)
-    warehouses[1].channels.add(channel_USD)
-    stocks_data = [
-        {"quantity": 10, "warehouse": "123"},
-        {"quantity": 5, "warehouse": "321"},
-    ]
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {
+        "variantId": variant_id,
+        "stocks": [
+            {
+                "warehouse": graphene.Node.to_global_id("Warehouse", warehouses[0].pk),
+                "quantity": 10,
+            },
+            {
+                "warehouse": graphene.Node.to_global_id("Warehouse", warehouses[1].pk),
+                "quantity": 5,
+            },
+        ],
+    }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant,
-            stocks_data,
-            warehouses,
-            get_plugins_manager(allow_replica=False),
-            site_settings,
-        )
-
-    # then - fires once per (variant, channel), dedup across the two warehouses
-    mocked_trigger.assert_called_once()
-    stock_info = mocked_trigger.call_args.args[0]
-    assert stock_info.variant_id == variant.id
-    assert stock_info.channel_slug == channel_USD.slug
-
-
-@mock.patch(
-    "saleor.warehouse.channel_stock_availability"
-    ".trigger_product_variant_back_in_stock_for_click_and_collect"
-)
-def test_update_stocks_triggers_back_in_stock_for_click_and_collect(
-    mocked_trigger,
-    variant,
-    channel_USD,
-    address,
-    site_settings,
-    django_capture_on_commit_callbacks,
-):
-    # given - two C&C warehouses with stocks at 0; update sets positive
-    site_settings.use_legacy_shipping_zone_stock_availability = False
-    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
-    cc_warehouses = Warehouse.objects.bulk_create(
-        [
-            Warehouse(
-                address=address.get_copy(),
-                name="cc-1",
-                slug="cc-1",
-                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
-            ),
-            Warehouse(
-                address=address.get_copy(),
-                name="cc-2",
-                slug="cc-2",
-                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
-            ),
-        ]
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_UPDATE_MUTATIONS,
+        variables,
+        permissions=[permission_manage_products],
     )
-    for warehouse in cc_warehouses:
-        warehouse.channels.add(channel_USD)
-    Stock.objects.bulk_create(
-        [
-            Stock(product_variant=variant, warehouse=cc_warehouses[0], quantity=0),
-            Stock(product_variant=variant, warehouse=cc_warehouses[1], quantity=0),
-        ]
-    )
-    stocks_data = [
-        {"quantity": 10, "warehouse": "123"},
-        {"quantity": 5, "warehouse": "321"},
-    ]
+    get_graphql_content(response)
 
-    # when
-    with django_capture_on_commit_callbacks(execute=True):
-        ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant,
-            stocks_data,
-            cc_warehouses,
-            get_plugins_manager(allow_replica=False),
-            site_settings,
-        )
-
-    # then - only the C&C event fires
+    # then
     mocked_trigger.assert_called_once()
-    stock_info = mocked_trigger.call_args.args[0]
-    assert stock_info.variant_id == variant.id
-    assert stock_info.channel_slug == channel_USD.slug
+    triggered_stocks, triggered_site_settings = mocked_trigger.call_args.args
+    assert {stock.pk for stock in triggered_stocks} == {stock.pk for stock in stocks}
+    assert triggered_site_settings == site_settings
 
 
-@mock.patch(
-    "saleor.warehouse.channel_stock_availability"
-    ".trigger_product_variant_out_of_stock_in_channel"
+@patch(
+    "saleor.graphql.product.bulk_mutations.product_variant_stocks_update"
+    ".trigger_out_of_stock_in_channel_events_for_stocks"
 )
-def test_update_stocks_triggers_out_of_stock_in_channel_for_non_cc_warehouses(
+def test_update_stocks_triggers_out_of_stock_channel_events(
     mocked_trigger,
+    staff_api_client,
     variant,
     warehouses,
-    channel_USD,
     site_settings,
-    django_capture_on_commit_callbacks,
+    permission_manage_products,
 ):
     # given - two stocks with availability; update sets both to 0
     site_settings.use_legacy_shipping_zone_stock_availability = False
     site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
-    Stock.objects.bulk_create(
+    stocks = Stock.objects.bulk_create(
         [
             Stock(product_variant=variant, warehouse=warehouses[0], quantity=10),
             Stock(product_variant=variant, warehouse=warehouses[1], quantity=5),
         ]
     )
-    warehouses[0].channels.add(channel_USD)
-    warehouses[1].channels.add(channel_USD)
-    stocks_data = [
-        {"quantity": 0, "warehouse": "123"},
-        {"quantity": 0, "warehouse": "321"},
-    ]
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {
+        "variantId": variant_id,
+        "stocks": [
+            {
+                "warehouse": graphene.Node.to_global_id("Warehouse", warehouses[0].pk),
+                "quantity": 0,
+            },
+            {
+                "warehouse": graphene.Node.to_global_id("Warehouse", warehouses[1].pk),
+                "quantity": 0,
+            },
+        ],
+    }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant,
-            stocks_data,
-            warehouses,
-            get_plugins_manager(allow_replica=False),
-            site_settings,
-        )
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_UPDATE_MUTATIONS,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    get_graphql_content(response)
 
     # then
     mocked_trigger.assert_called_once()
-    stock_info = mocked_trigger.call_args.args[0]
-    assert stock_info.variant_id == variant.id
-    assert stock_info.channel_slug == channel_USD.slug
+    triggered_stocks, triggered_site_settings = mocked_trigger.call_args.args
+    assert {stock.pk for stock in triggered_stocks} == {stock.pk for stock in stocks}
+    assert triggered_site_settings == site_settings
 
 
-@mock.patch(
-    "saleor.warehouse.channel_stock_availability"
-    ".trigger_product_variant_out_of_stock_for_click_and_collect"
+@patch(
+    "saleor.graphql.product.bulk_mutations.product_variant_stocks_update"
+    ".trigger_out_of_stock_in_channel_events_for_stocks"
 )
-def test_update_stocks_triggers_out_of_stock_for_click_and_collect(
-    mocked_trigger,
-    variant,
-    channel_USD,
-    address,
-    site_settings,
-    django_capture_on_commit_callbacks,
-):
-    # given - two C&C warehouses with availability; update sets to 0
-    site_settings.use_legacy_shipping_zone_stock_availability = False
-    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
-    cc_warehouses = Warehouse.objects.bulk_create(
-        [
-            Warehouse(
-                address=address.get_copy(),
-                name="cc-1",
-                slug="cc-1",
-                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
-            ),
-            Warehouse(
-                address=address.get_copy(),
-                name="cc-2",
-                slug="cc-2",
-                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
-            ),
-        ]
-    )
-    for warehouse in cc_warehouses:
-        warehouse.channels.add(channel_USD)
-    Stock.objects.bulk_create(
-        [
-            Stock(product_variant=variant, warehouse=cc_warehouses[0], quantity=10),
-            Stock(product_variant=variant, warehouse=cc_warehouses[1], quantity=5),
-        ]
-    )
-    stocks_data = [
-        {"quantity": 0, "warehouse": "123"},
-        {"quantity": 0, "warehouse": "321"},
-    ]
-
-    # when
-    with django_capture_on_commit_callbacks(execute=True):
-        ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant,
-            stocks_data,
-            cc_warehouses,
-            get_plugins_manager(allow_replica=False),
-            site_settings,
-        )
-
-    # then
-    mocked_trigger.assert_called_once()
-    stock_info = mocked_trigger.call_args.args[0]
-    assert stock_info.variant_id == variant.id
-    assert stock_info.channel_slug == channel_USD.slug
-
-
-@mock.patch(
-    "saleor.warehouse.channel_stock_availability"
-    ".trigger_product_variant_out_of_stock_in_channel"
-)
-@mock.patch(
-    "saleor.warehouse.channel_stock_availability"
-    ".trigger_product_variant_back_in_stock_in_channel"
-)
-@mock.patch(
-    "saleor.warehouse.channel_stock_availability"
-    ".trigger_product_variant_out_of_stock_for_click_and_collect"
-)
-@mock.patch(
-    "saleor.warehouse.channel_stock_availability"
-    ".trigger_product_variant_back_in_stock_for_click_and_collect"
+@patch(
+    "saleor.graphql.product.bulk_mutations.product_variant_stocks_update"
+    ".trigger_back_in_stock_in_channel_events_for_stocks"
 )
 def test_update_stocks_skips_channel_events_when_legacy_flag_enabled(
-    mocked_back_cc,
-    mocked_out_cc,
     mocked_back,
     mocked_out,
+    staff_api_client,
     variant,
     warehouses,
     site_settings,
-    django_capture_on_commit_callbacks,
+    permission_manage_products,
 ):
     # given - legacy flag is on; two stocks at 0 updated to positive
     site_settings.use_legacy_shipping_zone_stock_availability = True
@@ -888,38 +764,50 @@ def test_update_stocks_skips_channel_events_when_legacy_flag_enabled(
             Stock(product_variant=variant, warehouse=warehouses[1], quantity=0),
         ]
     )
-    stocks_data = [
-        {"quantity": 10, "warehouse": "123"},
-        {"quantity": 5, "warehouse": "321"},
-    ]
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {
+        "variantId": variant_id,
+        "stocks": [
+            {
+                "warehouse": graphene.Node.to_global_id("Warehouse", warehouses[0].pk),
+                "quantity": 10,
+            },
+            {
+                "warehouse": graphene.Node.to_global_id("Warehouse", warehouses[1].pk),
+                "quantity": 5,
+            },
+        ],
+    }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant,
-            stocks_data,
-            warehouses,
-            get_plugins_manager(allow_replica=False),
-            site_settings,
-        )
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_UPDATE_MUTATIONS,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    get_graphql_content(response)
 
     # then
-    mocked_out.assert_not_called()
     mocked_back.assert_not_called()
-    mocked_out_cc.assert_not_called()
-    mocked_back_cc.assert_not_called()
+    mocked_out.assert_not_called()
 
 
-@mock.patch(
-    "saleor.warehouse.channel_stock_availability"
-    ".trigger_product_variant_out_of_stock_in_channel"
+@patch(
+    "saleor.graphql.product.bulk_mutations.product_variant_stocks_update"
+    ".trigger_out_of_stock_in_channel_events_for_stocks"
 )
-def test_update_stocks_does_not_trigger_out_of_stock_when_quantity_remains(
-    mocked_trigger,
+@patch(
+    "saleor.graphql.product.bulk_mutations.product_variant_stocks_update"
+    ".trigger_back_in_stock_in_channel_events_for_stocks"
+)
+def test_update_stocks_does_not_trigger_channel_events_when_quantity_remains(
+    mocked_back,
+    mocked_out,
+    staff_api_client,
     variant,
     warehouses,
     site_settings,
-    django_capture_on_commit_callbacks,
+    permission_manage_products,
 ):
     # given - two stocks with availability; update reduces but keeps positive
     site_settings.use_legacy_shipping_zone_stock_availability = False
@@ -930,20 +818,29 @@ def test_update_stocks_does_not_trigger_out_of_stock_when_quantity_remains(
             Stock(product_variant=variant, warehouse=warehouses[1], quantity=8),
         ]
     )
-    stocks_data = [
-        {"quantity": 5, "warehouse": "123"},
-        {"quantity": 3, "warehouse": "321"},
-    ]
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {
+        "variantId": variant_id,
+        "stocks": [
+            {
+                "warehouse": graphene.Node.to_global_id("Warehouse", warehouses[0].pk),
+                "quantity": 5,
+            },
+            {
+                "warehouse": graphene.Node.to_global_id("Warehouse", warehouses[1].pk),
+                "quantity": 3,
+            },
+        ],
+    }
 
     # when
-    with django_capture_on_commit_callbacks(execute=True):
-        ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant,
-            stocks_data,
-            warehouses,
-            get_plugins_manager(allow_replica=False),
-            site_settings,
-        )
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_UPDATE_MUTATIONS,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    get_graphql_content(response)
 
     # then
-    mocked_trigger.assert_not_called()
+    mocked_back.assert_not_called()
+    mocked_out.assert_not_called()

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from unittest.mock import patch
 
 import graphene
@@ -6,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Sum
 
 from .....plugins.manager import get_plugins_manager
+from .....warehouse import WarehouseClickAndCollectOption
 from .....warehouse.error_codes import StockErrorCode
 from .....warehouse.models import Stock, Warehouse
 from ....tests.utils import get_graphql_content
@@ -222,7 +224,7 @@ def test_create_stocks_failed(product_with_single_variant, warehouse):
         create_stocks(variant, stocks_data, warehouses)
 
 
-def test_update_or_create_variant_stocks(variant, warehouses):
+def test_update_or_create_variant_stocks(variant, warehouses, site_settings):
     Stock.objects.create(
         product_variant=variant,
         warehouse=warehouses[0],
@@ -234,7 +236,11 @@ def test_update_or_create_variant_stocks(variant, warehouses):
     ]
 
     ProductVariantStocksUpdate.update_or_create_variant_stocks(
-        variant, stocks_data, warehouses, get_plugins_manager(allow_replica=False)
+        variant,
+        stocks_data,
+        warehouses,
+        get_plugins_manager(allow_replica=False),
+        site_settings,
     )
 
     variant.refresh_from_db()
@@ -261,6 +267,7 @@ def test_update_or_create_variant_stocks_when_stock_out_of_quantity(
     warehouses,
     any_webhook,
     settings,
+    site_settings,
     django_capture_on_commit_callbacks,
 ):
     # given
@@ -275,7 +282,11 @@ def test_update_or_create_variant_stocks_when_stock_out_of_quantity(
 
     with django_capture_on_commit_callbacks(execute=True):
         ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant, stocks_data, warehouses, get_plugins_manager(allow_replica=False)
+            variant,
+            stocks_data,
+            warehouses,
+            get_plugins_manager(allow_replica=False),
+            site_settings,
         )
 
     variant.refresh_from_db()
@@ -290,7 +301,9 @@ def test_update_or_create_variant_stocks_when_stock_out_of_quantity(
     assert variant.stocks.all()[0].quantity == 10
 
 
-def test_update_or_create_variant_stocks_empty_stocks_data(variant, warehouses):
+def test_update_or_create_variant_stocks_empty_stocks_data(
+    variant, warehouses, site_settings
+):
     Stock.objects.create(
         product_variant=variant,
         warehouse=warehouses[0],
@@ -298,7 +311,7 @@ def test_update_or_create_variant_stocks_empty_stocks_data(variant, warehouses):
     )
 
     ProductVariantStocksUpdate.update_or_create_variant_stocks(
-        variant, [], warehouses, get_plugins_manager(allow_replica=False)
+        variant, [], warehouses, get_plugins_manager(allow_replica=False), site_settings
     )
 
     variant.refresh_from_db()
@@ -321,6 +334,7 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_success(
     product_variant_stocks_updated_webhook,
     mocked_get_webhooks_for_event,
     settings,
+    site_settings,
     variant,
     warehouses,
     any_webhook,
@@ -342,7 +356,7 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_success(
 
     with django_capture_on_commit_callbacks(execute=True):
         ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant, stocks_data, warehouses, plugins
+            variant, stocks_data, warehouses, plugins, site_settings
         )
 
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 10
@@ -370,6 +384,7 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
     product_variant_stocks_update_webhook,
     mocked_get_webhooks_for_event,
     settings,
+    site_settings,
     variant,
     warehouses,
     any_webhook,
@@ -392,7 +407,7 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
 
     with django_capture_on_commit_callbacks(execute=True):
         ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant, stocks_data, warehouses, plugins
+            variant, stocks_data, warehouses, plugins, site_settings
         )
 
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 0
@@ -421,6 +436,7 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
     product_variant_stocks_updated_webhook,
     mocked_get_webhooks_for_event,
     settings,
+    site_settings,
     variant,
     warehouse,
     any_webhook,
@@ -444,7 +460,7 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
     # when
     with django_capture_on_commit_callbacks(execute=True):
         ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant, stocks_data, [warehouse], plugins
+            variant, stocks_data, [warehouse], plugins, site_settings
         )
     # then
     product_variant_back_in_stock_webhook.assert_called_once_with(
@@ -469,6 +485,7 @@ def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
     product_variant_stocks_updated_webhook,
     mocked_get_webhooks_for_event,
     settings,
+    site_settings,
     variant,
     warehouse,
     any_webhook,
@@ -492,7 +509,7 @@ def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
     # when
     with django_capture_on_commit_callbacks(execute=True):
         ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant, stocks_data, [warehouse], plugins
+            variant, stocks_data, [warehouse], plugins, site_settings
         )
     # then
     product_variant_stock_out_of_stock_webhook.assert_called_once_with(
@@ -517,6 +534,7 @@ def test_update_or_create_variant_stocks_with_out_of_stock_webhook_only(
     product_variant_stocks_update_webhook,
     mocked_get_webhooks_for_event,
     settings,
+    site_settings,
     variant,
     warehouses,
     any_webhook,
@@ -542,7 +560,7 @@ def test_update_or_create_variant_stocks_with_out_of_stock_webhook_only(
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 10
     with django_capture_on_commit_callbacks(execute=True):
         ProductVariantStocksUpdate.update_or_create_variant_stocks(
-            variant, stocks_data, warehouses, plugins
+            variant, stocks_data, warehouses, plugins, site_settings
         )
 
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 2
@@ -618,3 +636,314 @@ def test_invalidate_stocks_dataloader_on_update_stocks(
 
     # stock is updated in the second mutation
     assert update_stocks_data["stocks"][0]["quantity"] == new_quantity
+
+
+# --- Channel stock event tests ---
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_back_in_stock_in_channel"
+)
+def test_update_stocks_triggers_back_in_stock_in_channel_for_non_cc_warehouses(
+    mocked_trigger,
+    variant,
+    warehouses,
+    channel_USD,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given - two stocks in non-C&C warehouses, both at 0; update sets positive
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouses[0], quantity=0),
+            Stock(product_variant=variant, warehouse=warehouses[1], quantity=0),
+        ]
+    )
+    warehouses[0].channels.add(channel_USD)
+    warehouses[1].channels.add(channel_USD)
+    stocks_data = [
+        {"quantity": 10, "warehouse": "123"},
+        {"quantity": 5, "warehouse": "321"},
+    ]
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        ProductVariantStocksUpdate.update_or_create_variant_stocks(
+            variant,
+            stocks_data,
+            warehouses,
+            get_plugins_manager(allow_replica=False),
+            site_settings,
+        )
+
+    # then - fires once per (variant, channel), dedup across the two warehouses
+    mocked_trigger.assert_called_once()
+    stock_info = mocked_trigger.call_args.args[0]
+    assert stock_info.variant_id == variant.id
+    assert stock_info.channel_slug == channel_USD.slug
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_back_in_stock_for_click_and_collect"
+)
+def test_update_stocks_triggers_back_in_stock_for_click_and_collect(
+    mocked_trigger,
+    variant,
+    channel_USD,
+    address,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given - two C&C warehouses with stocks at 0; update sets positive
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    cc_warehouses = Warehouse.objects.bulk_create(
+        [
+            Warehouse(
+                address=address.get_copy(),
+                name="cc-1",
+                slug="cc-1",
+                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+            ),
+            Warehouse(
+                address=address.get_copy(),
+                name="cc-2",
+                slug="cc-2",
+                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+            ),
+        ]
+    )
+    for warehouse in cc_warehouses:
+        warehouse.channels.add(channel_USD)
+    Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=cc_warehouses[0], quantity=0),
+            Stock(product_variant=variant, warehouse=cc_warehouses[1], quantity=0),
+        ]
+    )
+    stocks_data = [
+        {"quantity": 10, "warehouse": "123"},
+        {"quantity": 5, "warehouse": "321"},
+    ]
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        ProductVariantStocksUpdate.update_or_create_variant_stocks(
+            variant,
+            stocks_data,
+            cc_warehouses,
+            get_plugins_manager(allow_replica=False),
+            site_settings,
+        )
+
+    # then - only the C&C event fires
+    mocked_trigger.assert_called_once()
+    stock_info = mocked_trigger.call_args.args[0]
+    assert stock_info.variant_id == variant.id
+    assert stock_info.channel_slug == channel_USD.slug
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_in_channel"
+)
+def test_update_stocks_triggers_out_of_stock_in_channel_for_non_cc_warehouses(
+    mocked_trigger,
+    variant,
+    warehouses,
+    channel_USD,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given - two stocks with availability; update sets both to 0
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouses[0], quantity=10),
+            Stock(product_variant=variant, warehouse=warehouses[1], quantity=5),
+        ]
+    )
+    warehouses[0].channels.add(channel_USD)
+    warehouses[1].channels.add(channel_USD)
+    stocks_data = [
+        {"quantity": 0, "warehouse": "123"},
+        {"quantity": 0, "warehouse": "321"},
+    ]
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        ProductVariantStocksUpdate.update_or_create_variant_stocks(
+            variant,
+            stocks_data,
+            warehouses,
+            get_plugins_manager(allow_replica=False),
+            site_settings,
+        )
+
+    # then
+    mocked_trigger.assert_called_once()
+    stock_info = mocked_trigger.call_args.args[0]
+    assert stock_info.variant_id == variant.id
+    assert stock_info.channel_slug == channel_USD.slug
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_for_click_and_collect"
+)
+def test_update_stocks_triggers_out_of_stock_for_click_and_collect(
+    mocked_trigger,
+    variant,
+    channel_USD,
+    address,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given - two C&C warehouses with availability; update sets to 0
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    cc_warehouses = Warehouse.objects.bulk_create(
+        [
+            Warehouse(
+                address=address.get_copy(),
+                name="cc-1",
+                slug="cc-1",
+                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+            ),
+            Warehouse(
+                address=address.get_copy(),
+                name="cc-2",
+                slug="cc-2",
+                click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+            ),
+        ]
+    )
+    for warehouse in cc_warehouses:
+        warehouse.channels.add(channel_USD)
+    Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=cc_warehouses[0], quantity=10),
+            Stock(product_variant=variant, warehouse=cc_warehouses[1], quantity=5),
+        ]
+    )
+    stocks_data = [
+        {"quantity": 0, "warehouse": "123"},
+        {"quantity": 0, "warehouse": "321"},
+    ]
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        ProductVariantStocksUpdate.update_or_create_variant_stocks(
+            variant,
+            stocks_data,
+            cc_warehouses,
+            get_plugins_manager(allow_replica=False),
+            site_settings,
+        )
+
+    # then
+    mocked_trigger.assert_called_once()
+    stock_info = mocked_trigger.call_args.args[0]
+    assert stock_info.variant_id == variant.id
+    assert stock_info.channel_slug == channel_USD.slug
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_in_channel"
+)
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_back_in_stock_in_channel"
+)
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_for_click_and_collect"
+)
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_back_in_stock_for_click_and_collect"
+)
+def test_update_stocks_skips_channel_events_when_legacy_flag_enabled(
+    mocked_back_cc,
+    mocked_out_cc,
+    mocked_back,
+    mocked_out,
+    variant,
+    warehouses,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given - legacy flag is on; two stocks at 0 updated to positive
+    site_settings.use_legacy_shipping_zone_stock_availability = True
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouses[0], quantity=0),
+            Stock(product_variant=variant, warehouse=warehouses[1], quantity=0),
+        ]
+    )
+    stocks_data = [
+        {"quantity": 10, "warehouse": "123"},
+        {"quantity": 5, "warehouse": "321"},
+    ]
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        ProductVariantStocksUpdate.update_or_create_variant_stocks(
+            variant,
+            stocks_data,
+            warehouses,
+            get_plugins_manager(allow_replica=False),
+            site_settings,
+        )
+
+    # then
+    mocked_out.assert_not_called()
+    mocked_back.assert_not_called()
+    mocked_out_cc.assert_not_called()
+    mocked_back_cc.assert_not_called()
+
+
+@mock.patch(
+    "saleor.warehouse.channel_stock_availability"
+    ".trigger_product_variant_out_of_stock_in_channel"
+)
+def test_update_stocks_does_not_trigger_out_of_stock_when_quantity_remains(
+    mocked_trigger,
+    variant,
+    warehouses,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given - two stocks with availability; update reduces but keeps positive
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
+    Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouses[0], quantity=10),
+            Stock(product_variant=variant, warehouse=warehouses[1], quantity=8),
+        ]
+    )
+    stocks_data = [
+        {"quantity": 5, "warehouse": "123"},
+        {"quantity": 3, "warehouse": "321"},
+    ]
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        ProductVariantStocksUpdate.update_or_create_variant_stocks(
+            variant,
+            stocks_data,
+            warehouses,
+            get_plugins_manager(allow_replica=False),
+            site_settings,
+        )
+
+    # then
+    mocked_trigger.assert_not_called()

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -645,7 +645,9 @@ class StocksWithAvailableQuantityByProductVariantIdAndChannelSlugLoader(
     context_key = "stocks_with_available_quantity_by_productvariant_and_channel"
 
     def batch_load(self, keys: Iterable[VariantIdChannelSlug]):
-        channel_slugs = list({channel_slug for _, channel_slug in keys})
+        channel_slugs = list(
+            {channel_slug for _, channel_slug in keys if channel_slug is not None}
+        )
 
         def with_channels(channels):
             def with_warehouses(warehouses_by_channel):

--- a/saleor/warehouse/channel_stock_availability.py
+++ b/saleor/warehouse/channel_stock_availability.py
@@ -70,12 +70,15 @@ def trigger_out_of_stock_in_channel_events_for_stocks(
         if not grouped_stocks:
             continue
 
-        for stock, channel_slug in _get_channels_without_other_available_warehouses(
+        for (
+            variant_id,
+            channel_slug,
+        ) in _get_channels_without_other_available_warehouses(
             grouped_stocks, cc_options
         ):
             trigger(
                 VariantChannelStockInfo(
-                    variant_id=stock.product_variant_id,
+                    variant_id=variant_id,
                     channel_slug=channel_slug,
                 ),
                 site_settings,
@@ -128,12 +131,15 @@ def trigger_back_in_stock_in_channel_events_for_stocks(
         if not grouped_stocks:
             continue
 
-        for stock, channel_slug in _get_channels_without_other_available_warehouses(
+        for (
+            variant_id,
+            channel_slug,
+        ) in _get_channels_without_other_available_warehouses(
             grouped_stocks, cc_options
         ):
             trigger(
                 VariantChannelStockInfo(
-                    variant_id=stock.product_variant_id,
+                    variant_id=variant_id,
                     channel_slug=channel_slug,
                 ),
                 site_settings,
@@ -148,13 +154,13 @@ def _is_click_and_collect_warehouse(stock: Stock) -> bool:
 
 def _get_channels_without_other_available_warehouses(
     stocks: list[Stock], cc_options: list[str]
-) -> list[tuple[Stock, str]]:
-    """Return (stock, channel_slug) pairs with no other same-kind warehouse availability.
+) -> set[tuple[int, str]]:
+    """Return unique (variant_id, channel_slug) pairs with no other same-kind warehouse availability.
 
     For each stock, checks every channel its warehouse belongs to. If no other
     warehouse of the same kind (C&C or non-C&C) in that channel has available
-    quantity for the stock's variant, the (stock, channel_slug) pair is included
-    in the result.
+    quantity for the stock's variant, the pair is included. Deduplicated so that
+    multiple stocks for the same variant produce only one entry per channel.
     """
     stock_ids = [stock.id for stock in stocks]
     warehouse_ids = list({stock.warehouse_id for stock in stocks})
@@ -221,15 +227,16 @@ def _get_channels_without_other_available_warehouses(
                     available_quantity
                 )
 
-    # Return (stock, channel_slug) for channels where no other warehouse has
-    # availability for the stock's variant.
-    result: list[tuple[Stock, str]] = []
+    # Return unique (variant_id, channel_slug) pairs for channels where no other
+    # warehouse has availability. Deduplicated so that multiple stocks for the
+    # same variant in different warehouses produce only one event per channel.
+    result: set[tuple[int, str]] = set()
     for stock in stocks:
         for channel_id, channel_slug in warehouse_id_to_channels_map.get(
             stock.warehouse_id, []
         ):
             if channel_available_per_stock.get((stock.id, channel_id), 0) == 0:
-                result.append((stock, channel_slug))
+                result.add((stock.product_variant_id, channel_slug))
 
     return result
 

--- a/saleor/warehouse/channel_stock_availability.py
+++ b/saleor/warehouse/channel_stock_availability.py
@@ -96,6 +96,90 @@ def trigger_back_in_stock_in_channel_events(
             )
 
 
+def trigger_out_of_stock_in_channel_events_for_stocks(
+    stocks: list[Stock],
+    site_settings: "SiteSettings",
+    requestor: "User | App | None" = None,
+    webhooks: "QuerySet[Webhook] | None" = None,
+) -> None:
+    """Bulk version of `trigger_out_of_stock_in_channel_events`.
+
+    Batches the channel/warehouse/availability queries across all stocks so the
+    total query count stays constant (~5) regardless of batch size.
+    """
+    _trigger_channel_stock_events_for_stocks(
+        stocks,
+        site_settings,
+        requestor,
+        webhooks,
+        cc_trigger=trigger_product_variant_out_of_stock_for_click_and_collect,
+        non_cc_trigger=trigger_product_variant_out_of_stock_in_channel,
+    )
+
+
+def trigger_back_in_stock_in_channel_events_for_stocks(
+    stocks: list[Stock],
+    site_settings: "SiteSettings",
+    requestor: "User | App | None" = None,
+    webhooks: "QuerySet[Webhook] | None" = None,
+) -> None:
+    """Bulk version of `trigger_back_in_stock_in_channel_events`.
+
+    Batches the channel/warehouse/availability queries across all stocks so the
+    total query count stays constant (~5) regardless of batch size.
+    """
+    _trigger_channel_stock_events_for_stocks(
+        stocks,
+        site_settings,
+        requestor,
+        webhooks,
+        cc_trigger=trigger_product_variant_back_in_stock_for_click_and_collect,
+        non_cc_trigger=trigger_product_variant_back_in_stock_in_channel,
+    )
+
+
+def _trigger_channel_stock_events_for_stocks(
+    stocks: list[Stock],
+    site_settings: "SiteSettings",
+    requestor: "User | App | None",
+    webhooks: "QuerySet[Webhook] | None",
+    cc_trigger,
+    non_cc_trigger,
+) -> None:
+    if not stocks:
+        return
+
+    cc_stocks: list[Stock] = []
+    non_cc_stocks: list[Stock] = []
+    for stock in stocks:
+        if _is_click_and_collect_warehouse(stock):
+            cc_stocks.append(stock)
+        else:
+            non_cc_stocks.append(stock)
+
+    for bucket_stocks, trigger, cc_options in [
+        (cc_stocks, cc_trigger, CC_OPTIONS),
+        (non_cc_stocks, non_cc_trigger, [WarehouseClickAndCollectOption.DISABLED]),
+    ]:
+        if not bucket_stocks:
+            continue
+        for (
+            stock,
+            channel_slug,
+        ) in _get_channels_without_other_available_warehouses_bulk(
+            bucket_stocks, cc_options
+        ):
+            trigger(
+                VariantChannelStockInfo(
+                    variant_id=stock.product_variant_id,
+                    channel_slug=channel_slug,
+                ),
+                site_settings,
+                requestor=requestor,
+                webhooks=webhooks,
+            )
+
+
 def _is_click_and_collect_warehouse(stock: Stock) -> bool:
     return stock.warehouse.click_and_collect_option in CC_OPTIONS
 
@@ -149,6 +233,105 @@ def _get_channels_without_other_available_warehouses(
         for channel_id, slug in channel_pairs
         if available_qty_per_channel.get(channel_id, 0) == 0
     ]
+
+
+def _get_channels_without_other_available_warehouses_bulk(
+    stocks: list[Stock], cc_options: list[str]
+) -> list[tuple[Stock, str]]:
+    """Return (stock, channel_slug) pairs with no other same-kind warehouse availability.
+
+    For each stock, checks every channel its warehouse belongs to. If no other
+    warehouse of the same kind (C&C or non-C&C) in that channel has available
+    quantity for the stock's variant, the (stock, channel_slug) pair is included
+    in the result.
+    """
+    stock_ids = [stock.id for stock in stocks]
+    warehouse_ids = list({stock.warehouse_id for stock in stocks})
+
+    # Find all warehouses of the same C&C kind in channels that contain any of
+    # the source stocks' warehouses. Source warehouses are included because
+    # warehouse A may serve as "the other warehouse" for a stock in warehouse B.
+    source_channels = ChannelWarehouse.objects.filter(
+        warehouse_id__in=warehouse_ids,
+        channel_id=OuterRef("channel_id"),
+    )
+    channel_warehouses = ChannelWarehouse.objects.filter(Exists(source_channels))
+    matching_warehouses = Warehouse.objects.filter(
+        Exists(channel_warehouses.filter(warehouse_id=OuterRef("pk"))),
+        click_and_collect_option__in=cc_options,
+    )
+
+    # Fetch available quantity per (warehouse, variant) for all relevant
+    # variants, excluding the source stocks themselves.
+    variant_ids = list({stock.product_variant_id for stock in stocks})
+    available_rows = (
+        Stock.objects.filter(
+            Exists(matching_warehouses.filter(pk=OuterRef("warehouse_id"))),
+            product_variant_id__in=variant_ids,
+        )
+        .exclude(id__in=stock_ids)
+        .annotate_available_quantity()
+        .values_list("warehouse_id", "product_variant_id", "available_quantity")
+    )
+
+    available_by_warehouse_variant: dict[tuple[UUID, int], int] = defaultdict(int)
+    availability_warehouse_ids: set[UUID] = set()
+    for warehouse_id, variant_id, available_quantity in available_rows:
+        available_by_warehouse_variant[(warehouse_id, variant_id)] += max(
+            available_quantity, 0
+        )
+        availability_warehouse_ids.add(warehouse_id)
+
+    # Map warehouse ids back to their channels. Includes both the warehouses
+    # from the availability results and the source stocks' warehouses so the
+    # final loop can resolve channel slugs for each stock.
+    warehouse_id_to_channels_map = _get_warehouse_to_channels_map(
+        list(availability_warehouse_ids | set(warehouse_ids))
+    )
+
+    # Group stocks by variant so we can match availability rows to stocks.
+    variant_id_to_stocks: dict[int, list[Stock]] = defaultdict(list)
+    for stock in stocks:
+        variant_id_to_stocks[stock.product_variant_id].append(stock)
+
+    # Accumulate available quantity per (stock, channel) from other warehouses.
+    # A warehouse is skipped for a stock when it is the stock's own warehouse.
+    channel_available_per_stock: dict[tuple[int, int], int] = defaultdict(int)
+    for (
+        warehouse_id,
+        variant_id,
+    ), available_quantity in available_by_warehouse_variant.items():
+        warehouse_channels = warehouse_id_to_channels_map.get(warehouse_id, [])
+        for stock in variant_id_to_stocks.get(variant_id, []):
+            if warehouse_id == stock.warehouse_id:
+                continue
+            for channel_id, _ in warehouse_channels:
+                channel_available_per_stock[(stock.id, channel_id)] += (
+                    available_quantity
+                )
+
+    # Return (stock, channel_slug) for channels where no other warehouse has
+    # availability for the stock's variant.
+    result: list[tuple[Stock, str]] = []
+    for stock in stocks:
+        for channel_id, channel_slug in warehouse_id_to_channels_map.get(
+            stock.warehouse_id, []
+        ):
+            if channel_available_per_stock.get((stock.id, channel_id), 0) == 0:
+                result.append((stock, channel_slug))
+
+    return result
+
+
+def _get_warehouse_to_channels_map(
+    warehouse_ids: list[UUID],
+) -> dict[UUID, list[tuple[int, str]]]:
+    warehouse_to_channels: dict[UUID, list[tuple[int, str]]] = defaultdict(list)
+    for channel_id, channel_slug, warehouse_id in ChannelWarehouse.objects.filter(
+        warehouse_id__in=warehouse_ids
+    ).values_list("channel_id", "channel__slug", "warehouse_id"):
+        warehouse_to_channels[warehouse_id].append((channel_id, channel_slug))
+    return warehouse_to_channels
 
 
 def _get_warehouse_id_to_channels_map(

--- a/saleor/warehouse/channel_stock_availability.py
+++ b/saleor/warehouse/channel_stock_availability.py
@@ -45,13 +45,7 @@ def trigger_out_of_stock_in_channel_events_for_stocks(
     if not stocks:
         return
 
-    cc_stocks: list[Stock] = []
-    non_cc_stocks: list[Stock] = []
-    for stock in stocks:
-        if _is_click_and_collect_warehouse(stock):
-            cc_stocks.append(stock)
-        else:
-            non_cc_stocks.append(stock)
+    cc_stocks, non_cc_stocks = _split_stocks_by_click_and_collect(stocks)
 
     NON_CC_OPTIONS = [WarehouseClickAndCollectOption.DISABLED]
     stocks_trigger_cc_options = [
@@ -104,13 +98,7 @@ def trigger_back_in_stock_in_channel_events_for_stocks(
     if not stocks:
         return
 
-    cc_stocks: list[Stock] = []
-    non_cc_stocks: list[Stock] = []
-    for stock in stocks:
-        if _is_click_and_collect_warehouse(stock):
-            cc_stocks.append(stock)
-        else:
-            non_cc_stocks.append(stock)
+    cc_stocks, non_cc_stocks = _split_stocks_by_click_and_collect(stocks)
 
     NON_CC_OPTIONS = [WarehouseClickAndCollectOption.DISABLED]
     stocks_trigger_cc_options = [
@@ -146,8 +134,29 @@ def trigger_back_in_stock_in_channel_events_for_stocks(
             )
 
 
-def _is_click_and_collect_warehouse(stock: Stock) -> bool:
-    return stock.warehouse.click_and_collect_option in CC_OPTIONS
+def _split_stocks_by_click_and_collect(
+    stocks: list[Stock],
+) -> tuple[list[Stock], list[Stock]]:
+    """Partition stocks into (cc_stocks, non_cc_stocks) with a single DB query.
+
+    Queries which warehouses among the stocks' warehouses are non-C&C
+    (`click_and_collect_option=DISABLED`); everything else is treated as C&C.
+    """
+    warehouse_ids = {stock.warehouse_id for stock in stocks}
+    non_cc_warehouse_ids = set(
+        Warehouse.objects.filter(
+            id__in=warehouse_ids,
+            click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+        ).values_list("id", flat=True)
+    )
+    cc_stocks: list[Stock] = []
+    non_cc_stocks: list[Stock] = []
+    for stock in stocks:
+        if stock.warehouse_id in non_cc_warehouse_ids:
+            non_cc_stocks.append(stock)
+        else:
+            cc_stocks.append(stock)
+    return cc_stocks, non_cc_stocks
 
 
 def _get_channels_without_other_available_warehouses(

--- a/saleor/warehouse/channel_stock_availability.py
+++ b/saleor/warehouse/channel_stock_availability.py
@@ -29,123 +29,19 @@ CC_OPTIONS = [
 ]
 
 
-def trigger_out_of_stock_in_channel_events(
-    stock: Stock,
-    site_settings: "SiteSettings",
-    requestor: "User | App | None" = None,
-    webhooks: "QuerySet[Webhook] | None" = None,
-) -> None:
-    """Fire channel-scoped OUT_OF_STOCK events for `stock`'s variant.
-
-    For each channel where `stock`'s warehouse belongs, fires
-    OUT_OF_STOCK_IN_CHANNEL (for regular warehouses) or
-    OUT_OF_STOCK_FOR_CLICK_AND_COLLECT (for C&C warehouses) when no other
-    warehouse of the same kind in that channel has remaining availability.
-
-    Call after `stock` has just reached 0 available.
-    """
-    is_cc = _is_click_and_collect_warehouse(stock)
-    # trigger for channel where there is no availability in other warehouses of
-    # the same kind (C&C or non-C&C)
-    for channel_slug in _get_channels_without_other_available_warehouses(stock, is_cc):
-        stock_info = VariantChannelStockInfo(
-            variant_id=stock.product_variant_id,
-            channel_slug=channel_slug,
-        )
-        if is_cc:
-            trigger_product_variant_out_of_stock_for_click_and_collect(
-                stock_info, site_settings, requestor=requestor, webhooks=webhooks
-            )
-        else:
-            trigger_product_variant_out_of_stock_in_channel(
-                stock_info, site_settings, requestor=requestor, webhooks=webhooks
-            )
-
-
-def trigger_back_in_stock_in_channel_events(
-    stock: Stock,
-    site_settings: "SiteSettings",
-    requestor: "User | App | None" = None,
-    webhooks: "QuerySet[Webhook] | None" = None,
-) -> None:
-    """Fire channel-scoped BACK_IN_STOCK events for `stock`'s variant.
-
-    For each channel where `stock`'s warehouse belongs, fires
-    BACK_IN_STOCK_IN_CHANNEL (for regular warehouses) or
-    BACK_IN_STOCK_FOR_CLICK_AND_COLLECT (for C&C warehouses) when no other
-    warehouse of the same kind in that channel has availability — i.e. `stock`
-    is the first one back.
-
-    Call after `stock` has just risen above 0 available.
-    """
-    is_cc = _is_click_and_collect_warehouse(stock)
-    # when no other warehouse of the same kind (C&C or non-C&C) in that channel
-    # has stock availability is the first one back, and event should be triggered
-    for channel_slug in _get_channels_without_other_available_warehouses(stock, is_cc):
-        stock_info = VariantChannelStockInfo(
-            variant_id=stock.product_variant_id,
-            channel_slug=channel_slug,
-        )
-        if is_cc:
-            trigger_product_variant_back_in_stock_for_click_and_collect(
-                stock_info, site_settings, requestor=requestor, webhooks=webhooks
-            )
-        else:
-            trigger_product_variant_back_in_stock_in_channel(
-                stock_info, site_settings, requestor=requestor, webhooks=webhooks
-            )
-
-
 def trigger_out_of_stock_in_channel_events_for_stocks(
     stocks: list[Stock],
     site_settings: "SiteSettings",
     requestor: "User | App | None" = None,
     webhooks: "QuerySet[Webhook] | None" = None,
 ) -> None:
-    """Bulk version of `trigger_out_of_stock_in_channel_events`.
+    """Fire channel-scoped OUT_OF_STOCK events for each `stock`'s variant.
 
-    Batches the channel/warehouse/availability queries across all stocks so the
-    total query count stays constant (~5) regardless of batch size.
+    For each channel where `stock`'s warehouse belongs, fires
+    OUT_OF_STOCK_IN_CHANNEL (for regular warehouses) or
+    OUT_OF_STOCK_FOR_CLICK_AND_COLLECT (for C&C warehouses) when no other
+    warehouse of the same kind in that channel has remaining availability.
     """
-    _trigger_channel_stock_events_for_stocks(
-        stocks,
-        site_settings,
-        requestor,
-        webhooks,
-        cc_trigger=trigger_product_variant_out_of_stock_for_click_and_collect,
-        non_cc_trigger=trigger_product_variant_out_of_stock_in_channel,
-    )
-
-
-def trigger_back_in_stock_in_channel_events_for_stocks(
-    stocks: list[Stock],
-    site_settings: "SiteSettings",
-    requestor: "User | App | None" = None,
-    webhooks: "QuerySet[Webhook] | None" = None,
-) -> None:
-    """Bulk version of `trigger_back_in_stock_in_channel_events`.
-
-    Batches the channel/warehouse/availability queries across all stocks so the
-    total query count stays constant (~5) regardless of batch size.
-    """
-    _trigger_channel_stock_events_for_stocks(
-        stocks,
-        site_settings,
-        requestor,
-        webhooks,
-        cc_trigger=trigger_product_variant_back_in_stock_for_click_and_collect,
-        non_cc_trigger=trigger_product_variant_back_in_stock_in_channel,
-    )
-
-
-def _trigger_channel_stock_events_for_stocks(
-    stocks: list[Stock],
-    site_settings: "SiteSettings",
-    requestor: "User | App | None",
-    webhooks: "QuerySet[Webhook] | None",
-    cc_trigger,
-    non_cc_trigger,
-) -> None:
     if not stocks:
         return
 
@@ -157,17 +53,83 @@ def _trigger_channel_stock_events_for_stocks(
         else:
             non_cc_stocks.append(stock)
 
-    for bucket_stocks, trigger, cc_options in [
-        (cc_stocks, cc_trigger, CC_OPTIONS),
-        (non_cc_stocks, non_cc_trigger, [WarehouseClickAndCollectOption.DISABLED]),
-    ]:
-        if not bucket_stocks:
+    NON_CC_OPTIONS = [WarehouseClickAndCollectOption.DISABLED]
+    stocks_trigger_cc_options = [
+        (
+            cc_stocks,
+            trigger_product_variant_out_of_stock_for_click_and_collect,
+            CC_OPTIONS,
+        ),
+        (
+            non_cc_stocks,
+            trigger_product_variant_out_of_stock_in_channel,
+            NON_CC_OPTIONS,
+        ),
+    ]
+    for grouped_stocks, trigger, cc_options in stocks_trigger_cc_options:
+        if not grouped_stocks:
             continue
-        for (
-            stock,
-            channel_slug,
-        ) in _get_channels_without_other_available_warehouses_bulk(
-            bucket_stocks, cc_options
+
+        for stock, channel_slug in _get_channels_without_other_available_warehouses(
+            grouped_stocks, cc_options
+        ):
+            trigger(
+                VariantChannelStockInfo(
+                    variant_id=stock.product_variant_id,
+                    channel_slug=channel_slug,
+                ),
+                site_settings,
+                requestor=requestor,
+                webhooks=webhooks,
+            )
+
+
+def trigger_back_in_stock_in_channel_events_for_stocks(
+    stocks: list[Stock],
+    site_settings: "SiteSettings",
+    requestor: "User | App | None" = None,
+    webhooks: "QuerySet[Webhook] | None" = None,
+) -> None:
+    """Fire channel-scoped BACK_IN_STOCK events for each `stock`'s variant.
+
+    For each channel where `stock`'s warehouse belongs, fires
+    BACK_IN_STOCK_IN_CHANNEL (for regular warehouses) or
+    BACK_IN_STOCK_FOR_CLICK_AND_COLLECT (for C&C warehouses) when no other
+    warehouse of the same kind in that channel has availability — i.e. `stock`
+    is the first one back.
+
+    Call after `stock` has just risen above 0 available.
+    """
+    if not stocks:
+        return
+
+    cc_stocks: list[Stock] = []
+    non_cc_stocks: list[Stock] = []
+    for stock in stocks:
+        if _is_click_and_collect_warehouse(stock):
+            cc_stocks.append(stock)
+        else:
+            non_cc_stocks.append(stock)
+
+    NON_CC_OPTIONS = [WarehouseClickAndCollectOption.DISABLED]
+    stocks_trigger_cc_options = [
+        (
+            cc_stocks,
+            trigger_product_variant_back_in_stock_for_click_and_collect,
+            CC_OPTIONS,
+        ),
+        (
+            non_cc_stocks,
+            trigger_product_variant_back_in_stock_in_channel,
+            NON_CC_OPTIONS,
+        ),
+    ]
+    for grouped_stocks, trigger, cc_options in stocks_trigger_cc_options:
+        if not grouped_stocks:
+            continue
+
+        for stock, channel_slug in _get_channels_without_other_available_warehouses(
+            grouped_stocks, cc_options
         ):
             trigger(
                 VariantChannelStockInfo(
@@ -185,57 +147,6 @@ def _is_click_and_collect_warehouse(stock: Stock) -> bool:
 
 
 def _get_channels_without_other_available_warehouses(
-    stock: Stock, is_cc: bool
-) -> list[str]:
-    """Return slugs of channels with no other warehouse having availability.
-
-    Returns warehouses of the same kind as `stock.warehouse` (C&C when
-    `is_cc` is True, otherwise regular). A channel is included when every such
-    warehouse in it — other than `stock.warehouse` — has zero available quantity
-    for `stock`'s variant.
-    """
-    channel_pairs: list[tuple[int, str]] = list(
-        ChannelWarehouse.objects.filter(warehouse_id=stock.warehouse_id).values_list(
-            "channel_id", "channel__slug"
-        )
-    )
-    if not channel_pairs:
-        return []
-    channel_ids = [channel[0] for channel in channel_pairs]
-
-    cc_options = CC_OPTIONS if is_cc else [WarehouseClickAndCollectOption.DISABLED]
-    channel_warehouses = ChannelWarehouse.objects.filter(
-        channel_id__in=channel_ids,
-    )
-    warehouses = Warehouse.objects.filter(
-        Exists(channel_warehouses.filter(warehouse_id=OuterRef("pk"))),
-        click_and_collect_option__in=cc_options,
-    ).exclude(pk=stock.warehouse_id)
-    available_by_warehouse: dict[UUID, int] = dict(
-        Stock.objects.filter(
-            Exists(warehouses.filter(pk=OuterRef("warehouse_id"))),
-            product_variant_id=stock.product_variant_id,
-        )
-        .annotate_available_quantity()
-        .values_list("warehouse_id", "available_quantity")
-    )
-
-    warehouse_id_to_channel_map = _get_warehouse_id_to_channels_map(
-        channel_ids, list(available_by_warehouse.keys())
-    )
-    available_qty_per_channel: dict[int, int] = defaultdict(int)
-    for warehouse_id, available_quantity in available_by_warehouse.items():
-        for channel_id in warehouse_id_to_channel_map.get(warehouse_id, []):
-            available_qty_per_channel[channel_id] += max(available_quantity, 0)
-
-    return [
-        slug
-        for channel_id, slug in channel_pairs
-        if available_qty_per_channel.get(channel_id, 0) == 0
-    ]
-
-
-def _get_channels_without_other_available_warehouses_bulk(
     stocks: list[Stock], cc_options: list[str]
 ) -> list[tuple[Stock, str]]:
     """Return (stock, channel_slug) pairs with no other same-kind warehouse availability.
@@ -331,16 +242,4 @@ def _get_warehouse_to_channels_map(
         warehouse_id__in=warehouse_ids
     ).values_list("channel_id", "channel__slug", "warehouse_id"):
         warehouse_to_channels[warehouse_id].append((channel_id, channel_slug))
-    return warehouse_to_channels
-
-
-def _get_warehouse_id_to_channels_map(
-    channel_ids: list[int], warehouse_ids: list[UUID]
-) -> dict[UUID, list[int]]:
-    warehouse_to_channels: dict[UUID, list[int]] = defaultdict(list)
-    for channel_id, warehouse_id in ChannelWarehouse.objects.filter(
-        warehouse_id__in=warehouse_ids,
-        channel_id__in=channel_ids,
-    ).values_list("channel_id", "warehouse_id"):
-        warehouse_to_channels[warehouse_id].append(channel_id)
     return warehouse_to_channels

--- a/saleor/warehouse/channel_stock_availability.py
+++ b/saleor/warehouse/channel_stock_availability.py
@@ -67,7 +67,7 @@ def trigger_out_of_stock_in_channel_events_for_stocks(
         for (
             variant_id,
             channel_slug,
-        ) in _get_channels_without_other_available_warehouses(
+        ) in _get_variant_channels_without_other_availability(
             grouped_stocks, cc_options
         ):
             trigger(
@@ -120,7 +120,7 @@ def trigger_back_in_stock_in_channel_events_for_stocks(
         for (
             variant_id,
             channel_slug,
-        ) in _get_channels_without_other_available_warehouses(
+        ) in _get_variant_channels_without_other_availability(
             grouped_stocks, cc_options
         ):
             trigger(
@@ -159,22 +159,60 @@ def _split_stocks_by_click_and_collect(
     return cc_stocks, non_cc_stocks
 
 
-def _get_channels_without_other_available_warehouses(
+def _get_variant_channels_without_other_availability(
     stocks: list[Stock], cc_options: list[str]
 ) -> set[tuple[int, str]]:
-    """Return unique (variant_id, channel_slug) pairs with no other same-kind warehouse availability.
+    """Return (variant_id, channel_slug) pairs where the source stocks are the only availability.
 
-    For each stock, checks every channel its warehouse belongs to. If no other
-    warehouse of the same kind (C&C or non-C&C) in that channel has available
-    quantity for the stock's variant, the pair is included. Deduplicated so that
+    For each stock, inspects every channel its warehouse belongs to. A pair is
+    included when no other warehouse of the same kind (C&C or non-C&C) in that
+    channel has available quantity for the stock's variant. Deduplicated so that
     multiple stocks for the same variant produce only one entry per channel.
+    """
+    source_warehouse_ids = {stock.warehouse_id for stock in stocks}
+
+    available_by_warehouse_and_variant = (
+        _fetch_other_warehouses_availability_per_variant(stocks, cc_options)
+    )
+
+    availability_warehouse_ids = {
+        warehouse_id for warehouse_id, _ in available_by_warehouse_and_variant
+    }
+    warehouse_id_to_channels_map = _get_warehouse_to_channels_map(
+        list(availability_warehouse_ids | source_warehouse_ids)
+    )
+
+    channel_available_per_stock = _sum_channel_availability_per_stock(
+        stocks, available_by_warehouse_and_variant, warehouse_id_to_channels_map
+    )
+
+    result: set[tuple[int, str]] = set()
+    for stock in stocks:
+        for channel_id, channel_slug in warehouse_id_to_channels_map.get(
+            stock.warehouse_id, []
+        ):
+            if channel_available_per_stock.get((stock.id, channel_id), 0) == 0:
+                result.add((stock.product_variant_id, channel_slug))
+
+    return result
+
+
+def _fetch_other_warehouses_availability_per_variant(
+    stocks: list[Stock], cc_options: list[str]
+) -> dict[tuple[UUID, int], int]:
+    """Fetch available quantity per (warehouse_id, variant_id) excluding source stocks.
+
+    Considers only warehouses of the matching C&C kind in channels that contain
+    any source stock's warehouse. Source warehouses themselves are included in
+    the scope because warehouse A may serve as "the other warehouse" for a stock
+    in warehouse B. The source stock rows are excluded from the aggregation so
+    the returned map represents availability from everywhere *qexcept* the
+    source stocks.
     """
     stock_ids = [stock.id for stock in stocks]
     warehouse_ids = list({stock.warehouse_id for stock in stocks})
+    variant_ids = list({stock.product_variant_id for stock in stocks})
 
-    # Find all warehouses of the same C&C kind in channels that contain any of
-    # the source stocks' warehouses. Source warehouses are included because
-    # warehouse A may serve as "the other warehouse" for a stock in warehouse B.
     source_channels = ChannelWarehouse.objects.filter(
         warehouse_id__in=warehouse_ids,
         channel_id=OuterRef("channel_id"),
@@ -185,9 +223,6 @@ def _get_channels_without_other_available_warehouses(
         click_and_collect_option__in=cc_options,
     )
 
-    # Fetch available quantity per (warehouse, variant) for all relevant
-    # variants, excluding the source stocks themselves.
-    variant_ids = list({stock.product_variant_id for stock in stocks})
     available_rows = (
         Stock.objects.filter(
             Exists(matching_warehouses.filter(pk=OuterRef("warehouse_id"))),
@@ -199,27 +234,28 @@ def _get_channels_without_other_available_warehouses(
     )
 
     available_by_warehouse_variant: dict[tuple[UUID, int], int] = defaultdict(int)
-    availability_warehouse_ids: set[UUID] = set()
     for warehouse_id, variant_id, available_quantity in available_rows:
         available_by_warehouse_variant[(warehouse_id, variant_id)] += max(
             available_quantity, 0
         )
-        availability_warehouse_ids.add(warehouse_id)
+    return available_by_warehouse_variant
 
-    # Map warehouse ids back to their channels. Includes both the warehouses
-    # from the availability results and the source stocks' warehouses so the
-    # final loop can resolve channel slugs for each stock.
-    warehouse_id_to_channels_map = _get_warehouse_to_channels_map(
-        list(availability_warehouse_ids | set(warehouse_ids))
-    )
 
-    # Group stocks by variant so we can match availability rows to stocks.
+def _sum_channel_availability_per_stock(
+    stocks: list[Stock],
+    available_by_warehouse_variant: dict[tuple[UUID, int], int],
+    warehouse_id_to_channels_map: dict[UUID, list[tuple[int, str]]],
+) -> dict[tuple[int, int], int]:
+    """Sum available quantity per (stock_id, channel_id) from warehouses other than the stock's own.
+
+    For each availability row, distributes its quantity across the channels its
+    warehouse belongs to, attributing it to every stock of the same variant
+    except the stock located in the same warehouse.
+    """
     variant_id_to_stocks: dict[int, list[Stock]] = defaultdict(list)
     for stock in stocks:
         variant_id_to_stocks[stock.product_variant_id].append(stock)
 
-    # Accumulate available quantity per (stock, channel) from other warehouses.
-    # A warehouse is skipped for a stock when it is the stock's own warehouse.
     channel_available_per_stock: dict[tuple[int, int], int] = defaultdict(int)
     for (
         warehouse_id,
@@ -233,19 +269,7 @@ def _get_channels_without_other_available_warehouses(
                 channel_available_per_stock[(stock.id, channel_id)] += (
                     available_quantity
                 )
-
-    # Return unique (variant_id, channel_slug) pairs for channels where no other
-    # warehouse has availability. Deduplicated so that multiple stocks for the
-    # same variant in different warehouses produce only one event per channel.
-    result: set[tuple[int, str]] = set()
-    for stock in stocks:
-        for channel_id, channel_slug in warehouse_id_to_channels_map.get(
-            stock.warehouse_id, []
-        ):
-            if channel_available_per_stock.get((stock.id, channel_id), 0) == 0:
-                result.add((stock.product_variant_id, channel_slug))
-
-    return result
+    return channel_available_per_stock
 
 
 def _get_warehouse_to_channels_map(

--- a/saleor/warehouse/channel_stock_availability.py
+++ b/saleor/warehouse/channel_stock_availability.py
@@ -100,8 +100,6 @@ def trigger_back_in_stock_in_channel_events_for_stocks(
     BACK_IN_STOCK_FOR_CLICK_AND_COLLECT (for C&C warehouses) when no other
     warehouse of the same kind in that channel has availability — i.e. `stock`
     is the first one back.
-
-    Call after `stock` has just risen above 0 available.
     """
     if not stocks:
         return

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -25,8 +25,8 @@ from ..order.models import OrderLine
 from ..plugins.manager import PluginsManager
 from ..product.models import ProductVariant, ProductVariantChannelListing
 from .channel_stock_availability import (
-    trigger_back_in_stock_in_channel_events,
-    trigger_out_of_stock_in_channel_events,
+    trigger_back_in_stock_in_channel_events_for_stocks,
+    trigger_out_of_stock_in_channel_events_for_stocks,
 )
 from .lock_objects import (
     allocation_with_stock_qs_select_for_update,
@@ -204,6 +204,7 @@ def allocate_stocks(
         legacy_stock_availability = (
             site_settings.use_legacy_shipping_zone_stock_availability
         )
+        out_of_stock_stocks: list[Stock] = []
         for allocation in allocations:
             allocated_stock = (
                 Allocation.objects.filter(stock_id=allocation.stock_id).aggregate(
@@ -215,14 +216,15 @@ def allocate_stocks(
                 transaction.on_commit(
                     lambda: manager.product_variant_out_of_stock(allocation.stock)
                 )
-                if not legacy_stock_availability:
-                    transaction.on_commit(
-                        partial(
-                            trigger_out_of_stock_in_channel_events,
-                            allocation.stock,
-                            site_settings,
-                        )
-                    )
+                out_of_stock_stocks.append(allocation.stock)
+        if out_of_stock_stocks and not legacy_stock_availability:
+            transaction.on_commit(
+                partial(
+                    trigger_out_of_stock_in_channel_events_for_stocks,
+                    out_of_stock_stocks,
+                    site_settings,
+                )
+            )
 
 
 def _prepare_stock_to_reserved_quantity_map(
@@ -402,6 +404,7 @@ def deallocate_stock(
     legacy_stock_availability = (
         site_settings.use_legacy_shipping_zone_stock_availability
     )
+    back_in_stock_stocks: list[Stock] = []
     for allocation_before_update in allocations_before_update:
         available_stock_now = Allocation.objects.available_quantity_for_stock(
             allocation_before_update.stock
@@ -415,14 +418,15 @@ def deallocate_stock(
                     allocation_before_update.stock
                 )
             )
-            if not legacy_stock_availability:
-                transaction.on_commit(
-                    partial(
-                        trigger_back_in_stock_in_channel_events,
-                        allocation_before_update.stock,
-                        site_settings,
-                    )
-                )
+            back_in_stock_stocks.append(allocation_before_update.stock)
+    if back_in_stock_stocks and not legacy_stock_availability:
+        transaction.on_commit(
+            partial(
+                trigger_back_in_stock_in_channel_events_for_stocks,
+                back_in_stock_stocks,
+                site_settings,
+            )
+        )
 
     Stock.objects.bulk_update(stocks_to_update, ["quantity_allocated"])
 
@@ -756,19 +760,21 @@ def deallocate_stock_for_orders(
     legacy_stock_availability = (
         site_settings.use_legacy_shipping_zone_stock_availability
     )
+    back_in_stock_stocks: list[Stock] = []
     for allocation in allocations_for_back_in_stock.annotate_stock_available_quantity():
         if allocation.stock_available_quantity <= 0:
             transaction.on_commit(
                 lambda: manager.product_variant_back_in_stock(allocation.stock)
             )
-            if not legacy_stock_availability:
-                transaction.on_commit(
-                    partial(
-                        trigger_back_in_stock_in_channel_events,
-                        allocation.stock,
-                        site_settings,
-                    )
-                )
+            back_in_stock_stocks.append(allocation.stock)
+    if back_in_stock_stocks and not legacy_stock_availability:
+        transaction.on_commit(
+            partial(
+                trigger_back_in_stock_in_channel_events_for_stocks,
+                back_in_stock_stocks,
+                site_settings,
+            )
+        )
 
     allocations.update(quantity_allocated=0)
     Stock.objects.bulk_update(stocks_to_update, ["quantity_allocated"])

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -24,10 +24,6 @@ from ..order.fetch import OrderLineInfo
 from ..order.models import OrderLine
 from ..plugins.manager import PluginsManager
 from ..product.models import ProductVariant, ProductVariantChannelListing
-from .channel_stock_availability import (
-    trigger_back_in_stock_in_channel_events_for_stocks,
-    trigger_out_of_stock_in_channel_events_for_stocks,
-)
 from .lock_objects import (
     allocation_with_stock_qs_select_for_update,
     stock_qs_select_for_update,
@@ -106,6 +102,13 @@ def allocate_stocks(
     for order line, until allocated all required quantity for the order line.
     If there is less quantity in stocks then rise InsufficientStock exception.
     """
+    # local import: channel_stock_availability transitively pulls in the
+    # webhook transport + graphql subscription types, which would create a
+    # circular import at `warehouse.management` top-level load time.
+    from .channel_stock_availability import (
+        trigger_out_of_stock_in_channel_events_for_stocks,
+    )
+
     # allocation only applied to order lines with variants with track inventory
     # set to True
     order_lines_info = get_order_lines_with_track_inventory(order_lines_info)
@@ -356,6 +359,11 @@ def deallocate_stock(
     quantity for the order line. If there is less quantity in stocks then
     raise an exception.
     """
+    # local import: to be removed when all webhook logic will be moved outside plugin
+    from .channel_stock_availability import (
+        trigger_back_in_stock_in_channel_events_for_stocks,
+    )
+
     lines = [line_info.line for line_info in order_lines_data]
     lines_allocations = allocation_with_stock_qs_select_for_update().filter(
         order_line__in=lines
@@ -746,6 +754,11 @@ def deallocate_stock_for_orders(
     site_settings: "SiteSettings",
 ):
     """Remove all allocations for given orders."""
+    # local import: to be removed when all webhook logic will be moved outside plugin
+    from .channel_stock_availability import (
+        trigger_back_in_stock_in_channel_events_for_stocks,
+    )
+
     lines = OrderLine.objects.filter(order_id__in=orders_ids)
     allocations = allocation_with_stock_qs_select_for_update().filter(
         Exists(lines.filter(id=OuterRef("order_line_id"))), quantity_allocated__gt=0

--- a/saleor/warehouse/tests/test_channel_stock_availability.py
+++ b/saleor/warehouse/tests/test_channel_stock_availability.py
@@ -445,9 +445,10 @@ def test_bulk_stocks_from_different_warehouses_in_same_channel(
     # when - both stocks passed together
     trigger_out_of_stock_in_channel_events_for_stocks([stock_a, stock_b], site_settings)
 
-    # then - both fire because there is no OTHER warehouse with availability
-    # (each warehouse only sees the other, which is also at 0)
-    assert mocked_out.call_count == 2
+    # then - fires once per (variant, channel), not once per stock
+    mocked_out.assert_called_once()
+    assert mocked_out.call_args.args[0].variant_id == variant.id
+    assert mocked_out.call_args.args[0].channel_slug == channel_USD.slug
 
 
 def test_bulk_warehouse_a_is_other_for_warehouse_b_stock(
@@ -561,3 +562,115 @@ def test_bulk_empty_list_does_not_fire(site_settings, mocker):
 
     # then
     mocked_out.assert_not_called()
+
+
+def test_bulk_two_different_variants_both_out_of_stock_fires_for_each(
+    product_with_two_variants, warehouse, channel_USD, site_settings, mocker
+):
+    # given - two different variants in the same warehouse, both at 0, no other
+    # warehouse in the channel
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    stocks = list(
+        Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
+    )
+    for stock in stocks:
+        stock.quantity = 0
+    Stock.objects.bulk_update(stocks, ["quantity"])
+
+    # when
+    trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
+
+    # then - one event per variant (not per stock), both in the same channel
+    assert mocked_out.call_count == 2
+    fired_pairs = {
+        (call.args[0].variant_id, call.args[0].channel_slug)
+        for call in mocked_out.call_args_list
+    }
+    assert fired_pairs == {
+        (variants[0].id, channel_USD.slug),
+        (variants[1].id, channel_USD.slug),
+    }
+
+
+def test_bulk_deduplicates_when_same_variant_has_multiple_stocks_across_warehouses(
+    variant, warehouse, channel_USD, channel_PLN, address, site_settings, mocker
+):
+    # given - same variant in two warehouses, both in two channels, both at 0
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    warehouse.channels.add(channel_PLN)
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD, channel_PLN)
+    stock_a, stock_b = Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouse, quantity=0),
+            Stock(product_variant=variant, warehouse=other_warehouse, quantity=0),
+        ]
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events_for_stocks([stock_a, stock_b], site_settings)
+
+    # then - fires once per channel (2 channels), not once per stock (4 would
+    # be stock_a×2channels + stock_b×2channels without dedup)
+    assert mocked_out.call_count == 2
+    fired_slugs = {call.args[0].channel_slug for call in mocked_out.call_args_list}
+    assert fired_slugs == {channel_USD.slug, channel_PLN.slug}
+
+
+def test_bulk_different_variants_partial_coverage_by_other_warehouse(
+    product_with_two_variants,
+    warehouse,
+    channel_USD,
+    channel_PLN,
+    address,
+    site_settings,
+    mocker,
+):
+    # given - variant X is covered by other warehouse in USD but not PLN
+    #         variant Y has no coverage in either channel
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    variant_x, variant_y = variants[0], variants[1]
+
+    warehouse.channels.add(channel_PLN)
+    stocks = list(
+        Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
+    )
+    for stock in stocks:
+        stock.quantity = 0
+    Stock.objects.bulk_update(stocks, ["quantity"])
+
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    # other warehouse only in USD, only has stock for variant X
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.create(
+        product_variant=variant_x, warehouse=other_warehouse, quantity=5
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
+
+    # then
+    # variant X: covered in USD (other warehouse has stock) → fires only for PLN
+    # variant Y: no coverage anywhere → fires for both USD and PLN
+    assert mocked_out.call_count == 3
+    fired_pairs = {
+        (call.args[0].variant_id, call.args[0].channel_slug)
+        for call in mocked_out.call_args_list
+    }
+    assert fired_pairs == {
+        (variant_x.id, channel_PLN.slug),
+        (variant_y.id, channel_USD.slug),
+        (variant_y.id, channel_PLN.slug),
+    }

--- a/saleor/warehouse/tests/test_channel_stock_availability.py
+++ b/saleor/warehouse/tests/test_channel_stock_availability.py
@@ -673,9 +673,6 @@ def test_bulk_out_of_stock_different_variants_partial_coverage_by_other_warehous
     }
 
 
-# --- Multi-stock (bulk) tests: back in stock ---
-
-
 def test_bulk_back_in_stock_fires_for_multiple_stocks_in_same_warehouse(
     product_with_two_variants, warehouse, channel_USD, site_settings, mocker
 ):

--- a/saleor/warehouse/tests/test_channel_stock_availability.py
+++ b/saleor/warehouse/tests/test_channel_stock_availability.py
@@ -324,14 +324,14 @@ def test_trigger_forwards_site_settings_requestor_and_webhooks(
     assert kwargs["webhooks"] is None
 
 
-# --- Multi-stock (bulk) tests ---
+# --- Multi-stock (bulk) tests: out of stock ---
 
 
-def test_bulk_fires_for_multiple_stocks_in_same_warehouse(
+def test_bulk_out_of_stock_fires_for_multiple_stocks_in_same_warehouse(
     product_with_two_variants, warehouse, channel_USD, site_settings, mocker
 ):
     # given - two variants in the same warehouse, both at 0
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_trigger = mocker.patch(OUT_IN_CHANNEL)
     variants = list(product_with_two_variants.variants.all())
     stocks = list(
         Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
@@ -343,13 +343,15 @@ def test_bulk_fires_for_multiple_stocks_in_same_warehouse(
     # when
     trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
 
-    # then - one event per (stock, channel) pair
-    assert mocked_out.call_count == 2
-    fired_variant_ids = {call.args[0].variant_id for call in mocked_out.call_args_list}
+    # then - one event per (variant, channel) pair
+    assert mocked_trigger.call_count == 2
+    fired_variant_ids = {
+        call.args[0].variant_id for call in mocked_trigger.call_args_list
+    }
     assert fired_variant_ids == {variants[0].id, variants[1].id}
 
 
-def test_bulk_does_not_fire_when_other_warehouse_covers_all_variants(
+def test_bulk_out_of_stock_does_not_fire_when_other_warehouse_covers_all_variants(
     product_with_two_variants,
     warehouse,
     channel_USD,
@@ -358,7 +360,7 @@ def test_bulk_does_not_fire_when_other_warehouse_covers_all_variants(
     mocker,
 ):
     # given - another non-C&C warehouse in the same channel has stock for both
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_trigger = mocker.patch(OUT_IN_CHANNEL)
     variants = list(product_with_two_variants.variants.all())
     stocks = list(
         Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
@@ -383,11 +385,11 @@ def test_bulk_does_not_fire_when_other_warehouse_covers_all_variants(
     # when
     trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
 
-    # then - neither fires, the other warehouse covers both variants
-    mocked_out.assert_not_called()
+    # then
+    mocked_trigger.assert_not_called()
 
 
-def test_bulk_fires_selectively_when_other_warehouse_covers_only_one_variant(
+def test_bulk_out_of_stock_fires_selectively_when_other_warehouse_covers_only_one_variant(
     product_with_two_variants,
     warehouse,
     channel_USD,
@@ -396,7 +398,7 @@ def test_bulk_fires_selectively_when_other_warehouse_covers_only_one_variant(
     mocker,
 ):
     # given - another warehouse has stock only for variants[0], not variants[1]
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_trigger = mocker.patch(OUT_IN_CHANNEL)
     variants = list(product_with_two_variants.variants.all())
     stocks = list(
         Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
@@ -418,16 +420,16 @@ def test_bulk_fires_selectively_when_other_warehouse_covers_only_one_variant(
     # when
     trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
 
-    # then - only variants[1] fires (variants[0] is covered by other_warehouse)
-    mocked_out.assert_called_once()
-    assert mocked_out.call_args.args[0].variant_id == variants[1].id
+    # then
+    mocked_trigger.assert_called_once()
+    assert mocked_trigger.call_args.args[0].variant_id == variants[1].id
 
 
-def test_bulk_stocks_from_different_warehouses_in_same_channel(
+def test_bulk_out_of_stock_deduplicates_same_variant_across_warehouses_in_channel(
     variant, warehouse, channel_USD, address, site_settings, mocker
 ):
-    # given - two warehouses in the same channel, both stocks for same variant at 0
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    # given - two warehouses in the same channel, same variant, both at 0
+    mocked_trigger = mocker.patch(OUT_IN_CHANNEL)
     other_warehouse = Warehouse.objects.create(
         address=address.get_copy(),
         name="other",
@@ -442,16 +444,16 @@ def test_bulk_stocks_from_different_warehouses_in_same_channel(
         ]
     )
 
-    # when - both stocks passed together
+    # when
     trigger_out_of_stock_in_channel_events_for_stocks([stock_a, stock_b], site_settings)
 
-    # then - fires once per (variant, channel), not once per stock
-    mocked_out.assert_called_once()
-    assert mocked_out.call_args.args[0].variant_id == variant.id
-    assert mocked_out.call_args.args[0].channel_slug == channel_USD.slug
+    # then - fires once per (variant, channel)
+    mocked_trigger.assert_called_once()
+    assert mocked_trigger.call_args.args[0].variant_id == variant.id
+    assert mocked_trigger.call_args.args[0].channel_slug == channel_USD.slug
 
 
-def test_bulk_warehouse_a_is_other_for_warehouse_b_stock(
+def test_bulk_out_of_stock_warehouse_a_is_other_for_warehouse_b_stock(
     product_with_two_variants,
     warehouse,
     channel_USD,
@@ -459,11 +461,11 @@ def test_bulk_warehouse_a_is_other_for_warehouse_b_stock(
     site_settings,
     mocker,
 ):
-    # given - warehouse A has variant X at 0 and variant Y at 5
+    # given - warehouse A has variant X (at 0) and variant Y (qty 5)
     #         warehouse B has variant Y at 0
     # For variant X in warehouse A: warehouse B has no stock → fires
-    # For variant Y in warehouse B: warehouse A has stock (qty=5) → does not fire
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    # For variant Y in warehouse B: warehouse A has stock → does not fire
+    mocked_trigger = mocker.patch(OUT_IN_CHANNEL)
     variants = list(product_with_two_variants.variants.all())
     variant_x, variant_y = variants[0], variants[1]
 
@@ -489,18 +491,17 @@ def test_bulk_warehouse_a_is_other_for_warehouse_b_stock(
         [stock_a_x, stock_b_y], site_settings
     )
 
-    # then - only variant X fires (warehouse B has no stock for variant X)
-    # variant Y does not fire (warehouse A has availability for variant Y)
-    mocked_out.assert_called_once()
-    assert mocked_out.call_args.args[0].variant_id == variant_x.id
+    # then
+    mocked_trigger.assert_called_once()
+    assert mocked_trigger.call_args.args[0].variant_id == variant_x.id
 
 
-def test_bulk_mixed_cc_and_non_cc_stocks(
+def test_bulk_out_of_stock_mixed_cc_and_non_cc_stocks(
     variant, warehouse, channel_USD, address, site_settings, mocker
 ):
     # given - one non-C&C stock and one C&C stock, both at 0
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
-    mocked_out_cc = mocker.patch(OUT_CC)
+    mocked_non_cc = mocker.patch(OUT_IN_CHANNEL)
+    mocked_cc = mocker.patch(OUT_CC)
     cc_warehouse = Warehouse.objects.create(
         address=address.get_copy(),
         name="cc",
@@ -521,17 +522,17 @@ def test_bulk_mixed_cc_and_non_cc_stocks(
     )
 
     # then - each fires in its own event type
-    mocked_out.assert_called_once()
-    assert mocked_out.call_args.args[0].variant_id == variant.id
-    mocked_out_cc.assert_called_once()
-    assert mocked_out_cc.call_args.args[0].variant_id == variant.id
+    mocked_non_cc.assert_called_once()
+    assert mocked_non_cc.call_args.args[0].variant_id == variant.id
+    mocked_cc.assert_called_once()
+    assert mocked_cc.call_args.args[0].variant_id == variant.id
 
 
-def test_bulk_multi_channel_fires_per_channel_independently(
+def test_bulk_out_of_stock_multi_channel_fires_per_channel_independently(
     variant, warehouse, channel_USD, channel_PLN, address, site_settings, mocker
 ):
     # given - warehouse in both channels; another warehouse with stock only in USD
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_trigger = mocker.patch(OUT_IN_CHANNEL)
     warehouse.channels.add(channel_PLN)
     stock = Stock.objects.create(
         product_variant=variant, warehouse=warehouse, quantity=0
@@ -549,27 +550,27 @@ def test_bulk_multi_channel_fires_per_channel_independently(
     trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then - fires only for PLN (USD has other warehouse with stock)
-    mocked_out.assert_called_once()
-    assert mocked_out.call_args.args[0].channel_slug == channel_PLN.slug
+    mocked_trigger.assert_called_once()
+    assert mocked_trigger.call_args.args[0].channel_slug == channel_PLN.slug
 
 
-def test_bulk_empty_list_does_not_fire(site_settings, mocker):
+def test_bulk_out_of_stock_empty_list_does_not_fire(site_settings, mocker):
     # given
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_trigger = mocker.patch(OUT_IN_CHANNEL)
 
     # when
     trigger_out_of_stock_in_channel_events_for_stocks([], site_settings)
 
     # then
-    mocked_out.assert_not_called()
+    mocked_trigger.assert_not_called()
 
 
-def test_bulk_two_different_variants_both_out_of_stock_fires_for_each(
+def test_bulk_out_of_stock_two_different_variants_fires_for_each(
     product_with_two_variants, warehouse, channel_USD, site_settings, mocker
 ):
     # given - two different variants in the same warehouse, both at 0, no other
     # warehouse in the channel
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_trigger = mocker.patch(OUT_IN_CHANNEL)
     variants = list(product_with_two_variants.variants.all())
     stocks = list(
         Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
@@ -581,11 +582,11 @@ def test_bulk_two_different_variants_both_out_of_stock_fires_for_each(
     # when
     trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
 
-    # then - one event per variant (not per stock), both in the same channel
-    assert mocked_out.call_count == 2
+    # then
+    assert mocked_trigger.call_count == 2
     fired_pairs = {
         (call.args[0].variant_id, call.args[0].channel_slug)
-        for call in mocked_out.call_args_list
+        for call in mocked_trigger.call_args_list
     }
     assert fired_pairs == {
         (variants[0].id, channel_USD.slug),
@@ -593,11 +594,11 @@ def test_bulk_two_different_variants_both_out_of_stock_fires_for_each(
     }
 
 
-def test_bulk_deduplicates_when_same_variant_has_multiple_stocks_across_warehouses(
+def test_bulk_out_of_stock_deduplicates_same_variant_multiple_warehouses_and_channels(
     variant, warehouse, channel_USD, channel_PLN, address, site_settings, mocker
 ):
     # given - same variant in two warehouses, both in two channels, both at 0
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_trigger = mocker.patch(OUT_IN_CHANNEL)
     warehouse.channels.add(channel_PLN)
     other_warehouse = Warehouse.objects.create(
         address=address.get_copy(),
@@ -616,14 +617,13 @@ def test_bulk_deduplicates_when_same_variant_has_multiple_stocks_across_warehous
     # when
     trigger_out_of_stock_in_channel_events_for_stocks([stock_a, stock_b], site_settings)
 
-    # then - fires once per channel (2 channels), not once per stock (4 would
-    # be stock_a×2channels + stock_b×2channels without dedup)
-    assert mocked_out.call_count == 2
-    fired_slugs = {call.args[0].channel_slug for call in mocked_out.call_args_list}
+    # then - fires once per channel (2 channels), not once per stock
+    assert mocked_trigger.call_count == 2
+    fired_slugs = {call.args[0].channel_slug for call in mocked_trigger.call_args_list}
     assert fired_slugs == {channel_USD.slug, channel_PLN.slug}
 
 
-def test_bulk_different_variants_partial_coverage_by_other_warehouse(
+def test_bulk_out_of_stock_different_variants_partial_coverage_by_other_warehouse(
     product_with_two_variants,
     warehouse,
     channel_USD,
@@ -634,7 +634,7 @@ def test_bulk_different_variants_partial_coverage_by_other_warehouse(
 ):
     # given - variant X is covered by other warehouse in USD but not PLN
     #         variant Y has no coverage in either channel
-    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_trigger = mocker.patch(OUT_IN_CHANNEL)
     variants = list(product_with_two_variants.variants.all())
     variant_x, variant_y = variants[0], variants[1]
 
@@ -662,12 +662,369 @@ def test_bulk_different_variants_partial_coverage_by_other_warehouse(
     trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
 
     # then
-    # variant X: covered in USD (other warehouse has stock) → fires only for PLN
-    # variant Y: no coverage anywhere → fires for both USD and PLN
-    assert mocked_out.call_count == 3
+    # variant X: covered in USD, uncovered in PLN → fires only for PLN
+    # variant Y: uncovered everywhere → fires for both USD and PLN
+    assert mocked_trigger.call_count == 3
     fired_pairs = {
         (call.args[0].variant_id, call.args[0].channel_slug)
-        for call in mocked_out.call_args_list
+        for call in mocked_trigger.call_args_list
+    }
+    assert fired_pairs == {
+        (variant_x.id, channel_PLN.slug),
+        (variant_y.id, channel_USD.slug),
+        (variant_y.id, channel_PLN.slug),
+    }
+
+
+# --- Multi-stock (bulk) tests: back in stock ---
+
+
+def test_bulk_back_in_stock_fires_for_multiple_stocks_in_same_warehouse(
+    product_with_two_variants, warehouse, channel_USD, site_settings, mocker
+):
+    # given - two variants in the same warehouse, both back at positive qty
+    mocked_trigger = mocker.patch(BACK_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    stocks = list(
+        Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
+    )
+    # stocks are already at qty 10 from the fixture
+    for stock in stocks:
+        stock.quantity = 10
+    Stock.objects.bulk_update(stocks, ["quantity"])
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks(stocks, site_settings)
+
+    # then - one event per (variant, channel) pair
+    assert mocked_trigger.call_count == 2
+    fired_variant_ids = {
+        call.args[0].variant_id for call in mocked_trigger.call_args_list
+    }
+    assert fired_variant_ids == {variants[0].id, variants[1].id}
+
+
+def test_bulk_back_in_stock_does_not_fire_when_other_warehouse_covers_all_variants(
+    product_with_two_variants,
+    warehouse,
+    channel_USD,
+    address,
+    site_settings,
+    mocker,
+):
+    # given - another non-C&C warehouse in the same channel already has stock
+    mocked_trigger = mocker.patch(BACK_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    stocks = list(
+        Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
+    )
+    for stock in stocks:
+        stock.quantity = 10
+    Stock.objects.bulk_update(stocks, ["quantity"])
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variants[0], warehouse=other_warehouse, quantity=5),
+            Stock(product_variant=variants[1], warehouse=other_warehouse, quantity=3),
+        ]
+    )
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks(stocks, site_settings)
+
+    # then - other warehouse already had stock, these aren't "first back"
+    mocked_trigger.assert_not_called()
+
+
+def test_bulk_back_in_stock_fires_selectively_when_other_warehouse_covers_only_one_variant(
+    product_with_two_variants,
+    warehouse,
+    channel_USD,
+    address,
+    site_settings,
+    mocker,
+):
+    # given - another warehouse has stock only for variants[0], not variants[1]
+    mocked_trigger = mocker.patch(BACK_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    stocks = list(
+        Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
+    )
+    for stock in stocks:
+        stock.quantity = 10
+    Stock.objects.bulk_update(stocks, ["quantity"])
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.create(
+        product_variant=variants[0], warehouse=other_warehouse, quantity=5
+    )
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks(stocks, site_settings)
+
+    # then - only variants[1] fires (variants[0] was already covered elsewhere)
+    mocked_trigger.assert_called_once()
+    assert mocked_trigger.call_args.args[0].variant_id == variants[1].id
+
+
+def test_bulk_back_in_stock_deduplicates_same_variant_across_warehouses_in_channel(
+    variant, warehouse, channel_USD, address, site_settings, mocker
+):
+    # given - two warehouses in the same channel, same variant, both back at positive
+    mocked_trigger = mocker.patch(BACK_IN_CHANNEL)
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    stock_a, stock_b = Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouse, quantity=10),
+            Stock(product_variant=variant, warehouse=other_warehouse, quantity=10),
+        ]
+    )
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks(
+        [stock_a, stock_b], site_settings
+    )
+
+    # then - fires once per (variant, channel)
+    mocked_trigger.assert_called_once()
+    assert mocked_trigger.call_args.args[0].variant_id == variant.id
+    assert mocked_trigger.call_args.args[0].channel_slug == channel_USD.slug
+
+
+def test_bulk_back_in_stock_warehouse_a_is_other_for_warehouse_b_stock(
+    product_with_two_variants,
+    warehouse,
+    channel_USD,
+    address,
+    site_settings,
+    mocker,
+):
+    # given - warehouse A has variant X back (qty 10) and variant Y with qty 5
+    #         warehouse B has variant Y back (qty 10)
+    # For variant X in warehouse A: warehouse B has no stock for X → fires
+    # For variant Y in warehouse B: warehouse A has stock for Y → does not fire
+    mocked_trigger = mocker.patch(BACK_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    variant_x, variant_y = variants[0], variants[1]
+
+    stock_a_x = Stock.objects.get(product_variant=variant_x, warehouse=warehouse)
+    stock_a_x.quantity = 10
+    stock_a_y = Stock.objects.get(product_variant=variant_y, warehouse=warehouse)
+    stock_a_y.quantity = 5
+    Stock.objects.bulk_update([stock_a_x, stock_a_y], ["quantity"])
+
+    warehouse_b = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="warehouse-b",
+        slug="warehouse-b",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    warehouse_b.channels.add(channel_USD)
+    stock_b_y = Stock.objects.create(
+        product_variant=variant_y, warehouse=warehouse_b, quantity=10
+    )
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks(
+        [stock_a_x, stock_b_y], site_settings
+    )
+
+    # then
+    mocked_trigger.assert_called_once()
+    assert mocked_trigger.call_args.args[0].variant_id == variant_x.id
+
+
+def test_bulk_back_in_stock_mixed_cc_and_non_cc_stocks(
+    variant, warehouse, channel_USD, address, site_settings, mocker
+):
+    # given - one non-C&C stock and one C&C stock, both back at positive qty
+    mocked_non_cc = mocker.patch(BACK_IN_CHANNEL)
+    mocked_cc = mocker.patch(BACK_CC)
+    cc_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="cc",
+        slug="cc",
+        click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+    )
+    cc_warehouse.channels.add(channel_USD)
+    stock_non_cc, stock_cc = Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouse, quantity=10),
+            Stock(product_variant=variant, warehouse=cc_warehouse, quantity=10),
+        ]
+    )
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks(
+        [stock_non_cc, stock_cc], site_settings
+    )
+
+    # then - each fires in its own event type
+    mocked_non_cc.assert_called_once()
+    assert mocked_non_cc.call_args.args[0].variant_id == variant.id
+    mocked_cc.assert_called_once()
+    assert mocked_cc.call_args.args[0].variant_id == variant.id
+
+
+def test_bulk_back_in_stock_multi_channel_fires_per_channel_independently(
+    variant, warehouse, channel_USD, channel_PLN, address, site_settings, mocker
+):
+    # given - warehouse in both channels; another warehouse with stock only in USD
+    mocked_trigger = mocker.patch(BACK_IN_CHANNEL)
+    warehouse.channels.add(channel_PLN)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=10
+    )
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="usd-only",
+        slug="usd-only",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=5)
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks([stock], site_settings)
+
+    # then - fires only for PLN (USD already has other warehouse with stock)
+    mocked_trigger.assert_called_once()
+    assert mocked_trigger.call_args.args[0].channel_slug == channel_PLN.slug
+
+
+def test_bulk_back_in_stock_empty_list_does_not_fire(site_settings, mocker):
+    # given
+    mocked_trigger = mocker.patch(BACK_IN_CHANNEL)
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks([], site_settings)
+
+    # then
+    mocked_trigger.assert_not_called()
+
+
+def test_bulk_back_in_stock_two_different_variants_fires_for_each(
+    product_with_two_variants, warehouse, channel_USD, site_settings, mocker
+):
+    # given - two different variants in the same warehouse, both back at positive,
+    # no other warehouse in the channel
+    mocked_trigger = mocker.patch(BACK_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    stocks = list(
+        Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
+    )
+    for stock in stocks:
+        stock.quantity = 10
+    Stock.objects.bulk_update(stocks, ["quantity"])
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks(stocks, site_settings)
+
+    # then
+    assert mocked_trigger.call_count == 2
+    fired_pairs = {
+        (call.args[0].variant_id, call.args[0].channel_slug)
+        for call in mocked_trigger.call_args_list
+    }
+    assert fired_pairs == {
+        (variants[0].id, channel_USD.slug),
+        (variants[1].id, channel_USD.slug),
+    }
+
+
+def test_bulk_back_in_stock_deduplicates_same_variant_multiple_warehouses_and_channels(
+    variant, warehouse, channel_USD, channel_PLN, address, site_settings, mocker
+):
+    # given - same variant in two warehouses, both in two channels, both back at positive
+    mocked_trigger = mocker.patch(BACK_IN_CHANNEL)
+    warehouse.channels.add(channel_PLN)
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD, channel_PLN)
+    stock_a, stock_b = Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouse, quantity=10),
+            Stock(product_variant=variant, warehouse=other_warehouse, quantity=10),
+        ]
+    )
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks(
+        [stock_a, stock_b], site_settings
+    )
+
+    # then - fires once per channel, not once per stock
+    assert mocked_trigger.call_count == 2
+    fired_slugs = {call.args[0].channel_slug for call in mocked_trigger.call_args_list}
+    assert fired_slugs == {channel_USD.slug, channel_PLN.slug}
+
+
+def test_bulk_back_in_stock_different_variants_partial_coverage_by_other_warehouse(
+    product_with_two_variants,
+    warehouse,
+    channel_USD,
+    channel_PLN,
+    address,
+    site_settings,
+    mocker,
+):
+    # given - variant X is covered by other warehouse in USD but not PLN
+    #         variant Y has no coverage in either channel
+    mocked_trigger = mocker.patch(BACK_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    variant_x, variant_y = variants[0], variants[1]
+
+    warehouse.channels.add(channel_PLN)
+    stocks = list(
+        Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
+    )
+    for stock in stocks:
+        stock.quantity = 10
+    Stock.objects.bulk_update(stocks, ["quantity"])
+
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    # other warehouse only in USD, only has stock for variant X
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.create(
+        product_variant=variant_x, warehouse=other_warehouse, quantity=5
+    )
+
+    # when
+    trigger_back_in_stock_in_channel_events_for_stocks(stocks, site_settings)
+
+    # then
+    # variant X: USD already covered by other warehouse, PLN uncovered → fires only for PLN
+    # variant Y: uncovered everywhere → fires for both USD and PLN
+    assert mocked_trigger.call_count == 3
+    fired_pairs = {
+        (call.args[0].variant_id, call.args[0].channel_slug)
+        for call in mocked_trigger.call_args_list
     }
     assert fired_pairs == {
         (variant_x.id, channel_PLN.slug),

--- a/saleor/warehouse/tests/test_channel_stock_availability.py
+++ b/saleor/warehouse/tests/test_channel_stock_availability.py
@@ -324,9 +324,6 @@ def test_trigger_forwards_site_settings_requestor_and_webhooks(
     assert kwargs["webhooks"] is None
 
 
-# --- Multi-stock (bulk) tests: out of stock ---
-
-
 def test_bulk_out_of_stock_fires_for_multiple_stocks_in_same_warehouse(
     product_with_two_variants, warehouse, channel_USD, site_settings, mocker
 ):

--- a/saleor/warehouse/tests/test_channel_stock_availability.py
+++ b/saleor/warehouse/tests/test_channel_stock_availability.py
@@ -1,7 +1,7 @@
 from .. import WarehouseClickAndCollectOption
 from ..channel_stock_availability import (
-    trigger_back_in_stock_in_channel_events,
-    trigger_out_of_stock_in_channel_events,
+    trigger_back_in_stock_in_channel_events_for_stocks,
+    trigger_out_of_stock_in_channel_events_for_stocks,
 )
 from ..interface import VariantChannelStockInfo
 from ..models import Allocation, Stock, Warehouse
@@ -35,7 +35,7 @@ def test_out_of_stock_fires_when_only_warehouse_in_bucket(
     )
 
     # when
-    trigger_out_of_stock_in_channel_events(stock, site_settings)
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then
     info = mocked_out.call_args.args[0]
@@ -63,7 +63,7 @@ def test_out_of_stock_does_not_fire_when_another_warehouse_has_stock(
     Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=5)
 
     # when
-    trigger_out_of_stock_in_channel_events(stock, site_settings)
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then
     mocked_out.assert_not_called()
@@ -88,7 +88,7 @@ def test_out_of_stock_fires_even_when_cc_warehouse_in_channel_has_stock(
     Stock.objects.create(product_variant=variant, warehouse=cc_warehouse, quantity=5)
 
     # when
-    trigger_out_of_stock_in_channel_events(stock, site_settings)
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then - non-C&C bucket is empty, event fires; C&C event is not raised
     mocked_out.assert_called_once()
@@ -113,7 +113,7 @@ def test_out_of_stock_in_cc_warehouse_fires_click_and_collect_event(
     )
 
     # when
-    trigger_out_of_stock_in_channel_events(stock, site_settings)
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then
     info = mocked_out_cc.call_args.args[0]
@@ -139,7 +139,7 @@ def test_back_in_stock_fires_when_all_other_warehouses_in_bucket_are_empty(
     Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=0)
 
     # when
-    trigger_back_in_stock_in_channel_events(stock, site_settings)
+    trigger_back_in_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then
     mocked_back.assert_called_once()
@@ -163,7 +163,7 @@ def test_back_in_stock_does_not_fire_when_another_warehouse_already_has_stock(
     Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=4)
 
     # when
-    trigger_back_in_stock_in_channel_events(stock, site_settings)
+    trigger_back_in_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then
     mocked_back.assert_not_called()
@@ -183,7 +183,7 @@ def test_does_not_fire_when_warehouse_belongs_to_no_channels(
     stock = Stock.objects.create(product_variant=variant, warehouse=orphan, quantity=0)
 
     # when
-    trigger_out_of_stock_in_channel_events(stock, site_settings)
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then
     mocked_out.assert_not_called()
@@ -209,7 +209,7 @@ def test_fires_only_for_channels_whose_bucket_is_empty(
     Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=5)
 
     # when
-    trigger_out_of_stock_in_channel_events(stock, site_settings)
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then - PLN bucket is empty (only `warehouse`), USD has another with stock
     mocked_out.assert_called_once()
@@ -240,7 +240,7 @@ def test_out_of_stock_fires_when_other_warehouse_has_only_fully_allocated_stock(
     )
 
     # when
-    trigger_out_of_stock_in_channel_events(stock, site_settings)
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then - other stock has 0 available -> event fires
     mocked_out.assert_called_once()
@@ -273,7 +273,7 @@ def test_out_of_stock_ignores_stocks_of_other_variants_in_same_bucket(
     )
 
     # when
-    trigger_out_of_stock_in_channel_events(stock, site_settings)
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then - other variant's stock is irrelevant; bucket is empty for tested variant
     mocked_out.assert_called_once()
@@ -297,7 +297,7 @@ def test_out_of_stock_ignores_warehouse_stock_attached_to_different_channel(
     Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=5)
 
     # when
-    trigger_out_of_stock_in_channel_events(stock, site_settings)
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then - the USD bucket has no other warehouses, event fires
     mocked_out.assert_called_once()
@@ -315,10 +315,249 @@ def test_trigger_forwards_site_settings_requestor_and_webhooks(
     )
 
     # when
-    trigger_out_of_stock_in_channel_events(stock, site_settings)
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then
     args, kwargs = mocked_out.call_args
     assert args[1] is site_settings
     assert kwargs["requestor"] is None
     assert kwargs["webhooks"] is None
+
+
+# --- Multi-stock (bulk) tests ---
+
+
+def test_bulk_fires_for_multiple_stocks_in_same_warehouse(
+    product_with_two_variants, warehouse, channel_USD, site_settings, mocker
+):
+    # given - two variants in the same warehouse, both at 0
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    stocks = list(
+        Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
+    )
+    for stock in stocks:
+        stock.quantity = 0
+    Stock.objects.bulk_update(stocks, ["quantity"])
+
+    # when
+    trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
+
+    # then - one event per (stock, channel) pair
+    assert mocked_out.call_count == 2
+    fired_variant_ids = {call.args[0].variant_id for call in mocked_out.call_args_list}
+    assert fired_variant_ids == {variants[0].id, variants[1].id}
+
+
+def test_bulk_does_not_fire_when_other_warehouse_covers_all_variants(
+    product_with_two_variants,
+    warehouse,
+    channel_USD,
+    address,
+    site_settings,
+    mocker,
+):
+    # given - another non-C&C warehouse in the same channel has stock for both
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    stocks = list(
+        Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
+    )
+    for stock in stocks:
+        stock.quantity = 0
+    Stock.objects.bulk_update(stocks, ["quantity"])
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variants[0], warehouse=other_warehouse, quantity=5),
+            Stock(product_variant=variants[1], warehouse=other_warehouse, quantity=3),
+        ]
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
+
+    # then - neither fires, the other warehouse covers both variants
+    mocked_out.assert_not_called()
+
+
+def test_bulk_fires_selectively_when_other_warehouse_covers_only_one_variant(
+    product_with_two_variants,
+    warehouse,
+    channel_USD,
+    address,
+    site_settings,
+    mocker,
+):
+    # given - another warehouse has stock only for variants[0], not variants[1]
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    stocks = list(
+        Stock.objects.filter(product_variant__in=variants, warehouse=warehouse)
+    )
+    for stock in stocks:
+        stock.quantity = 0
+    Stock.objects.bulk_update(stocks, ["quantity"])
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.create(
+        product_variant=variants[0], warehouse=other_warehouse, quantity=5
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
+
+    # then - only variants[1] fires (variants[0] is covered by other_warehouse)
+    mocked_out.assert_called_once()
+    assert mocked_out.call_args.args[0].variant_id == variants[1].id
+
+
+def test_bulk_stocks_from_different_warehouses_in_same_channel(
+    variant, warehouse, channel_USD, address, site_settings, mocker
+):
+    # given - two warehouses in the same channel, both stocks for same variant at 0
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="other",
+        slug="other",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    stock_a, stock_b = Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouse, quantity=0),
+            Stock(product_variant=variant, warehouse=other_warehouse, quantity=0),
+        ]
+    )
+
+    # when - both stocks passed together
+    trigger_out_of_stock_in_channel_events_for_stocks([stock_a, stock_b], site_settings)
+
+    # then - both fire because there is no OTHER warehouse with availability
+    # (each warehouse only sees the other, which is also at 0)
+    assert mocked_out.call_count == 2
+
+
+def test_bulk_warehouse_a_is_other_for_warehouse_b_stock(
+    product_with_two_variants,
+    warehouse,
+    channel_USD,
+    address,
+    site_settings,
+    mocker,
+):
+    # given - warehouse A has variant X at 0 and variant Y at 5
+    #         warehouse B has variant Y at 0
+    # For variant X in warehouse A: warehouse B has no stock → fires
+    # For variant Y in warehouse B: warehouse A has stock (qty=5) → does not fire
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    variants = list(product_with_two_variants.variants.all())
+    variant_x, variant_y = variants[0], variants[1]
+
+    stock_a_x = Stock.objects.get(product_variant=variant_x, warehouse=warehouse)
+    stock_a_x.quantity = 0
+    stock_a_y = Stock.objects.get(product_variant=variant_y, warehouse=warehouse)
+    stock_a_y.quantity = 5
+    Stock.objects.bulk_update([stock_a_x, stock_a_y], ["quantity"])
+
+    warehouse_b = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="warehouse-b",
+        slug="warehouse-b",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    warehouse_b.channels.add(channel_USD)
+    stock_b_y = Stock.objects.create(
+        product_variant=variant_y, warehouse=warehouse_b, quantity=0
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events_for_stocks(
+        [stock_a_x, stock_b_y], site_settings
+    )
+
+    # then - only variant X fires (warehouse B has no stock for variant X)
+    # variant Y does not fire (warehouse A has availability for variant Y)
+    mocked_out.assert_called_once()
+    assert mocked_out.call_args.args[0].variant_id == variant_x.id
+
+
+def test_bulk_mixed_cc_and_non_cc_stocks(
+    variant, warehouse, channel_USD, address, site_settings, mocker
+):
+    # given - one non-C&C stock and one C&C stock, both at 0
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    mocked_out_cc = mocker.patch(OUT_CC)
+    cc_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="cc",
+        slug="cc",
+        click_and_collect_option=WarehouseClickAndCollectOption.LOCAL_STOCK,
+    )
+    cc_warehouse.channels.add(channel_USD)
+    stock_non_cc, stock_cc = Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouse, quantity=0),
+            Stock(product_variant=variant, warehouse=cc_warehouse, quantity=0),
+        ]
+    )
+
+    # when
+    trigger_out_of_stock_in_channel_events_for_stocks(
+        [stock_non_cc, stock_cc], site_settings
+    )
+
+    # then - each fires in its own event type
+    mocked_out.assert_called_once()
+    assert mocked_out.call_args.args[0].variant_id == variant.id
+    mocked_out_cc.assert_called_once()
+    assert mocked_out_cc.call_args.args[0].variant_id == variant.id
+
+
+def test_bulk_multi_channel_fires_per_channel_independently(
+    variant, warehouse, channel_USD, channel_PLN, address, site_settings, mocker
+):
+    # given - warehouse in both channels; another warehouse with stock only in USD
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+    warehouse.channels.add(channel_PLN)
+    stock = Stock.objects.create(
+        product_variant=variant, warehouse=warehouse, quantity=0
+    )
+    other_warehouse = Warehouse.objects.create(
+        address=address.get_copy(),
+        name="usd-only",
+        slug="usd-only",
+        click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+    )
+    other_warehouse.channels.add(channel_USD)
+    Stock.objects.create(product_variant=variant, warehouse=other_warehouse, quantity=5)
+
+    # when
+    trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
+
+    # then - fires only for PLN (USD has other warehouse with stock)
+    mocked_out.assert_called_once()
+    assert mocked_out.call_args.args[0].channel_slug == channel_PLN.slug
+
+
+def test_bulk_empty_list_does_not_fire(site_settings, mocker):
+    # given
+    mocked_out = mocker.patch(OUT_IN_CHANNEL)
+
+    # when
+    trigger_out_of_stock_in_channel_events_for_stocks([], site_settings)
+
+    # then
+    mocked_out.assert_not_called()

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -1464,7 +1464,7 @@ def test_allocate_preorders_with_global_reservations(
 
 
 @mock.patch(
-    "saleor.warehouse.management.trigger_out_of_stock_in_channel_events_for_stocks"
+    "saleor.warehouse.channel_stock_availability.trigger_out_of_stock_in_channel_events_for_stocks"
 )
 def test_allocate_stocks_triggers_channel_out_of_stock_event_when_stock_runs_out(
     mocked_trigger,
@@ -1502,7 +1502,7 @@ def test_allocate_stocks_triggers_channel_out_of_stock_event_when_stock_runs_out
 
 
 @mock.patch(
-    "saleor.warehouse.management.trigger_out_of_stock_in_channel_events_for_stocks"
+    "saleor.warehouse.channel_stock_availability.trigger_out_of_stock_in_channel_events_for_stocks"
 )
 def test_allocate_stocks_does_not_trigger_channel_event_when_stock_remains(
     mocked_trigger,
@@ -1534,7 +1534,7 @@ def test_allocate_stocks_does_not_trigger_channel_event_when_stock_remains(
 
 
 @mock.patch(
-    "saleor.warehouse.management.trigger_out_of_stock_in_channel_events_for_stocks"
+    "saleor.warehouse.channel_stock_availability.trigger_out_of_stock_in_channel_events_for_stocks"
 )
 def test_allocate_stocks_skips_channel_event_when_legacy_flag_enabled(
     mocked_trigger,
@@ -1568,7 +1568,7 @@ def test_allocate_stocks_skips_channel_event_when_legacy_flag_enabled(
 
 
 @mock.patch(
-    "saleor.warehouse.management.trigger_back_in_stock_in_channel_events_for_stocks"
+    "saleor.warehouse.channel_stock_availability.trigger_back_in_stock_in_channel_events_for_stocks"
 )
 def test_deallocate_stock_triggers_channel_back_in_stock_event_when_stock_returns(
     mocked_trigger,
@@ -1607,7 +1607,7 @@ def test_deallocate_stock_triggers_channel_back_in_stock_event_when_stock_return
 
 
 @mock.patch(
-    "saleor.warehouse.management.trigger_back_in_stock_in_channel_events_for_stocks"
+    "saleor.warehouse.channel_stock_availability.trigger_back_in_stock_in_channel_events_for_stocks"
 )
 def test_deallocate_stock_skips_channel_event_when_legacy_flag_enabled(
     mocked_trigger,
@@ -1641,7 +1641,7 @@ def test_deallocate_stock_skips_channel_event_when_legacy_flag_enabled(
 
 
 @mock.patch(
-    "saleor.warehouse.management.trigger_back_in_stock_in_channel_events_for_stocks"
+    "saleor.warehouse.channel_stock_availability.trigger_back_in_stock_in_channel_events_for_stocks"
 )
 def test_deallocate_stock_for_orders_triggers_channel_back_in_stock_event(
     mocked_trigger,
@@ -1677,7 +1677,7 @@ def test_deallocate_stock_for_orders_triggers_channel_back_in_stock_event(
 
 
 @mock.patch(
-    "saleor.warehouse.management.trigger_back_in_stock_in_channel_events_for_stocks"
+    "saleor.warehouse.channel_stock_availability.trigger_back_in_stock_in_channel_events_for_stocks"
 )
 def test_deallocate_stock_for_orders_skips_channel_event_when_legacy_flag_enabled(
     mocked_trigger,

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -1463,7 +1463,9 @@ def test_allocate_preorders_with_global_reservations(
     )
 
 
-@mock.patch("saleor.warehouse.management.trigger_out_of_stock_in_channel_events")
+@mock.patch(
+    "saleor.warehouse.management.trigger_out_of_stock_in_channel_events_for_stocks"
+)
 def test_allocate_stocks_triggers_channel_out_of_stock_event_when_stock_runs_out(
     mocked_trigger,
     order_line,
@@ -1493,12 +1495,15 @@ def test_allocate_stocks_triggers_channel_out_of_stock_event_when_stock_runs_out
 
     # then
     mocked_trigger.assert_called_once()
-    fired_stock, fired_settings = mocked_trigger.call_args.args
-    assert fired_stock.pk == stock.pk
+    fired_stocks, fired_settings = mocked_trigger.call_args.args
+    assert len(fired_stocks) == 1
+    assert fired_stocks[0].pk == stock.pk
     assert fired_settings is site_settings
 
 
-@mock.patch("saleor.warehouse.management.trigger_out_of_stock_in_channel_events")
+@mock.patch(
+    "saleor.warehouse.management.trigger_out_of_stock_in_channel_events_for_stocks"
+)
 def test_allocate_stocks_does_not_trigger_channel_event_when_stock_remains(
     mocked_trigger,
     order_line,
@@ -1528,7 +1533,9 @@ def test_allocate_stocks_does_not_trigger_channel_event_when_stock_remains(
     mocked_trigger.assert_not_called()
 
 
-@mock.patch("saleor.warehouse.management.trigger_out_of_stock_in_channel_events")
+@mock.patch(
+    "saleor.warehouse.management.trigger_out_of_stock_in_channel_events_for_stocks"
+)
 def test_allocate_stocks_skips_channel_event_when_legacy_flag_enabled(
     mocked_trigger,
     order_line,
@@ -1560,7 +1567,9 @@ def test_allocate_stocks_skips_channel_event_when_legacy_flag_enabled(
     mocked_trigger.assert_not_called()
 
 
-@mock.patch("saleor.warehouse.management.trigger_back_in_stock_in_channel_events")
+@mock.patch(
+    "saleor.warehouse.management.trigger_back_in_stock_in_channel_events_for_stocks"
+)
 def test_deallocate_stock_triggers_channel_back_in_stock_event_when_stock_returns(
     mocked_trigger,
     allocation,
@@ -1591,12 +1600,15 @@ def test_deallocate_stock_triggers_channel_back_in_stock_event_when_stock_return
 
     # then
     mocked_trigger.assert_called_once()
-    fired_stock, fired_settings = mocked_trigger.call_args.args
-    assert fired_stock.pk == stock.pk
+    fired_stocks, fired_settings = mocked_trigger.call_args.args
+    assert len(fired_stocks) == 1
+    assert fired_stocks[0].pk == stock.pk
     assert fired_settings is site_settings
 
 
-@mock.patch("saleor.warehouse.management.trigger_back_in_stock_in_channel_events")
+@mock.patch(
+    "saleor.warehouse.management.trigger_back_in_stock_in_channel_events_for_stocks"
+)
 def test_deallocate_stock_skips_channel_event_when_legacy_flag_enabled(
     mocked_trigger,
     allocation,
@@ -1628,7 +1640,9 @@ def test_deallocate_stock_skips_channel_event_when_legacy_flag_enabled(
     mocked_trigger.assert_not_called()
 
 
-@mock.patch("saleor.warehouse.management.trigger_back_in_stock_in_channel_events")
+@mock.patch(
+    "saleor.warehouse.management.trigger_back_in_stock_in_channel_events_for_stocks"
+)
 def test_deallocate_stock_for_orders_triggers_channel_back_in_stock_event(
     mocked_trigger,
     order_line_with_allocation_in_many_stocks,
@@ -1641,10 +1655,12 @@ def test_deallocate_stock_for_orders_triggers_channel_back_in_stock_event(
     site_settings.save(update_fields=["use_legacy_shipping_zone_stock_availability"])
     order_line = order_line_with_allocation_in_many_stocks
     order = order_line.order
+    stocks = []
     for allocation in Allocation.objects.filter(order_line__order=order):
         stock = allocation.stock
         stock.quantity = allocation.quantity_allocated
         stock.save(update_fields=["quantity"])
+        stocks.append(stock)
 
     # when
     with django_capture_on_commit_callbacks(execute=True):
@@ -1654,11 +1670,15 @@ def test_deallocate_stock_for_orders_triggers_channel_back_in_stock_event(
             site_settings=site_settings,
         )
 
-    # then
-    assert mocked_trigger.call_count >= 1
+    # then - fires once with all affected stocks (bulk)
+    mocked_trigger.assert_called_once()
+    fired_stocks = mocked_trigger.call_args.args[0]
+    assert len(fired_stocks) == len(stocks)
 
 
-@mock.patch("saleor.warehouse.management.trigger_back_in_stock_in_channel_events")
+@mock.patch(
+    "saleor.warehouse.management.trigger_back_in_stock_in_channel_events_for_stocks"
+)
 def test_deallocate_stock_for_orders_skips_channel_event_when_legacy_flag_enabled(
     mocked_trigger,
     order_line_with_allocation_in_many_stocks,

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -33,6 +33,7 @@ from ....graphql.webhook.subscription_payload import (
     get_pre_save_payload_key,
     initialize_request,
 )
+from ....graphql.webhook.subscription_types import WEBHOOK_TYPES_MAP
 from ... import observability
 from ...event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...observability import WebhookData
@@ -106,10 +107,6 @@ def create_deliveries_for_multiple_subscription_objects(
     :return: List of event deliveries to send via webhook tasks.
     :param allow_replica: use replica database.
     """
-    # local import: top-level import would chain into the graphql tree and break
-    # early importers like saleor.warehouse.management
-    from ....graphql.webhook.subscription_types import WEBHOOK_TYPES_MAP
-
     if event_type not in WEBHOOK_TYPES_MAP:
         logger.info(
             "Skipping subscription webhook. Event %s is not subscribable.", event_type


### PR DESCRIPTION
- Call stock channel events in product variant stock mutations:
  - `productVariantStocksDelete`
  - `productVariantStocksCreate`
  - `productVariantStocksUpdate`
- Adjust methods for calling stock channel events to calculate for batches of stocks - one event per variant per channel is send
- Adjust relatives imports: drop relative import from `saleor/webhook/transport/asynchronous/transport.py`

[Plan](https://explain.dalibo.com/plan/58251g9h82hgd0h8) for stocks with available quantity.
[Plan](https://explain.dalibo.com/plan/62g5cb6a381ag45g) for warehouse to channels map.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
