### PR TITLE
Change graphql-inspector to run against proper branch

### DIFF
--- a/.github/workflows/graphql-inspector.yml
+++ b/.github/workflows/graphql-inspector.yml
@@ -22,4 +22,4 @@ jobs:
 
       - uses: graphql-hive/graphql-inspector@84c610fac649e0379643da772e77e775c6aeaf56 # release-1769448022768
         with:
-          schema: "${{ env.BASE_REF }}:saleor/graphql/schema.graphql"
+          schema: "${{ github.event.pull_request.base.sha }}:saleor/graphql/schema.graphql"

--- a/.github/workflows/graphql-inspector.yml
+++ b/.github/workflows/graphql-inspector.yml
@@ -14,8 +14,6 @@ jobs:
       contents: read
       checks: write
 
-    env:
-      BASE_REF: ${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/graphql-inspector.yml
+++ b/.github/workflows/graphql-inspector.yml
@@ -16,7 +16,6 @@ jobs:
 
     env:
       BASE_REF: ${{ github.base_ref }}
-
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/graphql-inspector.yml
+++ b/.github/workflows/graphql-inspector.yml
@@ -1,7 +1,7 @@
 name: GraphQL Inspector
 
 on:
-  push:
+  pull_request:
     paths: ["**.graphql"]
 
 permissions: {}
@@ -14,9 +14,12 @@ jobs:
       contents: read
       checks: write
 
+    env:
+      BASE_REF: ${{ github.base_ref }}
+
     steps:
       - uses: actions/checkout@v5
 
       - uses: graphql-hive/graphql-inspector@84c610fac649e0379643da772e77e775c6aeaf56 # release-1769448022768
         with:
-          schema: "main:saleor/graphql/schema.graphql"
+          schema: "${{ env.BASE_REF }}:saleor/graphql/schema.graphql"


### PR DESCRIPTION
graphql-inspector action is used to compare new changes with base branch, e.g. to detect breaking change.

However looks like it was not configured properly:
1. It always compared against main branch, so PR to `3.23` was also comparing to `main`
2. It was running on `push` instead of pull request, so e.g. merging PR to main run it 2nd time, which is not needed
3. It executes false positives, comparing 3.23 to main in the opposite direction - see [this](https://github.com/saleor/saleor/actions/runs/25541743925) (`main` has new mutation, it compares 3.23 to `main` and throws that we removed something, but we actually added)