### PR TITLE
fix: add GraphQL validation logs

### DIFF
--- a/saleor/graphql/core/validators/alias_count_limit_rule.py
+++ b/saleor/graphql/core/validators/alias_count_limit_rule.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 from django.conf import settings
@@ -7,6 +8,8 @@ from graphql.validation.rules.base import ValidationRule
 from graphql.validation.validation import ValidationContext
 
 from ...metrics import record_graphql_alias_count
+
+logger = logging.getLogger(__name__)
 
 
 class AliasCountLimitRule(ValidationRule):
@@ -23,6 +26,11 @@ class AliasCountLimitRule(ValidationRule):
 
     def leave_Document(self, *_args: Any) -> None:
         if self.alias_count_seen > self.limit:
+            logger.info(
+                "Query exceeds alias limit of %d, found %d aliases",
+                self.limit,
+                self.alias_count_seen,
+            )
             self.context.report_error(
                 GraphQLError(f"Number of aliases exceed the limit of {self.limit}")
             )

--- a/saleor/graphql/core/validators/mutation_count_limit_rule.py
+++ b/saleor/graphql/core/validators/mutation_count_limit_rule.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 from django.conf import settings
@@ -7,6 +8,8 @@ from graphql.validation.rules.base import ValidationRule
 from graphql.validation.validation import ValidationContext
 
 from ...metrics import record_graphql_mutation_count
+
+logger = logging.getLogger(__name__)
 
 
 class MutationCountLimitRule(ValidationRule):
@@ -23,6 +26,11 @@ class MutationCountLimitRule(ValidationRule):
 
     def leave_Document(self, *_args: Any) -> None:
         if self.seen_count > self.limit:
+            logger.info(
+                "Mutation count exceeds the limit of %d, found %d mutations",
+                self.limit,
+                self.seen_count,
+            )
             self.context.report_error(
                 GraphQLError(f"Number of mutations exceed the limit of {self.limit}")
             )


### PR DESCRIPTION
_Backport of 6b6c73f4acd47bad77b5c04f4aab8c0ec0d59d98 (#19175)_

Saleor 3.22.0 removed invalid request logs in https://github.com/saleor/saleor/pull/17798, whereas the GraphQL validators were designed under the assumption that these logs were still present; this causes a major visibility gap.

Part of https://linear.app/saleor/issue/PXTX-737/ (https://saleorcommerce.slack.com/archives/C090MG1LB3J/p1777456927581389)



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
