### PR TITLE
feat(devcontainer): use Celery eager mode by default

### DIFF
--- a/.devcontainer/backend.env
+++ b/.devcontainer/backend.env
@@ -2,8 +2,12 @@ DATABASE_URL=postgres://saleor:saleor@db/saleor
 DASHBOARD_URL=http://localhost:9000/
 DEFAULT_FROM_EMAIL=noreply@example.com
 CACHE_URL=redis://cache:6379/0
-CELERY_BROKER_URL=redis://cache:6379/1
 SECRET_KEY=changeme
 # Mailpit
 EMAIL_URL=smtp://mailpit:1025
 ALLOWED_HOSTS="localhost,127.0.0.1,host.docker.internal,host.containers.internal"
+
+# Uncomment to enable Celery in async mode. By default, we disable `CELERY_BROKER_URL`
+# in the devcontainer in order to use the Eager Mode (i.e., tasks will be processed
+# synchronously instead of offloading the tasks to Celery).
+#CELERY_BROKER_URL=redis://cache:6379/1


### PR DESCRIPTION
By default our devcontainer doesn't start Celery thus it doesn't make sense to enable Celery by default as it makes it harder for new contributors to start developing.

(ref: https://saleorcommerce.slack.com/archives/C0352SN0W3U/p1775557104696719)


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
