### PR TITLE
fix: missing libxslt in container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update \
   libwebp7 \
   libpq5 \
   libmagic1 \
+  libxslt1-dev `# libxslt is needed by lxml (PyPI)` \
   # Required by celery[sqs] which uses pycurl for AWS SQS support
   libcurl4 \
   # Required to allows to identify file types when handling file uploads


### PR DESCRIPTION
Fixes the following crash:

```
4.169 ImportError: Failed to import plugin saleor.plugins.user_email.plugin.UserEmailPlugin: libxslt.so.1: cannot open shared object file: No such file or directory
```

Caused by `lxml` upgrade from c2bb77cccdfd7b80ac0479d058ea6543ee949d09, as per https://lxml.de/installation.html, it requires libxslt to be installed.

Was manually tested and confirmed as properly working now by exporting products both using CSV and Excel files:

<img width="1643" height="795" alt="Screenshot 2026-05-06 at 13 02 28" src="https://github.com/user-attachments/assets/c4c5ee44-4ae6-4123-ab5c-9ccbf6d705bf" />

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
