### PR TITLE
Add Aspire Python apphost scaffold for Saleor

### DIFF
--- a/apphost.py
+++ b/apphost.py
@@ -1,0 +1,160 @@
+# Aspire Python AppHost
+# For more information, see: https://aspire.dev
+
+from pathlib import Path
+
+from aspire_app import create_builder
+
+
+with create_builder() as builder:
+    repo_root = str(Path(__file__).resolve().parent)
+    saleor_image = "saleor-devcontainer:local"
+
+    postgres_user = builder.add_parameter_with_value(
+        "postgres-user",
+        "saleor",
+        publish_value_as_default=True,
+    )
+    postgres_database = builder.add_parameter_with_value(
+        "postgres-database",
+        "saleor",
+        publish_value_as_default=True,
+    )
+    postgres_password = builder.add_parameter_with_generated_value(
+        "postgres-password",
+        {
+            "MinLength": 20,
+            "Lower": True,
+            "Upper": True,
+            "Numeric": True,
+            "MinLower": 1,
+            "MinUpper": 1,
+            "MinNumeric": 1,
+        },
+        secret=True,
+        persist=True,
+    )
+    default_from_email = builder.add_parameter_with_value(
+        "default-from-email",
+        "noreply@example.com",
+        publish_value_as_default=True,
+    )
+    secret_key = builder.add_parameter_with_generated_value(
+        "saleor-secret-key",
+        {
+            "MinLength": 50,
+            "Lower": True,
+            "Upper": True,
+            "Numeric": True,
+            "Special": True,
+            "MinLower": 1,
+            "MinUpper": 1,
+            "MinNumeric": 1,
+            "MinSpecial": 1,
+        },
+        secret=True,
+        persist=True,
+    )
+    allowed_hosts = builder.add_parameter_with_value(
+        "allowed-hosts",
+        "localhost,127.0.0.1,host.docker.internal,host.containers.internal",
+        publish_value_as_default=True,
+    )
+    allow_loopback_ips = builder.add_parameter_with_value(
+        "allow-loopback-ips",
+        "True",
+        publish_value_as_default=True,
+    )
+
+    db = builder.add_container("db", "postgres")
+    db.with_image_tag("15-alpine")
+    db.with_env("POSTGRES_USER", postgres_user)
+    db.with_env("POSTGRES_PASSWORD", postgres_password)
+    db.with_env("POSTGRES_DB", postgres_database)
+    db.with_endpoint(name="tcp", scheme="tcp", port=5432, target_port=5432)
+    db.with_volume("/var/lib/postgresql/data", name="saleor-db")
+
+    cache = builder.add_container("cache", "valkey/valkey")
+    cache.with_image_tag("8.1-alpine")
+    cache.with_endpoint(name="tcp", scheme="tcp", port=6379, target_port=6379)
+    cache.with_volume("/data", name="saleor-cache")
+
+    mailpit = builder.add_container("mailpit", "axllent/mailpit")
+    mailpit.with_endpoint(name="smtp", scheme="tcp", port=1025, target_port=1025)
+    mailpit.with_http_endpoint(name="http", port=8025, target_port=8025)
+
+    dashboard = builder.add_container("dashboard", "ghcr.io/saleor/saleor-dashboard")
+    dashboard.with_image_tag("3.22")
+    dashboard.with_http_endpoint(name="http", port=9000, target_port=80)
+
+    saleor_image_build = builder.add_executable(
+        "saleor-image-build",
+        "docker",
+        repo_root,
+        ["build", "-f", ".devcontainer/Dockerfile", "-t", saleor_image, "."],
+    )
+
+    db_endpoint = db.get_endpoint("tcp")
+    cache_endpoint = cache.get_endpoint("tcp")
+    mailpit_smtp_endpoint = mailpit.get_endpoint("smtp")
+    dashboard_http_endpoint = dashboard.get_endpoint("http")
+
+    def add_saleor_service(name: str, command: str):
+        wrapped_command = "\n".join(
+            [
+                'export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${SALEOR_DB_ENDPOINT#tcp://}/${POSTGRES_DATABASE}"',
+                'export CACHE_URL="redis://${SALEOR_CACHE_ENDPOINT#tcp://}/0"',
+                'export CELERY_BROKER_URL="redis://${SALEOR_CACHE_ENDPOINT#tcp://}/1"',
+                'export EMAIL_URL="smtp://${SALEOR_SMTP_ENDPOINT#tcp://}"',
+                'export DASHBOARD_URL="${SALEOR_DASHBOARD_ENDPOINT}"',
+                f"exec {command}",
+            ]
+        )
+
+        resource = builder.add_container(name, "saleor-devcontainer")
+        resource.with_image_tag("local")
+        resource.with_bind_mount(repo_root, "/app")
+        resource.with_container_runtime_args(["-w", "/app"])
+        resource.with_entrypoint("bash")
+        resource.with_args(["-lc", wrapped_command])
+        resource.with_env("POSTGRES_USER", postgres_user)
+        resource.with_env("POSTGRES_PASSWORD", postgres_password)
+        resource.with_env("POSTGRES_DATABASE", postgres_database)
+        resource.with_env("SALEOR_DB_ENDPOINT", db_endpoint)
+        resource.with_env("SALEOR_CACHE_ENDPOINT", cache_endpoint)
+        resource.with_env("SALEOR_SMTP_ENDPOINT", mailpit_smtp_endpoint)
+        resource.with_env("SALEOR_DASHBOARD_ENDPOINT", dashboard_http_endpoint)
+        resource.with_env("DEFAULT_FROM_EMAIL", default_from_email)
+        resource.with_env("SECRET_KEY", secret_key)
+        resource.with_env("ALLOWED_HOSTS", allowed_hosts)
+        resource.with_env("HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS", allow_loopback_ips)
+        resource.with_otlp_exporter()
+        resource.wait_for_completion(saleor_image_build)
+        resource.wait_for(db)
+        resource.wait_for(cache)
+        resource.wait_for(mailpit)
+        return resource
+
+    migrate = add_saleor_service("saleor-migrate", "uv run python manage.py migrate")
+
+    api = add_saleor_service(
+        "saleor-api",
+        "uv run uvicorn saleor.asgi:application --reload --host 0.0.0.0 --port 8000",
+    )
+    api.wait_for_completion(migrate)
+    api.with_http_endpoint(name="http", port=8000, target_port=8000)
+    api.with_http_health_check(path="/health/", endpoint_name="http")
+
+    worker = add_saleor_service(
+        "saleor-worker",
+        "uv run celery --app saleor.celeryconf:app worker -E",
+    )
+    worker.wait_for_completion(migrate)
+
+    scheduler = add_saleor_service(
+        "saleor-scheduler",
+        "uv run celery --app saleor.celeryconf:app beat --scheduler saleor.schedulers.schedulers.DatabaseScheduler",
+    )
+    scheduler.wait_for_completion(migrate)
+
+    builder.run()

