### PR TITLE
Prevent granting MANAGE_APPS to app

### DIFF
--- a/saleor/app/management/commands/utils.py
+++ b/saleor/app/management/commands/utils.py
@@ -11,6 +11,12 @@ def clean_permissions(required_permissions: list[str]):
                 f"Permission: {perm} doesn't exist in Saleor."
                 f" Available permissions: {all_permissions}"
             )
+    # Enforce the same "no app holds MANAGE_APPS" invariant that GraphQL mutations
+    # enforce. CLI commands bypass the GraphQL layer entirely, so without this
+    # guard `manage.py create_app foo --permission MANAGE_APPS` would silently
+    # produce an app that can manage other apps - a privilege-laundering primitive.
+    if "MANAGE_APPS" in required_permissions:
+        raise CommandError("Permission(s) cannot be granted to an app: MANAGE_APPS.")
     permissions = get_permissions(
         [all_permissions[perm] for perm in required_permissions]
     )

--- a/saleor/app/manifest_validations.py
+++ b/saleor/app/manifest_validations.py
@@ -99,6 +99,16 @@ def _clean_permissions(
     return [p for p in saleor_permissions if p.codename in permissions]
 
 
+def _ensure_app_permissions_allowed(required_permissions: list[str]) -> None:
+    if "MANAGE_APPS" not in required_permissions:
+        return
+    raise ValidationError(
+        "MANAGE_APPS permission cannot be granted to an app.",
+        code=AppErrorCode.OUT_OF_SCOPE_PERMISSION.value,
+        params={"permissions": ["MANAGE_APPS"]},
+    )
+
+
 def clean_manifest_data(manifest_data, raise_for_saleor_version=False):
     # Structural validation: required fields, field types, URL formats, brand logo.
     try:
@@ -121,6 +131,7 @@ def clean_manifest_data(manifest_data, raise_for_saleor_version=False):
         formatted_codename=Concat("content_type__app_label", Value("."), "codename")
     )
     try:
+        _ensure_app_permissions_allowed(manifest_data.get("permissions", []))
         app_permissions = _clean_permissions(
             manifest_data.get("permissions", []), saleor_permissions
         )

--- a/saleor/app/tests/test_app_commands.py
+++ b/saleor/app/tests/test_app_commands.py
@@ -2,7 +2,7 @@ from unittest.mock import ANY, Mock, call, patch
 
 import graphene
 import pytest
-from django.core.management import call_command
+from django.core.management import CommandError, call_command
 from django.forms import ValidationError
 from requests_hardened import HTTPSession
 
@@ -251,6 +251,17 @@ def test_sends_data_to_target_url(monkeypatch):
         json={"auth_token": ANY},
         allow_redirects=False,
     )
+
+
+def test_create_app_command_rejects_manage_apps_permission():
+    # given - the create_app command must not be a backdoor for granting MANAGE_APPS
+    name = "Privileged App"
+
+    # when / then
+    with pytest.raises(CommandError, match="MANAGE_APPS"):
+        call_command("create_app", name, permission=["MANAGE_APPS"])
+
+    assert not App.objects.filter(name=name).exists()
 
 
 def test_creates_app_with_identifier():

--- a/saleor/app/tests/test_manifest_validations.py
+++ b/saleor/app/tests/test_manifest_validations.py
@@ -1,8 +1,10 @@
 import pytest
+from django.core.exceptions import ValidationError
 from pydantic import ValidationError as PydanticValidationError
 
 from ..error_codes import AppErrorCode
 from ..manifest_schema import ICON_MIME_TYPES, ManifestSchema
