### PR TITLE
Add validation for incorrect cursor shape

### DIFF
--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -44,7 +44,10 @@ def to_global_cursor(values):
 
 def from_global_cursor(cursor) -> list[str]:
     values = unbase64(cursor)
-    return orjson.loads(values)
+    parsed = orjson.loads(values)
+    if not isinstance(parsed, list):
+        raise ValueError("Cursor must decode to a JSON array.")
+    return parsed
 
 
 def get_field_value(instance: DjangoModel, field_name: str):

--- a/saleor/graphql/core/tests/test_pagination.py
+++ b/saleor/graphql/core/tests/test_pagination.py
@@ -2,6 +2,7 @@ import base64
 import math
 
 import graphene
+import orjson
 import pytest
 
 from ....tests.models import Book
@@ -257,6 +258,16 @@ def test_pagination_invalid_cursor(books):
 
 def test_pagination_invalid_cursor_and_valid_base64(books):
     cursor = base64.b64encode(str.encode(f"{['Test']}")).decode("utf-8")
+    variables = {"first": 5, "after": cursor}
+
+    result = schema.execute(QUERY_PAGINATION_TEST, variables=variables)
+
+    assert len(result.errors) == 1
+    assert str(result.errors[0]) == "Received cursor is invalid."
+
+
+def test_pagination_cursor_decodes_to_non_list(books):
+    cursor = base64.b64encode(orjson.dumps({"id": "abc"})).decode("utf-8")
     variables = {"first": 5, "after": cursor}
 
     result = schema.execute(QUERY_PAGINATION_TEST, variables=variables)


### PR DESCRIPTION
Fixes https://saleor.sentry.io/issues/7434775854/

Previously validation only verified JSON encoded in base64, but cursor is expected to be list/tuple