--- a/apphost.run.json
+++ b/apphost.run.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "https": {
+      "applicationUrl": "https://localhost:25441;http://localhost:26441",
+      "environmentVariables": {
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:27441",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:28441"
+      }
+    }
+  }
+}

--- a/apphost_requirements.txt
+++ b/apphost_requirements.txt
@@ -1,0 +1,2 @@
+# Aspire Python AppHost requirements
+-e .modules

--- a/aspire-apphost-status.md
+++ b/aspire-apphost-status.md
@@ -1,0 +1,63 @@
+# Saleor Aspire Python AppHost status
+
+## Resources modeled in `apphost.py`
+
+- `db`: PostgreSQL 15 with a persistent volume
+- `cache`: Valkey 8.1 with a persistent volume
+- `mailpit`: SMTP + HTTP developer mail sink
+- `dashboard`: Saleor dashboard container image
+- `saleor-image-build`: local `docker build` step for `.devcontainer/Dockerfile`
+- `saleor-migrate`: `uv run python manage.py migrate`
+- `saleor-api`: `uv run uvicorn saleor.asgi:application --reload --host 0.0.0.0 --port 8000`
+- `saleor-worker`: Celery worker
+- `saleor-scheduler`: Celery beat scheduler
+
+## What was achieved
+
+- Converted the strongest temporary Saleor AppHost shape into a checked-in **Python AppHost scaffold** for the Saleor repository.
+- Preserved the second-pass refinement work from the stronger TypeScript harness:
+  - local-source backend containers built from `.devcontainer/Dockerfile`
+  - Aspire parameters/secrets for Saleor and Postgres settings
+  - endpoint-derived runtime URLs instead of hard-coded backend hostnames
+  - OTEL exporter wiring for the Saleor backend containers
+- Added the supporting Python AppHost files that Aspire source currently expects:
+  - `apphost.py`
+  - `aspire.config.json`
+  - `apphost.run.json`
+  - `pylock.apphost.toml`
+  - `apphost_requirements.txt`
+
+## Current limitations
+
+### Primary blocker: Python AppHost support in the current Aspire dev CLI build
+
+Using Aspire CLI `13.3.0-preview.1.26221.2+b94ddc9209f110bf02934345a04361183a73cc95`:
+
+- `aspire init --language python` fails with `Unknown language: 'python'`
+- even after enabling `experimentalPolyglot:python` with `aspire config set experimentalPolyglot:python true`
+- and even with an explicit `aspire.config.json` that points to `apphost.py`
+
+`aspire run` still fails with:
+
+```text
+Unrecognized app host type.
+```
+
+That means the checked-in Python AppHost files cannot currently be executed by this dev CLI build, even though Python polyglot support exists in Aspire source and the Python code-generation package is present there.
+
+### Secondary environment note
+
+The Python AppHost scaffold expects Python `>=3.11` (`pylock.apphost.toml`), while the default `python3` on this machine is `3.9.6`. A separate `python3.12` executable is available, so the runtime environment would still need PATH/tooling cleanup even after the CLI-side Python AppHost blocker is fixed.
+
+## Strongest validated result so far
+
+The strongest validated harness remains the temporary **TypeScript AppHost** created outside this repository during evaluation. That harness successfully validated:
+
+- local Saleor startup from local-source backend containers
+- GraphQL and health endpoints
+- Docker Compose publish artifact generation
+- parameter/secret refactoring
+- endpoint-derived URL composition
+- OTEL wiring
+
+The remaining unresolved runtime issue from that refined harness is narrower: under `aspire run`, the local-source Saleor backend containers can remain stuck in `Waiting` after dependencies are healthy, while the Python AppHost is blocked earlier at CLI recognition/discovery time.

