### PR TITLE
Add checkoutDelete mutation

### DIFF
--- a/saleor/graphql/checkout/mutations/__init__.py
+++ b/saleor/graphql/checkout/mutations/__init__.py
@@ -6,6 +6,7 @@ from .checkout_create_from_order import CheckoutCreateFromOrder
 from .checkout_customer_attach import CheckoutCustomerAttach
 from .checkout_customer_detach import CheckoutCustomerDetach
 from .checkout_customer_note_update import CheckoutCustomerNoteUpdate
+from .checkout_delete import CheckoutDelete
 from .checkout_delivery_method_update import CheckoutDeliveryMethodUpdate
 from .checkout_email_update import CheckoutEmailUpdate
 from .checkout_language_code_update import CheckoutLanguageCodeUpdate
@@ -27,6 +28,7 @@ __all__ = [
     "CheckoutCustomerAttach",
     "CheckoutCustomerDetach",
     "CheckoutCustomerNoteUpdate",
+    "CheckoutDelete",
     "CheckoutDeliveryMethodUpdate",
     "CheckoutEmailUpdate",
     "CheckoutLanguageCodeUpdate",

--- a/saleor/graphql/checkout/mutations/checkout_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_delete.py
@@ -4,7 +4,7 @@ from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.models import Checkout as CheckoutModel
 from ....permission.enums import CheckoutPermissions
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_324
+from ...core.descriptions import ADDED_IN_323
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.enums import CheckoutErrorCode as CheckoutErrorCodeEnum
 from ...core.mutations import BaseMutation
@@ -22,12 +22,12 @@ class CheckoutDeleteError(Error):
 class CheckoutDelete(BaseMutation):
     class Arguments:
         id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_324,
+            description="The checkout's ID." + ADDED_IN_323,
             required=True,
         )
 
     class Meta:
-        description = "Deletes a checkout." + ADDED_IN_324
+        description = "Deletes a checkout." + ADDED_IN_323
         doc_category = DOC_CATEGORY_CHECKOUT
         permissions = (CheckoutPermissions.MANAGE_CHECKOUTS,)
         error_type_class = CheckoutDeleteError

--- a/saleor/graphql/checkout/mutations/checkout_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_delete.py
@@ -1,7 +1,9 @@
 import graphene
+from django.core.exceptions import ValidationError
 
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.models import Checkout as CheckoutModel
+from ....checkout.utils import delete_checkouts
 from ....permission.enums import CheckoutPermissions
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_323
@@ -43,5 +45,14 @@ class CheckoutDelete(BaseMutation):
             qs=CheckoutModel.objects,
             code=CheckoutErrorCode.NOT_FOUND.value,
         )
-        checkout.delete()
+        if checkout.payment_transactions.exists():
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        "Cannot delete checkout with attached transactions.",
+                        code=CheckoutErrorCode.INVALID.value,
+                    )
+                }
+            )
+        delete_checkouts([checkout.pk])
         return CheckoutDelete()

--- a/saleor/graphql/checkout/mutations/checkout_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_delete.py
@@ -33,7 +33,9 @@ class CheckoutDelete(BaseMutation):
         error_type_class = CheckoutDeleteError
 
     @classmethod
