### PR TITLE
build: remove relative pyjwt publication date constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,12 +140,16 @@ exclude-newer = "3 weeks"
 
 [tool.uv.exclude-newer-package]
 # To customize on a per-package basis, for example you can do this:
-# setuptools = "30 days"
+# setuptools = "2026-04-07T14:30:00Z"
+# Note: the timestamp is the upload date but it doesn't need to be exactly the same
+#       as the one from PyPI but should be a few seconds or a minutes close
+#       to the actual PyPI publication time to reduce the risk of race conditions
+#       (i.e., someone uploading a malicious version during the provided time
+#       window)
+# Note: if you remove a package in this list and 'uv lock' doesn't update the lockfile,
+#       then try 'uv lock --refresh' this should force uv to detect the lockfile drift.
 django = "2026-04-07T14:30:00Z"
 requests-hardened = "2026-04-27T14:43:48Z"
-
-# Allow more recent pyjwt version due to https://github.com/jpadilla/pyjwt/security/advisories/GHSA-752w-5fwx-jx9f
-pyjwt = "10 days"
 
 [tool.poe.tasks]
 start.help = "Start development server with hot reload"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,13 +141,14 @@ exclude-newer = "3 weeks"
 [tool.uv.exclude-newer-package]
 # To customize on a per-package basis, for example you can do this:
 # setuptools = "2026-04-07T14:30:00Z"
-# Note: the timestamp is the upload date but it doesn't need to be exactly the same
-#       as the one from PyPI but should be a few seconds or a minutes close
-#       to the actual PyPI publication time to reduce the risk of race conditions
-#       (i.e., someone uploading a malicious version during the provided time
-#       window)
-# Note: if you remove a package in this list and 'uv lock' doesn't update the lockfile,
-#       then try 'uv lock --refresh' this should force uv to detect the lockfile drift.
+# Note: the timestamp should correspond to the package's upload time on PyPI.
+#       It doesn't need to match exactly, it can be set slightly after the actual
+#       publication time (add a few more seconds, but no more than a few minutes).
+#       Setting the timestamp too far after the publication time increases the risk
+#       of a race condition (e.g., a malicious version being uploaded within that
+#       window).
+# Note: if you remove a package from this list and 'uv lock' does not update the
+#       lockfile, run 'uv lock --refresh' to force a refresh.
 django = "2026-04-07T14:30:00Z"
 requests-hardened = "2026-04-27T14:43:48Z"
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,13 +9,12 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-06T14:45:24.237680315Z"
+exclude-newer = "2026-04-06T16:46:09.824035298Z"
 exclude-newer-span = "P3W"
 
 [options.exclude-newer-package]
-requests-hardened = "2026-04-27T14:43:48Z"
 django = "2026-04-07T14:30:00Z"
-pyjwt = { timestamp = "2026-04-17T14:45:24.237717191Z", span = "P10D" }
+requests-hardened = "2026-04-27T14:43:48Z"
 
 [[package]]
 name = "amqp"


### PR DESCRIPTION
This removes the 10 days age constraint as it is a relative time (instead of absolute) which is less secure, and is no longer needed due to the release now being older than 21 days.



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
