### PR TITLE
Added subscription to CUSTOMER_DELETED

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -36225,6 +36225,28 @@ type CustomerUpdated implements Event @doc(category: "Users") {
   user: User
 }
 
+"""
+Event sent when customer user is deleted.
+
+Added in Saleor 3.23.
+"""
+type CustomerDeleted implements Event @doc(category: "Users") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The user the event relates to."""
+  user: User
+}
+
 """Event sent when customer user metadata is updated."""
 type CustomerMetadataUpdated implements Event @doc(category: "Users") {
   """Time of the event."""

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1601,6 +1601,14 @@ class CustomerMetadataUpdated(SubscriptionObjectType, UserBase):
         description = "Event sent when customer user metadata is updated."
 
 
+class CustomerDeleted(SubscriptionObjectType, UserBase):
+    class Meta:
+        root_type = "User"
+        enable_dry_run = True
+        interfaces = (Event,)
+        description = "Event sent when customer user is deleted." + ADDED_IN_323
+
+
 class CollectionBase(AbstractType):
     collection = graphene.Field(
         "saleor.graphql.product.types.collections.Collection",
@@ -3270,6 +3278,7 @@ ASYNC_WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.FULFILLMENT_METADATA_UPDATED: FulfillmentMetadataUpdated,
     WebhookEventAsyncType.CUSTOMER_CREATED: CustomerCreated,
     WebhookEventAsyncType.CUSTOMER_UPDATED: CustomerUpdated,
+    WebhookEventAsyncType.CUSTOMER_DELETED: CustomerDeleted,
     WebhookEventAsyncType.CUSTOMER_METADATA_UPDATED: CustomerMetadataUpdated,
     WebhookEventAsyncType.COLLECTION_CREATED: CollectionCreated,
     WebhookEventAsyncType.COLLECTION_UPDATED: CollectionUpdated,

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1477,6 +1477,7 @@ def async_subscription_webhooks_with_root_objects(
         ],
         events.CUSTOMER_CREATED: [subscription_customer_created_webhook, customer_user],
         events.CUSTOMER_UPDATED: [subscription_customer_updated_webhook, customer_user],
+        events.CUSTOMER_DELETED: [subscription_customer_deleted_webhook, customer_user],
         events.CUSTOMER_METADATA_UPDATED: [
             subscription_customer_metadata_updated_webhook,
             customer_user,

--- a/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -2238,17 +2238,17 @@ def test_customer_updated(customer_user, subscription_customer_updated_webhook):
     assert deliveries[0].webhook == webhooks[0]
 
 
-def test_customer_deleted(customer_user, subscription_customer_created_webhook):
+def test_customer_deleted(customer_user, subscription_customer_deleted_webhook):
     # given
     customer_user_id = customer_user.id
     customer_user.delete()
     customer_user.id = customer_user_id
 
-    webhooks = [subscription_customer_created_webhook]
-    event_type = WebhookEventAsyncType.CUSTOMER_CREATED
+    webhooks = [subscription_customer_deleted_webhook]
+    event_type = WebhookEventAsyncType.CUSTOMER_DELETED
     expected_payload = json.dumps(
         generate_customer_payload(
-            customer_user, subscription_customer_created_webhook.app
+            customer_user, subscription_customer_deleted_webhook.app
         )
     )
 


### PR DESCRIPTION
CUSTOMER_DELETED webhook was single, not migrated webhook from legacy static payload to subscription queries.

This commit adds possibility to add subscription to this event. This:
1. Adds possibility for SMTP app to support it modern way
2. Fix custom apps in dashboard - now webhook can't be registered (validation requires query, Saleor doesn't support it in input)
3. We can start deprecating and removing old webhooks flow with static payload

Port to 3.23
https://github.com/saleor/saleor/pull/19174