-    def perform_mutation(cls, _root, info: ResolveInfo, /, *, id: str):
+    def perform_mutation(  # type: ignore[override]
+        cls, _root, info: ResolveInfo, /, *, id: str
+    ):
         checkout = cls.get_node_or_error(
             info,
             id,

--- a/saleor/graphql/checkout/mutations/checkout_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_delete.py
@@ -1,0 +1,45 @@
+import graphene
+
+from ....checkout.error_codes import CheckoutErrorCode
+from ....checkout.models import Checkout as CheckoutModel
+from ....permission.enums import CheckoutPermissions
+from ...core import ResolveInfo
+from ...core.descriptions import ADDED_IN_324
+from ...core.doc_category import DOC_CATEGORY_CHECKOUT
+from ...core.enums import CheckoutErrorCode as CheckoutErrorCodeEnum
+from ...core.mutations import BaseMutation
+from ...core.types import Error
+from ..types import Checkout
+
+
+class CheckoutDeleteError(Error):
+    code = CheckoutErrorCodeEnum(description="The error code.", required=True)
+
+    class Meta:
+        doc_category = DOC_CATEGORY_CHECKOUT
+
+
+class CheckoutDelete(BaseMutation):
+    class Arguments:
+        id = graphene.ID(
+            description="The checkout's ID." + ADDED_IN_324,
+            required=True,
+        )
+
+    class Meta:
+        description = "Deletes a checkout." + ADDED_IN_324
+        doc_category = DOC_CATEGORY_CHECKOUT
+        permissions = (CheckoutPermissions.MANAGE_CHECKOUTS,)
+        error_type_class = CheckoutDeleteError
+
+    @classmethod
+    def perform_mutation(cls, _root, info: ResolveInfo, /, *, id: str):
+        checkout = cls.get_node_or_error(
+            info,
+            id,
+            only_type=Checkout,
+            qs=CheckoutModel.objects,
+            code=CheckoutErrorCode.NOT_FOUND.value,
+        )
+        checkout.delete()
+        return CheckoutDelete()

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -26,6 +26,7 @@ from .mutations import (
     CheckoutCustomerAttach,
     CheckoutCustomerDetach,
     CheckoutCustomerNoteUpdate,
+    CheckoutDelete,
     CheckoutDeliveryMethodUpdate,
     CheckoutEmailUpdate,
     CheckoutLanguageCodeUpdate,
@@ -132,6 +133,7 @@ class CheckoutMutations(graphene.ObjectType):
     checkout_customer_attach = CheckoutCustomerAttach.Field()
     checkout_customer_detach = CheckoutCustomerDetach.Field()
     checkout_customer_note_update = CheckoutCustomerNoteUpdate.Field()
+    checkout_delete = CheckoutDelete.Field()
     checkout_email_update = CheckoutEmailUpdate.Field()
     checkout_line_delete = CheckoutLineDelete.Field(
         deprecation_reason="Use `checkoutLinesDelete` instead."

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delete.py
@@ -3,6 +3,7 @@ import pytest
 
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.models import Checkout
+from .....payment.models import TransactionItem
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
 
@@ -166,3 +167,33 @@ def test_checkout_delete_with_id_of_different_type(
         f"Invalid ID: {fake_checkout_id}. Expected: Checkout, received: User."
     )
     assert Checkout.objects.filter(pk=checkout.pk).exists()
+
+
+def test_checkout_delete_with_attached_transaction(
+    staff_api_client,
+    checkout_with_items,
+    permission_manage_checkouts,
+    transaction_item_generator,
+):
+    # given
+    checkout = checkout_with_items
+    checkout_id = to_global_id_or_none(checkout)
+    transaction = transaction_item_generator(checkout_id=checkout.pk)
+    variables = {"id": checkout_id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_CHECKOUT_DELETE,
+        variables,
+        permissions=[permission_manage_checkouts],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["checkoutDelete"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "id"
+    assert errors[0]["code"] == CheckoutErrorCode.INVALID.name
+    assert errors[0]["message"] == "Cannot delete checkout with attached transactions."
+    assert Checkout.objects.filter(pk=checkout.pk).exists()
+    assert TransactionItem.objects.filter(pk=transaction.pk).exists()

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delete.py
@@ -1,0 +1,138 @@
+import graphene
+import pytest
+
+from .....checkout.error_codes import CheckoutErrorCode
+from .....checkout.models import Checkout
+from ....core.utils import to_global_id_or_none
+from ....tests.utils import assert_no_permission, get_graphql_content
+
+MUTATION_CHECKOUT_DELETE = """
+    mutation checkoutDelete($id: ID!) {
+        checkoutDelete(id: $id) {
+            errors {
+                message
+                code
+                field
+            }
+        }
+    }
+"""
+
+
+def test_checkout_delete_by_staff(
+    staff_api_client, checkout_with_items, permission_manage_checkouts
+):
+    # given
+    checkout = checkout_with_items
+    checkout_id = to_global_id_or_none(checkout)
+    variables = {"id": checkout_id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_CHECKOUT_DELETE,
+        variables,
+        permissions=[permission_manage_checkouts],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutDelete"]
+    assert data["errors"] == []
+    assert not Checkout.objects.filter(pk=checkout.pk).exists()
+
+
+def test_checkout_delete_by_app(
+    app_api_client, checkout_with_items, permission_manage_checkouts
+):
+    # given
+    checkout = checkout_with_items
+    checkout_id = to_global_id_or_none(checkout)
+    variables = {"id": checkout_id}
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_CHECKOUT_DELETE,
+        variables,
+        permissions=[permission_manage_checkouts],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutDelete"]
+    assert data["errors"] == []
+    assert not Checkout.objects.filter(pk=checkout.pk).exists()
+
+
+@pytest.mark.parametrize("client", ["api_client", "user_api_client"])
+def test_checkout_delete_without_permission_is_denied(
+    client, request, checkout_with_items
+):
+    # given
+    api_client = request.getfixturevalue(client)
+    checkout = checkout_with_items
+    checkout_id = to_global_id_or_none(checkout)
+    variables = {"id": checkout_id}
+
+    # when
+    response = api_client.post_graphql(MUTATION_CHECKOUT_DELETE, variables)
+
+    # then
+    assert_no_permission(response)
+    assert Checkout.objects.filter(pk=checkout.pk).exists()
+
+
+def test_checkout_delete_by_staff_without_permission_is_denied(
+    staff_api_client, checkout_with_items
+):
+    # given
+    checkout = checkout_with_items
+    checkout_id = to_global_id_or_none(checkout)
+    variables = {"id": checkout_id}
+
+    # when
+    response = staff_api_client.post_graphql(MUTATION_CHECKOUT_DELETE, variables)
+
+    # then
+    assert_no_permission(response)
+    assert Checkout.objects.filter(pk=checkout.pk).exists()
+
+
+def test_checkout_delete_by_app_without_permission_is_denied(
+    app_api_client, checkout_with_items
+):
+    # given
+    checkout = checkout_with_items
+    checkout_id = to_global_id_or_none(checkout)
+    variables = {"id": checkout_id}
+
+    # when
+    response = app_api_client.post_graphql(MUTATION_CHECKOUT_DELETE, variables)
+
+    # then
+    assert_no_permission(response)
+    assert Checkout.objects.filter(pk=checkout.pk).exists()
+
+
+def test_checkout_delete_invalid_checkout_id(
+    staff_api_client, checkout_with_items, permission_manage_checkouts
+):
+    # given
+    checkout = checkout_with_items
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    checkout.delete()
+    variables = {"id": checkout_id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_CHECKOUT_DELETE,
+        variables,
+        permissions=[permission_manage_checkouts],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["checkoutDelete"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "id"
+    assert errors[0]["code"] == CheckoutErrorCode.NOT_FOUND.name
+    assert errors[0]["message"] == f"Couldn't resolve to a node: {checkout_id}"

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delete.py
@@ -136,3 +136,33 @@ def test_checkout_delete_invalid_checkout_id(
     assert errors[0]["field"] == "id"
     assert errors[0]["code"] == CheckoutErrorCode.NOT_FOUND.name
     assert errors[0]["message"] == f"Couldn't resolve to a node: {checkout_id}"
+
+
+def test_checkout_delete_with_id_of_different_type(
+    staff_api_client,
+    checkout_with_items,
+    customer_user,
+    permission_manage_checkouts,
+):
+    # given
+    checkout = checkout_with_items
+    fake_checkout_id = graphene.Node.to_global_id("User", customer_user.pk)
+    variables = {"id": fake_checkout_id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_CHECKOUT_DELETE,
+        variables,
+        permissions=[permission_manage_checkouts],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["checkoutDelete"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "id"
+    assert errors[0]["code"] == CheckoutErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["message"] == (
+        f"Invalid ID: {fake_checkout_id}. Expected: Checkout, received: User."
+    )
+    assert Checkout.objects.filter(pk=checkout.pk).exists()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20675,14 +20675,16 @@ type Mutation {
   """
   Deletes a checkout.
   
-  Added in Saleor 3.24.
+  Added in Saleor 3.24. 
   
   Requires one of the following permissions: MANAGE_CHECKOUTS.
   """
   checkoutDelete(
-    """The checkout's ID.
+    """
+    The checkout's ID.
     
-    Added in Saleor 3.24."""
+    Added in Saleor 3.24.
+    """
     id: ID!
   ): CheckoutDelete @doc(category: "Checkout")
 
@@ -30658,7 +30660,7 @@ type CheckoutCustomerNoteUpdate @doc(category: "Checkout") @webhookEventsInfo(as
 """
 Deletes a checkout.
 
-Added in Saleor 3.24.
+Added in Saleor 3.24. 
 
 Requires one of the following permissions: MANAGE_CHECKOUTS.
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20675,7 +20675,7 @@ type Mutation {
   """
   Deletes a checkout.
   
-  Added in Saleor 3.24. 
+  Added in Saleor 3.23. 
   
   Requires one of the following permissions: MANAGE_CHECKOUTS.
   """
@@ -20683,7 +20683,7 @@ type Mutation {
     """
     The checkout's ID.
     
-    Added in Saleor 3.24.
+    Added in Saleor 3.23.
     """
     id: ID!
   ): CheckoutDelete @doc(category: "Checkout")
@@ -30660,7 +30660,7 @@ type CheckoutCustomerNoteUpdate @doc(category: "Checkout") @webhookEventsInfo(as
 """
 Deletes a checkout.
 
-Added in Saleor 3.24. 
+Added in Saleor 3.23. 
 
 Requires one of the following permissions: MANAGE_CHECKOUTS.
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20673,6 +20673,20 @@ type Mutation {
   ): CheckoutCustomerNoteUpdate @doc(category: "Checkout") @webhookEventsInfo(asyncEvents: [CHECKOUT_UPDATED], syncEvents: [])
 
   """
+  Deletes a checkout.
+  
+  Added in Saleor 3.24.
+  
+  Requires one of the following permissions: MANAGE_CHECKOUTS.
+  """
+  checkoutDelete(
+    """The checkout's ID.
+    
+    Added in Saleor 3.24."""
+    id: ID!
+  ): CheckoutDelete @doc(category: "Checkout")
+
+  """
   Updates email address in the existing checkout object.
   
   Triggers the following webhook events:
@@ -30639,6 +30653,30 @@ type CheckoutCustomerNoteUpdate @doc(category: "Checkout") @webhookEventsInfo(as
   checkout: Checkout
   checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use `errors` field instead.")
   errors: [CheckoutError!]!
+}
+
+"""
+Deletes a checkout.
+
+Added in Saleor 3.24.
+
+Requires one of the following permissions: MANAGE_CHECKOUTS.
+"""
+type CheckoutDelete @doc(category: "Checkout") {
+  errors: [CheckoutDeleteError!]!
+}
+
+type CheckoutDeleteError @doc(category: "Checkout") {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: CheckoutErrorCode!
 }
 
 """


### PR DESCRIPTION
## Summary
- Add checkoutDelete(id: ID!) mutation guarded by MANAGE_CHECKOUTS
- Return only a dedicated CheckoutDeleteError errors list, with no checkout payload
- Register the mutation in the checkout schema and checked-in GraphQL schema
- Add coverage for staff/app access, permission denial, and missing checkout errors

Closes #19114