### PR TITLE
Release 3.23.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.23.4",
+  "version": "3.23.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.23.4",
+      "version": "3.23.5",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.23.4",
+  "version": "3.23.5",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.23.4"
+version = "3.23.5"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,7 +1,7 @@
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.23.4"
+__version__ = "3.23.5"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2512,7 +2512,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.23.4"
+version = "3.23.5"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
* Release 3.23.5 (40e1545015)
* Allow apps to receive their own lifecycle webhooks (#19160) (ae5c2af59c)
* Change graphql-inspector to run against proper branch (#19197) (#19198) (c20bd9d8f5)
* [3.23] CheckoutDelete mutation (Port) (#19196) (3aa7f61bda)
*    Added subscription to CUSTOMER_DELETED (#19174) (54e678186e)
