### PR TITLE
Trigger channel stock events for multiple objects

### DIFF
--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_create.py
@@ -323,9 +323,10 @@ def test_create_stocks_triggers_back_in_stock_in_channel_for_non_cc_warehouses(
 
     # then - fires once per (variant, channel), dedup across the two warehouses
     mocked_trigger.assert_called_once()
-    stock_info = mocked_trigger.call_args.args[0]
-    assert stock_info.variant_id == variant.id
-    assert stock_info.channel_slug == channel_USD.slug
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].variant_id == variant.id
+    assert stock_infos[0].channel_slug == channel_USD.slug
 
 
 @mock.patch(
@@ -385,9 +386,10 @@ def test_create_stocks_triggers_back_in_stock_for_click_and_collect(
 
     # then
     mocked_trigger.assert_called_once()
-    stock_info = mocked_trigger.call_args.args[0]
-    assert stock_info.variant_id == variant.id
-    assert stock_info.channel_slug == channel_USD.slug
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].variant_id == variant.id
+    assert stock_infos[0].channel_slug == channel_USD.slug
 
 
 @mock.patch(

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_delete.py
@@ -221,9 +221,10 @@ def test_delete_stocks_triggers_out_of_stock_in_channel_for_non_cc_warehouses(
 
     # then - fires once per (variant, channel), dedup across warehouses
     mocked_trigger.assert_called_once()
-    stock_info = mocked_trigger.call_args.args[0]
-    assert stock_info.variant_id == variant.id
-    assert stock_info.channel_slug == channel_USD.slug
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].variant_id == variant.id
+    assert stock_infos[0].channel_slug == channel_USD.slug
 
 
 @mock.patch(
@@ -283,9 +284,10 @@ def test_delete_stocks_triggers_out_of_stock_for_click_and_collect(
 
     # then
     mocked_trigger.assert_called_once()
-    stock_info = mocked_trigger.call_args.args[0]
-    assert stock_info.variant_id == variant.id
-    assert stock_info.channel_slug == channel_USD.slug
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].variant_id == variant.id
+    assert stock_infos[0].channel_slug == channel_USD.slug
 
 
 @mock.patch(

--- a/saleor/warehouse/channel_stock_availability.py
+++ b/saleor/warehouse/channel_stock_availability.py
@@ -64,21 +64,22 @@ def trigger_out_of_stock_in_channel_events_for_stocks(
         if not grouped_stocks:
             continue
 
-        for (
-            variant_id,
-            channel_slug,
-        ) in _get_variant_channels_without_other_availability(
-            grouped_stocks, cc_options
-        ):
-            trigger(
-                VariantChannelStockInfo(
-                    variant_id=variant_id,
-                    channel_slug=channel_slug,
-                ),
-                site_settings,
-                requestor=requestor,
-                webhooks=webhooks,
+        stock_infos = [
+            VariantChannelStockInfo(variant_id=variant_id, channel_slug=channel_slug)
+            for variant_id, channel_slug in (
+                _get_variant_channels_without_other_availability(
+                    grouped_stocks, cc_options
+                )
             )
+        ]
+        if not stock_infos:
+            continue
+        trigger(
+            stock_infos,
+            site_settings,
+            requestor=requestor,
+            webhooks=webhooks,
+        )
 
 
 def trigger_back_in_stock_in_channel_events_for_stocks(
@@ -117,21 +118,22 @@ def trigger_back_in_stock_in_channel_events_for_stocks(
         if not grouped_stocks:
             continue
 
-        for (
-            variant_id,
-            channel_slug,
-        ) in _get_variant_channels_without_other_availability(
-            grouped_stocks, cc_options
-        ):
-            trigger(
-                VariantChannelStockInfo(
-                    variant_id=variant_id,
-                    channel_slug=channel_slug,
-                ),
-                site_settings,
-                requestor=requestor,
-                webhooks=webhooks,
+        stock_infos = [
+            VariantChannelStockInfo(variant_id=variant_id, channel_slug=channel_slug)
+            for variant_id, channel_slug in (
+                _get_variant_channels_without_other_availability(
+                    grouped_stocks, cc_options
+                )
             )
+        ]
+        if not stock_infos:
+            continue
+        trigger(
+            stock_infos,
+            site_settings,
+            requestor=requestor,
+            webhooks=webhooks,
+        )
 
 
 def _split_stocks_by_click_and_collect(

--- a/saleor/warehouse/tests/test_channel_stock_availability.py
+++ b/saleor/warehouse/tests/test_channel_stock_availability.py
@@ -38,10 +38,10 @@ def test_out_of_stock_fires_when_only_warehouse_in_bucket(
     trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then
-    info = mocked_out.call_args.args[0]
-    assert info == VariantChannelStockInfo(
-        variant_id=variant.id, channel_slug=channel_USD.slug
-    )
+    stock_infos = mocked_out.call_args.args[0]
+    assert stock_infos == [
+        VariantChannelStockInfo(variant_id=variant.id, channel_slug=channel_USD.slug)
+    ]
     mocked_out_cc.assert_not_called()
 
 
@@ -116,8 +116,9 @@ def test_out_of_stock_in_cc_warehouse_fires_click_and_collect_event(
     trigger_out_of_stock_in_channel_events_for_stocks([stock], site_settings)
 
     # then
-    info = mocked_out_cc.call_args.args[0]
-    assert info.channel_slug == channel_USD.slug
+    stock_infos = mocked_out_cc.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].channel_slug == channel_USD.slug
     mocked_out.assert_not_called()
 
 
@@ -213,8 +214,9 @@ def test_fires_only_for_channels_whose_bucket_is_empty(
 
     # then - PLN bucket is empty (only `warehouse`), USD has another with stock
     mocked_out.assert_called_once()
-    info = mocked_out.call_args.args[0]
-    assert info.channel_slug == channel_PLN.slug
+    stock_infos = mocked_out.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].channel_slug == channel_PLN.slug
 
 
 def test_out_of_stock_fires_when_other_warehouse_has_only_fully_allocated_stock(
@@ -301,8 +303,9 @@ def test_out_of_stock_ignores_warehouse_stock_attached_to_different_channel(
 
     # then - the USD bucket has no other warehouses, event fires
     mocked_out.assert_called_once()
-    info = mocked_out.call_args.args[0]
-    assert info.channel_slug == channel_USD.slug
+    stock_infos = mocked_out.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].channel_slug == channel_USD.slug
 
 
 def test_trigger_forwards_site_settings_requestor_and_webhooks(
@@ -340,11 +343,10 @@ def test_bulk_out_of_stock_fires_for_multiple_stocks_in_same_warehouse(
     # when
     trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
 
-    # then - one event per (variant, channel) pair
-    assert mocked_trigger.call_count == 2
-    fired_variant_ids = {
-        call.args[0].variant_id for call in mocked_trigger.call_args_list
-    }
+    # then - one batched call carrying one info per (variant, channel)
+    mocked_trigger.assert_called_once()
+    stock_infos = mocked_trigger.call_args.args[0]
+    fired_variant_ids = {info.variant_id for info in stock_infos}
     assert fired_variant_ids == {variants[0].id, variants[1].id}
 
 
@@ -419,7 +421,9 @@ def test_bulk_out_of_stock_fires_selectively_when_other_warehouse_covers_only_on
 
     # then
     mocked_trigger.assert_called_once()
-    assert mocked_trigger.call_args.args[0].variant_id == variants[1].id
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].variant_id == variants[1].id
 
 
 def test_bulk_out_of_stock_deduplicates_same_variant_across_warehouses_in_channel(
@@ -446,8 +450,10 @@ def test_bulk_out_of_stock_deduplicates_same_variant_across_warehouses_in_channe
 
     # then - fires once per (variant, channel)
     mocked_trigger.assert_called_once()
-    assert mocked_trigger.call_args.args[0].variant_id == variant.id
-    assert mocked_trigger.call_args.args[0].channel_slug == channel_USD.slug
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].variant_id == variant.id
+    assert stock_infos[0].channel_slug == channel_USD.slug
 
 
 def test_bulk_out_of_stock_warehouse_a_is_other_for_warehouse_b_stock(
@@ -490,7 +496,9 @@ def test_bulk_out_of_stock_warehouse_a_is_other_for_warehouse_b_stock(
 
     # then
     mocked_trigger.assert_called_once()
-    assert mocked_trigger.call_args.args[0].variant_id == variant_x.id
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].variant_id == variant_x.id
 
 
 def test_bulk_out_of_stock_mixed_cc_and_non_cc_stocks(
@@ -520,9 +528,13 @@ def test_bulk_out_of_stock_mixed_cc_and_non_cc_stocks(
 
     # then - each fires in its own event type
     mocked_non_cc.assert_called_once()
-    assert mocked_non_cc.call_args.args[0].variant_id == variant.id
+    non_cc_infos = mocked_non_cc.call_args.args[0]
+    assert len(non_cc_infos) == 1
+    assert non_cc_infos[0].variant_id == variant.id
     mocked_cc.assert_called_once()
-    assert mocked_cc.call_args.args[0].variant_id == variant.id
+    cc_infos = mocked_cc.call_args.args[0]
+    assert len(cc_infos) == 1
+    assert cc_infos[0].variant_id == variant.id
 
 
 def test_bulk_out_of_stock_multi_channel_fires_per_channel_independently(
@@ -548,7 +560,9 @@ def test_bulk_out_of_stock_multi_channel_fires_per_channel_independently(
 
     # then - fires only for PLN (USD has other warehouse with stock)
     mocked_trigger.assert_called_once()
-    assert mocked_trigger.call_args.args[0].channel_slug == channel_PLN.slug
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].channel_slug == channel_PLN.slug
 
 
 def test_bulk_out_of_stock_empty_list_does_not_fire(site_settings, mocker):
@@ -580,11 +594,9 @@ def test_bulk_out_of_stock_two_different_variants_fires_for_each(
     trigger_out_of_stock_in_channel_events_for_stocks(stocks, site_settings)
 
     # then
-    assert mocked_trigger.call_count == 2
-    fired_pairs = {
-        (call.args[0].variant_id, call.args[0].channel_slug)
-        for call in mocked_trigger.call_args_list
-    }
+    mocked_trigger.assert_called_once()
+    stock_infos = mocked_trigger.call_args.args[0]
+    fired_pairs = {(info.variant_id, info.channel_slug) for info in stock_infos}
     assert fired_pairs == {
         (variants[0].id, channel_USD.slug),
         (variants[1].id, channel_USD.slug),
@@ -615,8 +627,10 @@ def test_bulk_out_of_stock_deduplicates_same_variant_multiple_warehouses_and_cha
     trigger_out_of_stock_in_channel_events_for_stocks([stock_a, stock_b], site_settings)
 
     # then - fires once per channel (2 channels), not once per stock
-    assert mocked_trigger.call_count == 2
-    fired_slugs = {call.args[0].channel_slug for call in mocked_trigger.call_args_list}
+    mocked_trigger.assert_called_once()
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 2
+    fired_slugs = {info.channel_slug for info in stock_infos}
     assert fired_slugs == {channel_USD.slug, channel_PLN.slug}
 
 
@@ -661,11 +675,10 @@ def test_bulk_out_of_stock_different_variants_partial_coverage_by_other_warehous
     # then
     # variant X: covered in USD, uncovered in PLN → fires only for PLN
     # variant Y: uncovered everywhere → fires for both USD and PLN
-    assert mocked_trigger.call_count == 3
-    fired_pairs = {
-        (call.args[0].variant_id, call.args[0].channel_slug)
-        for call in mocked_trigger.call_args_list
-    }
+    mocked_trigger.assert_called_once()
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 3
+    fired_pairs = {(info.variant_id, info.channel_slug) for info in stock_infos}
     assert fired_pairs == {
         (variant_x.id, channel_PLN.slug),
         (variant_y.id, channel_USD.slug),
@@ -690,11 +703,10 @@ def test_bulk_back_in_stock_fires_for_multiple_stocks_in_same_warehouse(
     # when
     trigger_back_in_stock_in_channel_events_for_stocks(stocks, site_settings)
 
-    # then - one event per (variant, channel) pair
-    assert mocked_trigger.call_count == 2
-    fired_variant_ids = {
-        call.args[0].variant_id for call in mocked_trigger.call_args_list
-    }
+    # then - one batched call carrying one info per (variant, channel)
+    mocked_trigger.assert_called_once()
+    stock_infos = mocked_trigger.call_args.args[0]
+    fired_variant_ids = {info.variant_id for info in stock_infos}
     assert fired_variant_ids == {variants[0].id, variants[1].id}
 
 
@@ -769,7 +781,9 @@ def test_bulk_back_in_stock_fires_selectively_when_other_warehouse_covers_only_o
 
     # then - only variants[1] fires (variants[0] was already covered elsewhere)
     mocked_trigger.assert_called_once()
-    assert mocked_trigger.call_args.args[0].variant_id == variants[1].id
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].variant_id == variants[1].id
 
 
 def test_bulk_back_in_stock_deduplicates_same_variant_across_warehouses_in_channel(
@@ -798,8 +812,10 @@ def test_bulk_back_in_stock_deduplicates_same_variant_across_warehouses_in_chann
 
     # then - fires once per (variant, channel)
     mocked_trigger.assert_called_once()
-    assert mocked_trigger.call_args.args[0].variant_id == variant.id
-    assert mocked_trigger.call_args.args[0].channel_slug == channel_USD.slug
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].variant_id == variant.id
+    assert stock_infos[0].channel_slug == channel_USD.slug
 
 
 def test_bulk_back_in_stock_warehouse_a_is_other_for_warehouse_b_stock(
@@ -842,7 +858,9 @@ def test_bulk_back_in_stock_warehouse_a_is_other_for_warehouse_b_stock(
 
     # then
     mocked_trigger.assert_called_once()
-    assert mocked_trigger.call_args.args[0].variant_id == variant_x.id
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].variant_id == variant_x.id
 
 
 def test_bulk_back_in_stock_mixed_cc_and_non_cc_stocks(
@@ -872,9 +890,13 @@ def test_bulk_back_in_stock_mixed_cc_and_non_cc_stocks(
 
     # then - each fires in its own event type
     mocked_non_cc.assert_called_once()
-    assert mocked_non_cc.call_args.args[0].variant_id == variant.id
+    non_cc_infos = mocked_non_cc.call_args.args[0]
+    assert len(non_cc_infos) == 1
+    assert non_cc_infos[0].variant_id == variant.id
     mocked_cc.assert_called_once()
-    assert mocked_cc.call_args.args[0].variant_id == variant.id
+    cc_infos = mocked_cc.call_args.args[0]
+    assert len(cc_infos) == 1
+    assert cc_infos[0].variant_id == variant.id
 
 
 def test_bulk_back_in_stock_multi_channel_fires_per_channel_independently(
@@ -900,7 +922,9 @@ def test_bulk_back_in_stock_multi_channel_fires_per_channel_independently(
 
     # then - fires only for PLN (USD already has other warehouse with stock)
     mocked_trigger.assert_called_once()
-    assert mocked_trigger.call_args.args[0].channel_slug == channel_PLN.slug
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 1
+    assert stock_infos[0].channel_slug == channel_PLN.slug
 
 
 def test_bulk_back_in_stock_empty_list_does_not_fire(site_settings, mocker):
@@ -932,11 +956,9 @@ def test_bulk_back_in_stock_two_different_variants_fires_for_each(
     trigger_back_in_stock_in_channel_events_for_stocks(stocks, site_settings)
 
     # then
-    assert mocked_trigger.call_count == 2
-    fired_pairs = {
-        (call.args[0].variant_id, call.args[0].channel_slug)
-        for call in mocked_trigger.call_args_list
-    }
+    mocked_trigger.assert_called_once()
+    stock_infos = mocked_trigger.call_args.args[0]
+    fired_pairs = {(info.variant_id, info.channel_slug) for info in stock_infos}
     assert fired_pairs == {
         (variants[0].id, channel_USD.slug),
         (variants[1].id, channel_USD.slug),
@@ -969,8 +991,10 @@ def test_bulk_back_in_stock_deduplicates_same_variant_multiple_warehouses_and_ch
     )
 
     # then - fires once per channel, not once per stock
-    assert mocked_trigger.call_count == 2
-    fired_slugs = {call.args[0].channel_slug for call in mocked_trigger.call_args_list}
+    mocked_trigger.assert_called_once()
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 2
+    fired_slugs = {info.channel_slug for info in stock_infos}
     assert fired_slugs == {channel_USD.slug, channel_PLN.slug}
 
 
@@ -1015,11 +1039,10 @@ def test_bulk_back_in_stock_different_variants_partial_coverage_by_other_warehou
     # then
     # variant X: USD already covered by other warehouse, PLN uncovered → fires only for PLN
     # variant Y: uncovered everywhere → fires for both USD and PLN
-    assert mocked_trigger.call_count == 3
-    fired_pairs = {
-        (call.args[0].variant_id, call.args[0].channel_slug)
-        for call in mocked_trigger.call_args_list
-    }
+    mocked_trigger.assert_called_once()
+    stock_infos = mocked_trigger.call_args.args[0]
+    assert len(stock_infos) == 3
+    fired_pairs = {(info.variant_id, info.channel_slug) for info in stock_infos}
     assert fired_pairs == {
         (variant_x.id, channel_PLN.slug),
         (variant_y.id, channel_USD.slug),

--- a/saleor/warehouse/tests/webhooks/test_channel_stock_events.py
+++ b/saleor/warehouse/tests/webhooks/test_channel_stock_events.py
@@ -14,6 +14,14 @@ from ...webhooks.channel_stock_events import (
     trigger_product_variant_out_of_stock_in_channel,
 )
 
+TRIGGER_PATH = (
+    "saleor.warehouse.webhooks.channel_stock_events"
+    ".trigger_webhooks_async_for_multiple_objects"
+)
+GET_WEBHOOKS_PATH = (
+    "saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event"
+)
+
 
 @pytest.fixture
 def stock_info():
@@ -41,8 +49,8 @@ def stock_info():
         ),
     ],
 )
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+@mock.patch(TRIGGER_PATH)
+@mock.patch(GET_WEBHOOKS_PATH)
 def test_trigger_dispatches(
     mocked_get_webhooks,
     mocked_trigger,
@@ -57,17 +65,19 @@ def test_trigger_dispatches(
     mocked_get_webhooks.return_value = [any_webhook]
 
     # when
-    trigger_fn(stock_info, site_settings)
+    trigger_fn([stock_info], site_settings)
 
     # then
     mocked_get_webhooks.assert_called_once_with(event_type)
     mocked_trigger.assert_called_once()
-    args, kwargs = mocked_trigger.call_args
-    assert args[1] == event_type
-    assert args[2] == [any_webhook]
-    assert kwargs["subscribable_object"] is stock_info
+    kwargs = mocked_trigger.call_args.kwargs
+    assert kwargs["event_type"] == event_type
+    assert kwargs["webhooks"] == [any_webhook]
     assert kwargs["requestor"] is None
-    legacy_payload = json.loads(kwargs["legacy_data_generator"]())
+    payloads = kwargs["webhook_payloads_data"]
+    assert len(payloads) == 1
+    assert payloads[0].subscribable_object is stock_info
+    legacy_payload = json.loads(payloads[0].legacy_data_generator())
     assert legacy_payload == {
         "product_variant_id": graphene.Node.to_global_id(
             "ProductVariant", stock_info.variant_id
@@ -76,8 +86,8 @@ def test_trigger_dispatches(
     }
 
 
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+@mock.patch(TRIGGER_PATH)
+@mock.patch(GET_WEBHOOKS_PATH)
 def test_trigger_skipped_when_legacy_flag_on(
     mocked_get_webhooks, mocked_trigger, stock_info, site_settings
 ):
@@ -87,7 +97,7 @@ def test_trigger_skipped_when_legacy_flag_on(
     # when
     _trigger(
         WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
-        stock_info,
+        [stock_info],
         site_settings,
         None,
         None,
@@ -98,8 +108,30 @@ def test_trigger_skipped_when_legacy_flag_on(
     mocked_trigger.assert_not_called()
 
 
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+@mock.patch(TRIGGER_PATH)
+@mock.patch(GET_WEBHOOKS_PATH)
+def test_trigger_empty_stock_infos_skips(
+    mocked_get_webhooks, mocked_trigger, site_settings
+):
+    # given
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+
+    # when
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        [],
+        site_settings,
+        None,
+        None,
+    )
+
+    # then
+    mocked_get_webhooks.assert_not_called()
+    mocked_trigger.assert_not_called()
+
+
+@mock.patch(TRIGGER_PATH)
+@mock.patch(GET_WEBHOOKS_PATH)
 def test_trigger_no_webhooks_skips(
     mocked_get_webhooks, mocked_trigger, stock_info, site_settings
 ):
@@ -110,7 +142,7 @@ def test_trigger_no_webhooks_skips(
     # when
     _trigger(
         WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
-        stock_info,
+        [stock_info],
         site_settings,
         None,
         None,
@@ -120,8 +152,8 @@ def test_trigger_no_webhooks_skips(
     mocked_trigger.assert_not_called()
 
 
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+@mock.patch(TRIGGER_PATH)
+@mock.patch(GET_WEBHOOKS_PATH)
 def test_trigger_uses_passed_webhooks(
     mocked_get_webhooks,
     mocked_trigger,
@@ -135,7 +167,7 @@ def test_trigger_uses_passed_webhooks(
     # when
     _trigger(
         WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
-        stock_info,
+        [stock_info],
         site_settings,
         None,
         [any_webhook],
@@ -143,11 +175,11 @@ def test_trigger_uses_passed_webhooks(
 
     # then
     mocked_get_webhooks.assert_not_called()
-    assert mocked_trigger.call_args.args[2] == [any_webhook]
+    assert mocked_trigger.call_args.kwargs["webhooks"] == [any_webhook]
 
 
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+@mock.patch(TRIGGER_PATH)
+@mock.patch(GET_WEBHOOKS_PATH)
 def test_trigger_filters_webhooks_by_channel_slug(
     mocked_get_webhooks, mocked_trigger, stock_info, site_settings
 ):
@@ -161,7 +193,7 @@ def test_trigger_filters_webhooks_by_channel_slug(
     # when
     _trigger(
         WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
-        stock_info,
+        [stock_info],
         site_settings,
         None,
         None,
@@ -171,8 +203,8 @@ def test_trigger_filters_webhooks_by_channel_slug(
     mocked_trigger.assert_not_called()
 
 
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.trigger_webhooks_async")
-@mock.patch("saleor.warehouse.webhooks.channel_stock_events.get_webhooks_for_event")
+@mock.patch(TRIGGER_PATH)
+@mock.patch(GET_WEBHOOKS_PATH)
 def test_trigger_passes_through_when_subscription_has_no_channel_filter(
     mocked_get_webhooks, mocked_trigger, stock_info, site_settings
 ):
@@ -186,7 +218,7 @@ def test_trigger_passes_through_when_subscription_has_no_channel_filter(
     # when
     _trigger(
         WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
-        stock_info,
+        [stock_info],
         site_settings,
         None,
         None,
@@ -194,4 +226,62 @@ def test_trigger_passes_through_when_subscription_has_no_channel_filter(
 
     # then
     mocked_trigger.assert_called_once()
-    assert mocked_trigger.call_args.args[2] == [webhook]
+    assert mocked_trigger.call_args.kwargs["webhooks"] == [webhook]
+
+
+@mock.patch(TRIGGER_PATH)
+@mock.patch(GET_WEBHOOKS_PATH)
+def test_trigger_groups_multiple_channels_into_separate_calls(
+    mocked_get_webhooks, mocked_trigger, any_webhook, site_settings
+):
+    # given - two stock infos in different channels, one shared subscription webhook
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    mocked_get_webhooks.return_value = [any_webhook]
+    info_a = VariantChannelStockInfo(variant_id=1, channel_slug="default")
+    info_b = VariantChannelStockInfo(variant_id=2, channel_slug="other")
+
+    # when
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        [info_a, info_b],
+        site_settings,
+        None,
+        None,
+    )
+
+    # then - one call per channel, each with a single payload
+    assert mocked_trigger.call_count == 2
+    dispatched = {
+        call.kwargs["webhook_payloads_data"][0].subscribable_object.channel_slug: [
+            payload.subscribable_object.variant_id
+            for payload in call.kwargs["webhook_payloads_data"]
+        ]
+        for call in mocked_trigger.call_args_list
+    }
+    assert dispatched == {"default": [info_a.variant_id], "other": [info_b.variant_id]}
+
+
+@mock.patch(TRIGGER_PATH)
+@mock.patch(GET_WEBHOOKS_PATH)
+def test_trigger_batches_multiple_variants_in_same_channel(
+    mocked_get_webhooks, mocked_trigger, any_webhook, site_settings
+):
+    # given - two variants in the same channel
+    site_settings.use_legacy_shipping_zone_stock_availability = False
+    mocked_get_webhooks.return_value = [any_webhook]
+    info_a = VariantChannelStockInfo(variant_id=1, channel_slug="default")
+    info_b = VariantChannelStockInfo(variant_id=2, channel_slug="default")
+
+    # when
+    _trigger(
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
+        [info_a, info_b],
+        site_settings,
+        None,
+        None,
+    )
+
+    # then - one call carrying both payloads
+    mocked_trigger.assert_called_once()
+    payloads = mocked_trigger.call_args.kwargs["webhook_payloads_data"]
+    assert [payload.subscribable_object for payload in payloads] == [info_a, info_b]

--- a/saleor/warehouse/webhooks/channel_stock_events.py
+++ b/saleor/warehouse/webhooks/channel_stock_events.py
@@ -1,4 +1,6 @@
 import json
+from collections import defaultdict
+from functools import partial
 from typing import TYPE_CHECKING
 
 import graphene
@@ -6,7 +8,10 @@ import graphene
 from ...account.models import User
 from ...app.models import App
 from ...webhook.event_types import WebhookEventAsyncType
-from ...webhook.transport.asynchronous.transport import trigger_webhooks_async
+from ...webhook.transport.asynchronous.transport import (
+    WebhookPayloadData,
+    trigger_webhooks_async_for_multiple_objects,
+)
 from ...webhook.utils import filter_webhooks_for_channel, get_webhooks_for_event
 from ..interface import VariantChannelStockInfo
 
@@ -33,39 +38,51 @@ def _build_legacy_payload(stock_info: VariantChannelStockInfo) -> str:
 
 def _trigger(
     event_type: str,
-    stock_info: VariantChannelStockInfo,
+    stock_infos: list[VariantChannelStockInfo],
     site_settings: "SiteSettings",
     requestor: T_REQUESTOR,
     webhooks: "QuerySet[Webhook] | None",
 ) -> None:
-    # channel stock availability are only triggered when legacy shipping zone
-    # stock availability is disabled
+    # channel stock availability events are only triggered when legacy shipping
+    # zone stock availability is disabled
     if site_settings.use_legacy_shipping_zone_stock_availability:
+        return
+    if not stock_infos:
         return
     if webhooks is None:
         webhooks = get_webhooks_for_event(event_type)
-    channel_webhooks = filter_webhooks_for_channel(webhooks, stock_info.channel_slug)
-    if not channel_webhooks:
-        return
-    trigger_webhooks_async(
-        None,
-        event_type,
-        channel_webhooks,
-        subscribable_object=stock_info,
-        requestor=requestor,
-        legacy_data_generator=lambda: _build_legacy_payload(stock_info),
-    )
+
+    stock_infos_by_channel: dict[str, list[VariantChannelStockInfo]] = defaultdict(list)
+    for stock_info in stock_infos:
+        stock_infos_by_channel[stock_info.channel_slug].append(stock_info)
+
+    for channel_slug, channel_stock_infos in stock_infos_by_channel.items():
+        channel_webhooks = filter_webhooks_for_channel(webhooks, channel_slug)
+        if not channel_webhooks:
+            continue
+        trigger_webhooks_async_for_multiple_objects(
+            event_type=event_type,
+            webhooks=channel_webhooks,
+            webhook_payloads_data=[
+                WebhookPayloadData(
+                    subscribable_object=stock_info,
+                    legacy_data_generator=partial(_build_legacy_payload, stock_info),
+                )
+                for stock_info in channel_stock_infos
+            ],
+            requestor=requestor,
+        )
 
 
 def trigger_product_variant_out_of_stock_in_channel(
-    stock_info: VariantChannelStockInfo,
+    stock_infos: list[VariantChannelStockInfo],
     site_settings: "SiteSettings",
     requestor: T_REQUESTOR = None,
     webhooks: "QuerySet[Webhook] | None" = None,
 ) -> None:
     _trigger(
         WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
-        stock_info,
+        stock_infos,
         site_settings,
         requestor,
         webhooks,
@@ -73,14 +90,14 @@ def trigger_product_variant_out_of_stock_in_channel(
 
 
 def trigger_product_variant_back_in_stock_in_channel(
-    stock_info: VariantChannelStockInfo,
+    stock_infos: list[VariantChannelStockInfo],
     site_settings: "SiteSettings",
     requestor: T_REQUESTOR = None,
     webhooks: "QuerySet[Webhook] | None" = None,
 ) -> None:
     _trigger(
         WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_IN_CHANNEL,
-        stock_info,
+        stock_infos,
         site_settings,
         requestor,
         webhooks,
@@ -88,14 +105,14 @@ def trigger_product_variant_back_in_stock_in_channel(
 
 
 def trigger_product_variant_out_of_stock_for_click_and_collect(
-    stock_info: VariantChannelStockInfo,
+    stock_infos: list[VariantChannelStockInfo],
     site_settings: "SiteSettings",
     requestor: T_REQUESTOR = None,
     webhooks: "QuerySet[Webhook] | None" = None,
 ) -> None:
     _trigger(
         WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK_FOR_CLICK_AND_COLLECT,
-        stock_info,
+        stock_infos,
         site_settings,
         requestor,
         webhooks,
@@ -103,14 +120,14 @@ def trigger_product_variant_out_of_stock_for_click_and_collect(
 
 
 def trigger_product_variant_back_in_stock_for_click_and_collect(
-    stock_info: VariantChannelStockInfo,
+    stock_infos: list[VariantChannelStockInfo],
     site_settings: "SiteSettings",
     requestor: T_REQUESTOR = None,
     webhooks: "QuerySet[Webhook] | None" = None,
 ) -> None:
     _trigger(
         WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK_FOR_CLICK_AND_COLLECT,
-        stock_info,
+        stock_infos,
         site_settings,
         requestor,
         webhooks,


### PR DESCRIPTION
Adjust channel stock events to create deliveries in batch

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
