### PR TITLE
Fix: Voucher usage logic in DraftOrderUpdate and relative URL validation in TransactionCreate

### DIFF
--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -82,8 +82,7 @@ def increase_voucher_usage(
 
 def increase_voucher_code_usage_value(code: "VoucherCode") -> None:
     """Increase voucher code uses by 1."""
-    code.used = F("used") + 1
-    code.save(update_fields=["used"])
+    VoucherCode.objects.filter(pk=code.pk).update(used=F("used") + 1)
 
 
 def decrease_voucher_code_usage_value(code: "VoucherCode") -> None:

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -327,11 +327,14 @@ class DraftOrderUpdate(
         old_voucher,
         old_voucher_code,
     ):
-        if "voucher" not in cleaned_input:
+        if "voucher" not in cleaned_input and "voucher_code" not in cleaned_input:
             return
 
-        voucher = cleaned_input["voucher"]
-        if voucher is None and old_voucher is None:
+        new_voucher = cleaned_input.get("voucher")
+        new_code_instance = cleaned_input.get("voucher_code_instance")
+        new_voucher_code = new_code_instance.code if new_code_instance else None
+
+        if new_voucher == old_voucher and new_voucher_code == old_voucher_code:
             return
 
         # create or update voucher discount object
@@ -344,20 +347,20 @@ class DraftOrderUpdate(
         # handle voucher usage
         user_email = get_customer_email_for_voucher_usage(instance)
 
-        if voucher:
-            code_instance = cleaned_input.pop("voucher_code_instance", None)
+        if old_voucher:
+            # handle removing voucher
+            old_code_instance = VoucherCode.objects.filter(code=old_voucher_code).first()
+            # user_email is None as we do not have anything to release in terms of
+            # apply once per customer
+            release_voucher_code_usage(old_code_instance, old_voucher, user_email=None)
+
+        if new_voucher and new_code_instance:
             increase_voucher_usage(
-                voucher,
-                code_instance,
+                new_voucher,
+                new_code_instance,
                 user_email,
                 increase_voucher_customer_usage=False,
             )
-        elif old_voucher:
-            # handle removing voucher
-            voucher_code = VoucherCode.objects.filter(code=old_voucher_code).first()
-            # user_email is None as we do not have anything to release in terms of
-            # apply once per customer
-            release_voucher_code_usage(voucher_code, old_voucher, user_email=None)
 
     @classmethod
     def handle_shipping(cls, cleaned_input, instance: models.Order, info):

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update_voucher_usage_logic.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update_voucher_usage_logic.py
@@ -1,0 +1,131 @@
+import graphene
+import pytest
+from .....discount.models import Voucher
+from .....order import OrderStatus
+from ....tests.utils import get_graphql_content
+
+DRAFT_ORDER_UPDATE_MUTATION = """
+    mutation draftUpdate(
+    $id: ID!,
+    $input: DraftOrderInput!,
+    ) {
+        draftOrderUpdate(
+            id: $id,
+            input: $input
+        ) {
+            errors {
+                field
+                code
+                message
+            }
+            order {
+                voucher {
+                    code
+                }
+                voucherCode
+            }
+        }
+    }
+"""
+
+def test_draft_order_update_with_same_voucher_does_not_increase_usage(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    voucher,
+):
+    # given
+    order = draft_order
+    code_instance = voucher.codes.first()
+    order.voucher = voucher
+    order.voucher_code = code_instance.code
+    order.save(update_fields=["voucher", "voucher_code"])
+
+    channel = order.channel
+    channel.include_draft_order_in_voucher_usage = True
+    channel.save(update_fields=["include_draft_order_in_voucher_usage"])
+
+    code_instance.used = 1
+    code_instance.save(update_fields=["used"])
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    query = DRAFT_ORDER_UPDATE_MUTATION
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
+
+    variables = {
+        "id": order_id,
+        "input": {
+            "voucher": voucher_id,
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderUpdate"]
+    assert not data["errors"]
+    
+    code_instance.refresh_from_db()
+    # Usage should still be 1, not 2
+    assert code_instance.used == 1
+
+def test_draft_order_update_change_voucher_releases_old_increases_new(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    voucher,
+    voucher_percentage,
+):
+    # given
+    order = draft_order
+    
+    # Setup old voucher
+    old_voucher = voucher
+    old_code_instance = old_voucher.codes.first()
+    order.voucher = old_voucher
+    order.voucher_code = old_code_instance.code
+    order.save(update_fields=["voucher", "voucher_code"])
+    
+    old_code_instance.used = 1
+    old_code_instance.save(update_fields=["used"])
+
+    # Setup new voucher
+    new_voucher = voucher_percentage
+    new_code_instance = new_voucher.codes.first()
+    new_code_instance.used = 0
+    new_code_instance.save(update_fields=["used"])
+
+    channel = order.channel
+    channel.include_draft_order_in_voucher_usage = True
+    channel.save(update_fields=["include_draft_order_in_voucher_usage"])
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    query = DRAFT_ORDER_UPDATE_MUTATION
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    new_voucher_id = graphene.Node.to_global_id("Voucher", new_voucher.id)
+
+    variables = {
+        "id": order_id,
+        "input": {
+            "voucher": new_voucher_id,
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderUpdate"]
+    assert not data["errors"]
+    
+    old_code_instance.refresh_from_db()
+    new_code_instance.refresh_from_db()
+    
+    # Old usage should be released (1 -> 0)
+    assert old_code_instance.used == 0
+    # New usage should be increased (0 -> 1)
+    assert new_code_instance.used == 1

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -124,6 +124,8 @@ class TransactionCreate(BaseMutation):
     def validate_external_url(cls, external_url: str | None, error_code: str):
         if external_url is None:
             return
+        if external_url.startswith("/"):
+            return
         validator = URLValidator()
         try:
             validator(external_url)

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create_external_url.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create_external_url.py
@@ -1,0 +1,72 @@
+import graphene
+from .....payment.error_codes import TransactionCreateErrorCode
+from ....tests.utils import get_graphql_content
+
+MUTATION_TRANSACTION_CREATE = """
+mutation TransactionCreate(
+    $id: ID!,
+    $transaction: TransactionCreateInput!
+    ){
+    transactionCreate(
+            id: $id,
+            transaction: $transaction
+        ){
+        transaction{
+            externalUrl
+        }
+        errors{
+            field
+            message
+            code
+        }
+    }
+}
+"""
+
+def test_transaction_create_with_absolute_external_url(
+    order_with_lines, permission_manage_payments, app_api_client
+):
+    # given
+    external_url = "https://example.com/success"
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "name": "Credit Card",
+            "externalUrl": external_url,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["transactionCreate"]
+    assert not data["errors"]
+    assert data["transaction"]["externalUrl"] == external_url
+
+def test_transaction_create_with_relative_external_url(
+    order_with_lines, permission_manage_payments, app_api_client
+):
+    # given
+    external_url = "/success"
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "name": "Credit Card",
+            "externalUrl": external_url,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["transactionCreate"]
+    assert not data["errors"]
+    assert data["transaction"]["externalUrl"] == external_url


### PR DESCRIPTION
## Description
This PR addresses two critical issues:
1. **DraftOrderUpdate Voucher Logic:** Fixed a bug where voucher usage was double-counted on repeated updates and was not correctly released when a voucher was changed.
2. **Atomicity:** Refactored `increase_voucher_code_usage_value` to use `.update()` instead of `.save()` for atomicity, strictly adhering to the project's concurrency guidelines.
3. **TransactionCreate Validation:** Fixed an issue where `externalUrl` rejected valid relative URLs starting with `/`.

## Changes Made
- Refactored `DraftOrderUpdate.handle_order_voucher` to correctly manage voucher transitions (release old, increase new).
- Updated `increase_voucher_code_usage_value` to use atomic DB-level `.update()`.
- Updated `validate_external_url` in `TransactionCreate` to allow relative paths.

## Verification
- Added comprehensive tests for voucher usage logic in `DraftOrderUpdate`.
- Added targeted tests for `externalUrl` relative path validation.
