### PR TITLE
Handle null values in WeightScalar validation

### DIFF
--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -96,6 +96,8 @@ class WeightScalar(graphene.Scalar):
     @staticmethod
     def parse_value(value):
         if isinstance(value, dict):
+            if value.get("value") is None:
+                return None
             weight = Weight(**{value["unit"]: value["value"]})
         else:
             weight = WeightScalar.parse_decimal(value)

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -3718,6 +3718,35 @@ def test_create_product_with_weight_variable(
     assert result_weight["unit"] == site_settings.default_weight_unit.upper()
 
 
+def test_create_product_with_null_weight_value_returns_validation_error(
+    staff_api_client,
+    category,
+    permission_manage_products,
+    product_type_without_variant,
+):
+    category_id = graphene.Node.to_global_id("Category", category.pk)
+    product_type_id = graphene.Node.to_global_id(
+        "ProductType", product_type_without_variant.pk
+    )
+    variables = {
+        "category": category_id,
+        "productType": product_type_id,
+        "name": "Test",
+        "weight": {"unit": "KG", "value": None},
+    }
+
+    response = staff_api_client.post_graphql(
+        MUTATION_CREATE_PRODUCT_WITH_WEIGHT_GQL_VARIABLE,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["productCreate"]["product"] is None
+    error = content["data"]["productCreate"]["errors"][0]
+    assert error["field"] == "weight"
+
+
 @pytest.mark.parametrize(
     ("weight", "expected_weight_value"),
     [


### PR DESCRIPTION
## Summary

Adds validation handling for `None` values passed into `WeightScalar.parse_value`.

Previously, when a GraphQL mutation passed a weight object with `"value": null`, the scalar attempted to construct a `Weight` instance directly, which could raise an exception instead of returning a validation error.

This change:

* returns `None` when the weight value is null
* prevents invalid `Weight(...)` construction
* adds regression test coverage for product creation with invalid weight input

## Testing

Attempted to run:

pytest saleor/graphql/product/tests/mutations/test_product_create.py -k "weight"

Local execution could not complete because project dependencies were not fully installed:

ModuleNotFoundError: No module named 'dj_database_url'

Additionally verified syntax successfully with:

python -m py_compile saleor/graphql/core/scalars.py saleor/graphql/product/tests/mutations/test_product_create.py