### PR TITLE
Handle RequestDataTooBig error

### DIFF
--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -244,6 +244,22 @@ def test_unexpected_types_in_json_request_body(client, data):
     assert errors[0]["message"] == "Unable to parse query."
 
 
+def test_request_body_too_big(client, settings):
+    # given
+    settings.DATA_UPLOAD_MAX_MEMORY_SIZE = 10
+    data = '{"query": "query { products(first: 10) { edges { node { id } } } }"}'
+
+    # when
+    response = client.post(API_PATH, data, content_type="application/json")
+
+    # then
+    assert response.status_code == 413
+    content = get_graphql_content_from_response(response)
+    errors = content.get("errors")
+    assert len(errors) == 1
+    assert errors[0]["message"] == "Request body exceeds maximum size."
+
+
 def test_invalid_query(api_client):
     query = "query { invalid }"
     response = api_client.post_graphql(query, check_no_permissions=False)

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin
 import orjson
 from django.conf import settings
 from django.core.cache import cache
+from django.core.exceptions import RequestDataTooBig
 from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import render
 from django.views.generic import View
@@ -171,6 +172,17 @@ class GraphQLView(View):
     def _handle_query(self, request: HttpRequest) -> JsonResponse:
         try:
             data = self.parse_body(request)
+        except RequestDataTooBig:
+            return JsonResponse(
+                data={
+                    "errors": [
+                        self.format_error(
+                            GraphQLError("Request body exceeds maximum size.")
+                        )
+                    ]
+                },
+                status=413,
+            )
         except ValueError:
             return JsonResponse(
                 data={


### PR DESCRIPTION
Fixes https://saleor.sentry.io/issues/7458508760/?notification_uuid=fd8ae8fa-27a8-4f7e-8b38-4d32b5bb96c6&alert_rule_id=11198640&alert_type=issue

On HTTP layer request is rejected by Django. This commit handles exception and returns valid HTTP error and meaningful message. Also error should no longer go to Sentry