### PR TITLE
fix: raise GraphQLError for invalid weight inputs in WeightScalar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Webhooks
 
 ### Other changes
+- Fixed `WeightScalar.parse_value()` to raise `GraphQLError` with descriptive messages instead of crashing with `TypeError` when weight inputs contain null, negative, or invalid values. Fixes #18680.
 
 #### Search improvements
 

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -5,6 +5,7 @@ import graphene
 from graphene.types.generic import GenericScalar
 from graphql.language import ast
 from measurement.measures import Weight
+from graphql.error import GraphQLError
 
 from ...core.weight import (
     convert_weight_to_default_weight_unit,
@@ -96,10 +97,33 @@ class WeightScalar(graphene.Scalar):
     @staticmethod
     def parse_value(value):
         if isinstance(value, dict):
-            weight = Weight(**{value["unit"]: value["value"]})
+            unit = value.get("unit")
+            weight_value = value.get("value")
+
+            if unit is None:
+                raise GraphQLError("Weight unit cannot be null.")
+            if weight_value is None:
+                raise GraphQLError("Weight value cannot be null.")
+
+            try:
+                weight_decimal = decimal.Decimal(str(weight_value))
+            except decimal.DecimalException:
+                raise GraphQLError(
+                    f"Weight value must be a number, got: {weight_value!r}"
+                )
+
+            if weight_decimal < 0:
+                raise GraphQLError("Weight value cannot be negative.")
+
+            try:
+                return Weight(**{unit: weight_decimal})
+            except (TypeError, ValueError, AttributeError):
+                raise GraphQLError(
+                    f"Invalid weight unit: {unit!r}. "
+                    "Use a valid unit such as 'KG', 'LB', 'OZ', or 'G'."
+                )
         else:
-            weight = WeightScalar.parse_decimal(value)
-        return weight
+            return WeightScalar.parse_decimal(value)
 
     @staticmethod
     def serialize(weight):

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -6,6 +6,9 @@ from ....order.models import Order
 from ....payment.interface import PaymentGatewayData
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
 from ..utils import to_global_id_or_none
+from ..scalars import WeightScalar
+from graphql.error import GraphQLError
+
 
 QUERY_CHECKOUT = """
 query getCheckout($token: UUID!) {
@@ -419,3 +422,44 @@ def test_correct_date_time_as_input(
 
     # then
     get_graphql_content(response)
+
+    
+# --- WeightScalar.parse_value tests ---
+
+def test_weight_scalar_parse_value_null_value():
+    """Reproduces issue #18680: null value should raise GraphQLError, not TypeError."""
+    with pytest.raises(GraphQLError, match="Weight value cannot be null."):
+        WeightScalar.parse_value({"unit": "KG", "value": None})
+
+
+def test_weight_scalar_parse_value_null_unit():
+    with pytest.raises(GraphQLError, match="Weight unit cannot be null."):
+        WeightScalar.parse_value({"unit": None, "value": 5.0})
+
+
+def test_weight_scalar_parse_value_negative():
+    with pytest.raises(GraphQLError, match="Weight value cannot be negative."):
+        WeightScalar.parse_value({"unit": "KG", "value": -5.0})
+
+
+def test_weight_scalar_parse_value_invalid_unit():
+    with pytest.raises(GraphQLError, match="Invalid weight unit"):
+        WeightScalar.parse_value({"unit": "INVALID", "value": 5.0})
+
+
+def test_weight_scalar_parse_value_non_numeric():
+    with pytest.raises(GraphQLError, match="Weight value must be a number"):
+        WeightScalar.parse_value({"unit": "KG", "value": "not-a-number"})
+
+
+def test_weight_scalar_parse_value_valid():
+    from measurement.measures import Weight
+    result = WeightScalar.parse_value({"unit": "KG", "value": 5.0})
+    assert isinstance(result, Weight)
+
+
+def test_weight_scalar_parse_value_zero():
+    """Zero is a valid weight (e.g. for digital products)."""
+    from measurement.measures import Weight
+    result = WeightScalar.parse_value({"unit": "KG", "value": 0})
+    assert isinstance(result, Weight)

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -24,7 +24,6 @@ from ...order.models import Order
 from ...payment import TransactionAction, TransactionEventType
 from ...payment.interface import RefundData, TransactionActionData, TransactionData
 from ...payment.models import TransactionItem
-from ...plugins.manager import get_plugins_manager
 from ...product.models import ProductVariant
 from ...warehouse import WarehouseClickAndCollectOption
 from ..payloads import (


### PR DESCRIPTION
- Add null checks for unit and value fields
- Add negative value validation
- Add descriptive error messages instead of silent None returns or TypeError crashes
- Add unit tests covering all invalid input cases

Fixes #18680

This fixes a `TypeError` crash in `WeightScalar.parse_value()` when weight inputs contain null, negative, or invalid values. Instead of crashing or returning `None` silently, the fix raises `GraphQLError` with descriptive messages consistent with Saleor's existing validation patterns. Also adds negative value validation not present in PR #18684.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: No documentation changes required — this is a bug fix to internal scalar validation.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
