### PR TITLE
Release 3.22.50

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.49",
+  "version": "3.22.50",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.49",
+      "version": "3.22.50",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.49",
+  "version": "3.22.50",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.22.49"
+version = "3.22.50"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.49"
+__version__ = "3.22.50"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2549,7 +2549,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.22.49"
+version = "3.22.50"
 source = { virtual = "." }
 dependencies = [
     { name = "adyen", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
Changes since 3.22.49:
- 6057472c721a431a1b66ddc1ff35f7f3a89acf53  Mikail Kocak: release: v3.22.50
- 1ed88a34d9bd7e547a609c326933ca78af26f617  Mikail: bump: Django v5.2.14 (#19188)
- 9ce1ce386c652dfc3c0389f9488197759f0b260c  Mikail: deps: upgrade cryptography & pillow (#19184)
- 81771f00104fc75e013a4e2da03774d99f1e3604  Mikail: fix: add GraphQL validation logs (#19177)