### PR TITLE
fix: crash when telemetry is disabled and lifespan is enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,4 +64,4 @@ LABEL org.opencontainers.image.title="saleor/saleor" \
   org.opencontainers.image.authors="Saleor Commerce (https://saleor.io)" \
   org.opencontainers.image.licenses="BSD-3-Clause"
 
-CMD ["uvicorn", "saleor.asgi:application", "--host=0.0.0.0", "--port=8000", "--workers=2", "--lifespan=on", "--ws=none", "--no-server-header", "--no-access-log", "--timeout-keep-alive=35", "--timeout-graceful-shutdown=30", "--limit-max-requests=10000"]
+CMD ["uvicorn", "saleor.asgi:application", "--host=0.0.0.0", "--port=8000", "--workers=2", "--lifespan=auto", "--ws=none", "--no-server-header", "--no-access-log", "--timeout-keep-alive=35", "--timeout-graceful-shutdown=30", "--limit-max-requests=10000"]


### PR DESCRIPTION
When `SEND_USAGE_TELEMETRY=False` and `--lifespan=on` was still present, the startup would crash:

```
$ SEND_USAGE_TELEMETRY=false uvicorn saleor.asgi:application --lifespan=on
2026-05-14 15:16:09,412 WARNING saleor.core.jwt_manager RSA_PRIVATE_KEY is missing. Using temporary key for local development with DEBUG mode. [PID:45018:MainThread]
INFO:     Started server process [45018]
INFO:     Waiting for application startup.
ERROR:    Exception in 'lifespan' protocol
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/uvicorn/lifespan/on.py", line 86, in main
    await app(scope, self.receive, self.send)
  File "/usr/local/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 29, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/saleor/asgi/telemetry.py", line 26, in telemetry_wrapper
    return await application(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/saleor/asgi/cors_handler.py", line 21, in cors_wrapper
    await application(scope, receive, send)
  File "/app/saleor/asgi/gzip_compression.py", line 145, in gzip_compression_wrapper
    await app(scope, receive, send)
  File "/app/saleor/asgi/health_check.py", line 16, in health_check_wrapper
    return await application(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/asgi.py", line 161, in __call__
    raise ValueError(
ValueError: Django can only handle ASGI/HTTP connections, not lifespan.
ERROR:    Application startup failed. Exiting.
```

This issue is resolved by leaving it up to uvicorn to detect whether to enable lifespan or disable it.

Part of #19202 - needs to be backported to 3.23

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