+from ..manifest_validations import clean_manifest_data
 
 MINIMAL_MANIFEST = {
     "id": "app.example",
@@ -300,6 +302,50 @@ def test_manifest_schema_extra_fields_ignored():
 
     # then
     assert schema.id == MINIMAL_MANIFEST["id"]
+
+
+@pytest.mark.django_db
+def test_clean_manifest_data_rejects_manage_apps_permission():
+    # given - manifest declaring MANAGE_APPS must be rejected even though the
+    # permission name is valid, to prevent privilege laundering through an app
+    manifest_data = {
+        **MINIMAL_MANIFEST,
+        "permissions": ["MANAGE_APPS"],
+    }
+
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        clean_manifest_data(manifest_data)
+
+    # then
+    errors = exc_info.value.message_dict
+    assert list(errors.keys()) == ["permissions"]
+    permission_errors = exc_info.value.error_dict["permissions"]
+    assert len(permission_errors) == 1
+    error = permission_errors[0]
+    assert error.code == AppErrorCode.OUT_OF_SCOPE_PERMISSION.value
+    assert error.params == {"permissions": ["MANAGE_APPS"]}
+
+
+@pytest.mark.django_db
+def test_clean_manifest_data_rejects_manage_apps_permission_alongside_others():
+    # given - mixing MANAGE_APPS with allowed permissions still rejects the whole
+    # manifest, leaving no partial-success path
+    manifest_data = {
+        **MINIMAL_MANIFEST,
+        "permissions": ["MANAGE_PRODUCTS", "MANAGE_APPS"],
+    }
+
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        clean_manifest_data(manifest_data)
+
+    # then
+    permission_errors = exc_info.value.error_dict["permissions"]
+    assert len(permission_errors) == 1
+    error = permission_errors[0]
+    assert error.code == AppErrorCode.OUT_OF_SCOPE_PERMISSION.value
+    assert error.params == {"permissions": ["MANAGE_APPS"]}
 
 
 def test_manifest_schema_deprecated_fields_accepted():

--- a/saleor/graphql/app/mutations/app_create.py
+++ b/saleor/graphql/app/mutations/app_create.py
@@ -13,7 +13,7 @@ from ...decorators import staff_member_required
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils import get_user_or_app_from_context
 from ..types import App
-from ..utils import ensure_can_manage_permissions
+from ..utils import ensure_app_permissions_allowed, ensure_can_manage_permissions
 
 
 class AppInput(BaseInputObjectType):
@@ -69,6 +69,7 @@ class AppCreate(DeprecatedModelMutation):
         if "permissions" in cleaned_input:
             requestor = get_user_or_app_from_context(info.context)
             permissions = cleaned_input.pop("permissions")
+            ensure_app_permissions_allowed(permissions)
             cleaned_input["permissions"] = get_permissions(permissions)
             ensure_can_manage_permissions(requestor, permissions)
         return cleaned_input

--- a/saleor/graphql/app/mutations/app_install.py
+++ b/saleor/graphql/app/mutations/app_install.py
@@ -13,7 +13,7 @@ from ...core.utils import WebhookEventInfo
 from ...decorators import staff_member_required
 from ...utils import get_user_or_app_from_context
 from ..types import AppInstallation
-from ..utils import ensure_can_manage_permissions
+from ..utils import ensure_app_permissions_allowed, ensure_can_manage_permissions
 
 
 class AppInstallInput(BaseInputObjectType):
@@ -70,6 +70,7 @@ class AppInstall(DeprecatedModelMutation):
         permissions = cleaned_input.pop("permissions", None)
         if permissions:
             requestor = get_user_or_app_from_context(info.context)
+            ensure_app_permissions_allowed(permissions)
             cleaned_input["permissions"] = get_permissions(permissions)
             ensure_can_manage_permissions(requestor, permissions)
         return cleaned_input

--- a/saleor/graphql/app/mutations/app_update.py
+++ b/saleor/graphql/app/mutations/app_update.py
@@ -13,7 +13,7 @@ from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils import get_user_or_app_from_context, requestor_is_superuser
 from ..types import App
-from ..utils import ensure_can_manage_permissions
+from ..utils import ensure_app_permissions_allowed, ensure_can_manage_permissions
 from .app_create import AppInput
 
 
@@ -59,6 +59,7 @@ class AppUpdate(DeprecatedModelMutation):
         # clean and prepare permissions
         if "permissions" in cleaned_input:
             permissions = cleaned_input.pop("permissions")
+            ensure_app_permissions_allowed(permissions)
             cleaned_input["permissions"] = get_permissions(permissions)
             ensure_can_manage_permissions(requestor, permissions)
         return cleaned_input

--- a/saleor/graphql/app/tests/mutations/test_app_create.py
+++ b/saleor/graphql/app/tests/mutations/test_app_create.py
@@ -257,3 +257,27 @@ def test_app_create_mutation_no_permissions(
     }
     response = staff_api_client.post_graphql(query, variables=variables)
     assert_no_permission(response)
+
+
+def test_app_create_rejects_manage_apps_permission(superuser_api_client):
+    # given - even a superuser cannot grant MANAGE_APPS to an app
+    query = APP_CREATE_MUTATION
+    variables = {
+        "name": "Privileged integration",
+        "permissions": [PermissionEnum.MANAGE_APPS.name],
+    }
+
+    # when
+    response = superuser_api_client.post_graphql(query, variables=variables)
+    content = get_graphql_content(response)
+    data = content["data"]["appCreate"]
+
+    # then
+    errors = data["errors"]
+    assert not data["app"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "permissions"
+    assert error["code"] == AppErrorCode.OUT_OF_SCOPE_PERMISSION.name
+    assert error["permissions"] == [PermissionEnum.MANAGE_APPS.name]
+    assert App.objects.count() == 0

--- a/saleor/graphql/app/tests/mutations/test_app_install.py
+++ b/saleor/graphql/app/tests/mutations/test_app_install.py
@@ -237,3 +237,25 @@ def test_install_app_mutation_with_null_permissions(
     # then
     assert data["appInstallation"]
     assert not data["errors"]
+
+
+def test_app_install_rejects_manage_apps_permission(superuser_api_client):
+    # given - even a superuser cannot grant MANAGE_APPS to an installed app
+    variables = {
+        "app_name": "Privileged integration",
+        "manifest_url": "http://localhost:3000/manifest",
+        "permissions": [PermissionEnum.MANAGE_APPS.name],
+    }
+
+    # when
+    data = _mutate_app_install(superuser_api_client, variables)
+
+    # then
+    errors = data["errors"]
+    assert not data["appInstallation"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "permissions"
+    assert error["code"] == AppErrorCode.OUT_OF_SCOPE_PERMISSION.name
+    assert error["permissions"] == [PermissionEnum.MANAGE_APPS.name]
+    assert AppInstallation.objects.count() == 0

--- a/saleor/graphql/app/tests/mutations/test_app_update.py
+++ b/saleor/graphql/app/tests/mutations/test_app_update.py
@@ -457,3 +457,34 @@ def test_app_update_mutation_removed_app(
     assert app_data["app"] is None
     assert app_data["errors"][0]["code"] == AppErrorCode.NOT_FOUND.name
     assert app_data["errors"][0]["field"] == "id"
+
+
+def test_app_update_rejects_manage_apps_permission(
+    app_with_token, permission_manage_products, superuser_api_client
+):
+    # given - even a superuser cannot grant MANAGE_APPS to an app
+    app = app_with_token
+    app.permissions.add(permission_manage_products)
+    app_id = graphene.Node.to_global_id("App", app.id)
+    variables = {
+        "id": app_id,
+        "permissions": [PermissionEnum.MANAGE_APPS.name],
+    }
+
+    # when
+    response = superuser_api_client.post_graphql(
+        APP_UPDATE_MUTATION, variables=variables
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["appUpdate"]
+
+    # then
+    errors = data["errors"]
+    assert not data["app"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "permissions"
+    assert error["code"] == AppErrorCode.OUT_OF_SCOPE_PERMISSION.name
+    assert error["permissions"] == [PermissionEnum.MANAGE_APPS.name]
+    app.refresh_from_db()
+    assert list(app.permissions.all()) == [permission_manage_products]

--- a/saleor/graphql/app/tests/test_utils.py
+++ b/saleor/graphql/app/tests/test_utils.py
@@ -1,0 +1,67 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from ....app.error_codes import AppErrorCode
+from ....permission.enums import (
+    AccountPermissions,
+    AppPermission,
+    OrderPermissions,
+    ProductPermissions,
+)
+from ..utils import ensure_app_permissions_allowed
+
+
+def test_ensure_app_permissions_allowed_passes_when_no_manage_apps():
+    permissions = [
+        ProductPermissions.MANAGE_PRODUCTS.value,
+        OrderPermissions.MANAGE_ORDERS.value,
+    ]
+
+    # when / then - does not raise
+    ensure_app_permissions_allowed(permissions)
+
+
+def test_ensure_app_permissions_allowed_passes_with_empty_list():
+    # when / then - does not raise
+    ensure_app_permissions_allowed([])
+
+
+def test_ensure_app_permissions_allowed_rejects_manage_apps():
+    permissions = [AppPermission.MANAGE_APPS.value]
+
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        ensure_app_permissions_allowed(permissions)
+
+    # then
+    error = exc_info.value.error_dict["permissions"][0]
+    assert error.code == AppErrorCode.OUT_OF_SCOPE_PERMISSION.value
+    assert error.params == {"permissions": [AppPermission.MANAGE_APPS.value]}
+
+
+def test_ensure_app_permissions_allowed_rejects_manage_apps_alongside_others():
+    # given - MANAGE_APPS mixed with allowed permissions still rejects the whole input
+    permissions = [
+        ProductPermissions.MANAGE_PRODUCTS.value,
+        AppPermission.MANAGE_APPS.value,
+        AccountPermissions.MANAGE_USERS.value,
+    ]
+
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        ensure_app_permissions_allowed(permissions)
+
+    # then
+    error = exc_info.value.error_dict["permissions"][0]
+    assert error.code == AppErrorCode.OUT_OF_SCOPE_PERMISSION.value
+    assert error.params == {"permissions": [AppPermission.MANAGE_APPS.value]}
+
+
+def test_ensure_app_permissions_allowed_does_not_match_enum_name():
+    # given - the enum NAME ("MANAGE_APPS") must not be confused with the dotted
+    # codename ("app.manage_apps"). PermissionEnum input is deserialized as the
+    # value, so an input list of just the name should not trigger the guard.
+    permissions = ["MANAGE_APPS"]
+
+    # when / then - does not raise; the helper compares against the dotted codename
+    ensure_app_permissions_allowed(permissions)

--- a/saleor/graphql/app/utils.py
+++ b/saleor/graphql/app/utils.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ValidationError
 
 from ...app.models import App
+from ...permission.enums import AppPermission
 from ..account.utils import get_out_of_scope_permissions
 from ..core.enums import AppErrorCode
 from ..utils import requestor_is_superuser
@@ -22,6 +23,28 @@ def ensure_can_manage_permissions(requestor, permission_items):
         raise ValidationError(
             {"permissions": ValidationError(error_msg, code=code, params=params)}
         )
+
+
+def ensure_app_permissions_allowed(permission_items: list[str]):
+    """Reject permissions that an App must never hold.
+
+    Apps must not hold MANAGE_APPS regardless of requestor scope - even
+    superusers cannot grant it. This prevents privilege laundering through a
+    non-human principal.
+
+    permission_items contains dotted codenames as produced by graphene's
+    PermissionEnum deserialization (e.g. "app.manage_apps").
+    """
+    manage_apps = AppPermission.MANAGE_APPS.value
+    if manage_apps not in permission_items:
+        return
+
+    error_msg = "MANAGE_APPS permission cannot be granted to an app."
+    code = AppErrorCode.OUT_OF_SCOPE_PERMISSION.value
+    params = {"permissions": [manage_apps]}
+    raise ValidationError(
+        {"permissions": ValidationError(error_msg, code=code, params=params)}
+    )
 
 
 def validate_app_is_not_removed(


### PR DESCRIPTION
Previously there was only partial protection against granting app a MANAGE_APPS permission.

Apps should not have one, because in such case it can leak of the initial permission scope.

This PR targets missing spots: commands, human/admin mutations as well

Port of https://github.com/saleor/saleor/pull/19166