### PR TITLE
Fix out of stock and back in stocks

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_variant_stocks_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_stocks_update.py
@@ -118,10 +118,11 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
             stock, is_created = warehouse_models.Stock.objects.get_or_create(
                 product_variant=variant, warehouse=warehouse
             )
-            if is_created or (
-                (stock.quantity - stock.quantity_allocated)
-                <= 0
-                < stock_data["quantity"]
+            old_available = stock.quantity - stock.quantity_allocated
+            new_available = stock_data["quantity"] - stock.quantity_allocated
+
+            if (is_created and new_available > 0) or (
+                old_available <= 0 < new_available
             ):
                 cls.call_event(
                     manager.product_variant_back_in_stock,
@@ -130,9 +131,7 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
                 )
                 back_in_stock_stocks.append(stock)
 
-            if stock_data["quantity"] <= 0 or (
-                stock_data["quantity"] - stock.quantity_allocated <= 0
-            ):
+            if old_available > 0 >= new_available:
                 cls.call_event(
                     manager.product_variant_out_of_stock,
                     stock,

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
@@ -388,9 +388,10 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
     any_webhook,
     django_capture_on_commit_callbacks,
 ):
+    # given — stocks currently have availability, update drops both to 0
     Stock.objects.bulk_create(
         [
-            Stock(product_variant=variant, warehouse=warehouse)
+            Stock(product_variant=variant, warehouse=warehouse, quantity=5)
             for warehouse in warehouses
         ]
     )
@@ -401,14 +402,16 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
     stocks_data = [
         {"quantity": 0, "warehouse": "123"},
     ]
-    assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 0
+    assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 10
 
+    # when
     with django_capture_on_commit_callbacks(execute=True):
         ProductVariantStocksUpdate.update_or_create_variant_stocks(
             variant, stocks_data, warehouses, plugins, site_settings
         )
 
-    assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 0
+    # then — updated stock transitioned from available (5) to out of stock (0)
+    assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 5
 
     stock = Stock.objects.all()[1]
     product_variant_back_in_stock_webhook.assert_not_called()


### PR DESCRIPTION
Adjust `productVariantStocksUpdate` as the stock events were not properly called. 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