--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,10 @@
+{
+  "appHost": {
+    "path": "apphost.py",
+    "language": "python"
+  },
+  "sdk": {
+    "version": "13.3.0-preview.1.26221.2"
+  },
+  "channel": "daily"
+}

--- a/pylock.apphost.toml
+++ b/pylock.apphost.toml
@@ -1,0 +1,10 @@
+created-by = 'Aspire'
+lock-version = '1.0'
+requires-python = '>=3.11'
+
+[[packages]]
+name = "aspire_app"
+editable = true
+
+[packages.directory]
+path = ".modules"


### PR DESCRIPTION
## Summary
- add a best-effort Python Aspire AppHost scaffold for Saleor
- add a status markdown file documenting modeled resources, achieved work, and remaining limitations
- document the current Aspire dev CLI blocker for Python AppHost recognition/discovery

## Notes
- The fork now contains `apphost.py` plus the supporting Python AppHost files (`aspire.config.json`, `apphost.run.json`, `pylock.apphost.toml`, `apphost_requirements.txt`).
- The current Aspire dev CLI build still blocks execution of Python AppHosts here: `aspire init --language python` returns `Unknown language: 'python'`, and `aspire run` with `experimentalPolyglot:python=true` returns `Unrecognized app host type.`
- `aspire-apphost-status.md` captures the strongest validated Saleor result so far and the remaining limitations precisely.
