### PR TITLE
Reject control characters from the request

### DIFF
--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -221,23 +221,69 @@ def test_invalid_request_body_error_is_not_logged(client, caplog, settings, debu
     assert caplog.records == []
 
 
-@pytest.mark.parametrize(
-    "control_char",
-    [
-        "\x00",  # NUL
-        "\x01",  # SOH (C0)
-        "\x08",  # backspace (C0)
-        "\x0b",  # vertical tab (C0)
-        "\x1f",  # unit separator (C0, last)
-        "\x7f",  # DEL
-        "\x80",  # C1 (first)
-        "\x9f",  # C1 (last)
-    ],
-)
-def test_request_body_with_control_character_is_rejected(client, control_char):
+CONTROL_CHARS = [
+    "\x00",  # NUL
+    "\x01",  # SOH (C0)
+    "\x08",  # backspace (C0)
+    "\x0b",  # vertical tab (C0)
+    "\x1f",  # unit separator (C0, last)
+    "\x7f",  # DEL
+    "\x80",  # C1 (first)
+    "\x9f",  # C1 (last)
+]
+
+
+@pytest.mark.parametrize("control_char", CONTROL_CHARS)
+def test_request_body_with_control_character_in_query_is_rejected(client, control_char):
     # given
     query = f'{{"query": "{{ category(slug: \\"foo{control_char}bar\\") {{ id }} }}"}}'
     data = query.encode("utf-8")
+
+    # when
+    response = client.post(API_PATH, data, content_type="application/json")
+
+    # then
+    assert response.status_code == 400
+    content = get_graphql_content_from_response(response)
+    errors = content.get("errors")
+    assert len(errors) == 1
+    assert errors[0]["message"] == "Unable to parse query."
+
+
+@pytest.mark.parametrize("control_char", CONTROL_CHARS)
+def test_request_body_with_control_character_in_operation_name_is_rejected(
+    client, control_char
+):
+    # given
+    data = json.dumps(
+        {
+            "query": "query GetTypename { __typename }",
+            "operationName": f"GetTypename{control_char}",
+        }
+    )
+
+    # when
+    response = client.post(API_PATH, data, content_type="application/json")
+
+    # then
+    assert response.status_code == 400
+    content = get_graphql_content_from_response(response)
+    errors = content.get("errors")
+    assert len(errors) == 1
+    assert errors[0]["message"] == "Unable to parse query."
+
+
+@pytest.mark.parametrize("control_char", CONTROL_CHARS)
+def test_request_body_with_control_character_in_variables_is_rejected(
+    client, control_char
+):
+    # given
+    data = json.dumps(
+        {
+            "query": "query($slug: String!) { category(slug: $slug) { id } }",
+            "variables": {"slug": f"foo{control_char}bar"},
+        }
+    )
 
     # when
     response = client.post(API_PATH, data, content_type="application/json")
@@ -263,6 +309,27 @@ def test_request_body_with_whitespace_control_character_is_accepted(client, whit
     assert response.status_code == 200
     content = get_graphql_content_from_response(response)
     assert content["data"] == {"__typename": "Query"}
+
+
+@pytest.mark.parametrize("whitespace", ["\t", "\n", "\r"])
+def test_request_body_with_whitespace_control_character_in_variables_is_accepted(
+    api_client, whitespace
+):
+    # given - whitespace inside variable values must round-trip as data
+    slug_with_whitespace = f"foo{whitespace}bar"
+    data = {
+        "query": "query($slug: String!) { category(slug: $slug) { id } }",
+        "variables": {"slug": slug_with_whitespace},
+    }
+
+    # when
+    response = api_client.post(data=data)
+
+    # then - no slug matches but the request is accepted and resolves to null
+    assert response.status_code == 200
+    content = get_graphql_content_from_response(response)
+    assert "errors" not in content
+    assert content["data"] == {"category": None}
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -221,9 +221,23 @@ def test_invalid_request_body_error_is_not_logged(client, caplog, settings, debu
     assert caplog.records == []
 
 
-def test_request_body_with_nul_byte_is_rejected(client, caplog):
+@pytest.mark.parametrize(
+    "control_char",
+    [
+        "\x00",  # NUL
+        "\x01",  # SOH (C0)
+        "\x08",  # backspace (C0)
+        "\x0b",  # vertical tab (C0)
+        "\x1f",  # unit separator (C0, last)
+        "\x7f",  # DEL
+        "\x80",  # C1 (first)
+        "\x9f",  # C1 (last)
+    ],
+)
+def test_request_body_with_control_character_is_rejected(client, control_char):
     # given
-    data = b'{"query": "{ category(slug: \\"foo\x00bar\\") { id } }"}'
+    query = f'{{"query": "{{ category(slug: \\"foo{control_char}bar\\") {{ id }} }}"}}'
+    data = query.encode("utf-8")
 
     # when
     response = client.post(API_PATH, data, content_type="application/json")
@@ -234,6 +248,21 @@ def test_request_body_with_nul_byte_is_rejected(client, caplog):
     errors = content.get("errors")
     assert len(errors) == 1
     assert errors[0]["message"] == "Unable to parse query."
+
+
+@pytest.mark.parametrize("whitespace", ["\t", "\n", "\r"])
+def test_request_body_with_whitespace_control_character_is_accepted(client, whitespace):
+    # given - whitespace controls are legal in JSON and GraphQL source
+    query = f"{{{whitespace}__typename{whitespace}}}"
+    data = json.dumps({"query": query})
+
+    # when
+    response = client.post(API_PATH, data, content_type="application/json")
+
+    # then
+    assert response.status_code == 200
+    content = get_graphql_content_from_response(response)
+    assert content["data"] == {"__typename": "Query"}
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -221,6 +221,21 @@ def test_invalid_request_body_error_is_not_logged(client, caplog, settings, debu
     assert caplog.records == []
 
 
+def test_request_body_with_nul_byte_is_rejected(client, caplog):
+    # given
+    data = b'{"query": "{ category(slug: \\"foo\x00bar\\") { id } }"}'
+
+    # when
+    response = client.post(API_PATH, data, content_type="application/json")
+
+    # then
+    assert response.status_code == 400
+    content = get_graphql_content_from_response(response)
+    errors = content.get("errors")
+    assert len(errors) == 1
+    assert errors[0]["message"] == "Unable to parse query."
+
+
 @pytest.mark.parametrize(
     "data",
     [

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -68,6 +68,19 @@ INT_ERROR_MSG = "Int cannot represent non 32-bit signed integer value"
 FORBIDDEN_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]")
 
 
+def _contains_control_chars(value) -> bool:
+    if isinstance(value, str):
+        return FORBIDDEN_CONTROL_CHARS.search(value) is not None
+    if isinstance(value, dict):
+        return any(
+            _contains_control_chars(k) or _contains_control_chars(v)
+            for k, v in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_control_chars(item) for item in value)
+    return False
+
+
 def default_serializer(obj):
     if isinstance(obj, decimal.Decimal):
         return str(obj)
@@ -552,6 +565,11 @@ class GraphQLView(View):
             if FORBIDDEN_CONTROL_CHARS.search(body_str):
                 raise ValueError("Request body contains control characters.")
             body = orjson.loads(body_str)
+            # JSON allows control chars to be escaped (e.g. "\u0000"), which
+            # passes the raw-body check above but decodes into an actual
+            # control codepoint inside parsed strings.
+            if _contains_control_chars(body):
+                raise ValueError("Request body contains control characters.")
             if isinstance(body, dict) or isinstance(body, list):
                 return body
 

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -528,10 +528,19 @@ class GraphQLView(View):
 
     @staticmethod
     def parse_body(request: HttpRequest):
+        # psycopg rejects NUL bytes in text parameters; reaching the DB layer
+        # with one produces an unhandled DataError. Reject text GraphQL bodies
+        # that contain a NUL byte rather than stripping it - assume the
+        # request is rogue. Multipart bodies are not checked here because
+        # uploaded files legitimately contain NUL bytes in binary payloads.
         content_type = request.content_type
         if content_type == "application/graphql":
+            if b"\x00" in request.body:
+                raise ValueError("Request body contains NUL byte.")
             return {"query": request.body.decode("utf-8")}
         if content_type == "application/json":
+            if b"\x00" in request.body:
+                raise ValueError("Request body contains NUL byte.")
             body = orjson.loads(request.body)
             if isinstance(body, dict) or isinstance(body, list):
                 return body

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -61,8 +61,9 @@ INT_ERROR_MSG = "Int cannot represent non 32-bit signed integer value"
 
 # Control characters that should never appear unescaped in a GraphQL request
 # body. Covers C0 (0x00-0x1F) except whitespace (\t \n \r) plus DEL and C1
-# (0x7F-0x9F). NUL bytes trip psycopg with an unhandled DataError; the rest
-# enable log/header injection and have no legitimate use in JSON or GraphQL
+# (0x7F-0x9F). More info: https://en.wikipedia.org/wiki/C0_and_C1_control_codes
+# NUL bytes trip psycopg with an unhandled DataError; the rest can enable log
+# and header injections and have no legitimate use in JSON or GraphQL
 # source text.
 FORBIDDEN_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]")
 

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -1,6 +1,7 @@
 import decimal
 import hashlib
 import importlib
+import re
 import time
 from inspect import isclass
 from typing import Any, cast
@@ -57,6 +58,13 @@ from .utils import (
 from .utils.validators import check_if_query_contains_only_schema
 
 INT_ERROR_MSG = "Int cannot represent non 32-bit signed integer value"
+
+# Control characters that should never appear unescaped in a GraphQL request
+# body. Covers C0 (0x00-0x1F) except whitespace (\t \n \r) plus DEL and C1
+# (0x7F-0x9F). NUL bytes trip psycopg with an unhandled DataError; the rest
+# enable log/header injection and have no legitimate use in JSON or GraphQL
+# source text.
+FORBIDDEN_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]")
 
 
 def default_serializer(obj):
@@ -528,20 +536,21 @@ class GraphQLView(View):
 
     @staticmethod
     def parse_body(request: HttpRequest):
-        # psycopg rejects NUL bytes in text parameters; reaching the DB layer
-        # with one produces an unhandled DataError. Reject text GraphQL bodies
-        # that contain a NUL byte rather than stripping it - assume the
-        # request is rogue. Multipart bodies are not checked here because
-        # uploaded files legitimately contain NUL bytes in binary payloads.
+        # Reject text GraphQL bodies containing control characters rather than
+        # stripping them - assume the request is rogue. Multipart bodies are
+        # not checked here because uploaded files legitimately contain control
+        # bytes in binary payloads.
         content_type = request.content_type
         if content_type == "application/graphql":
-            if b"\x00" in request.body:
-                raise ValueError("Request body contains NUL byte.")
-            return {"query": request.body.decode("utf-8")}
+            body = request.body.decode("utf-8")
+            if FORBIDDEN_CONTROL_CHARS.search(body):
+                raise ValueError("Request body contains control characters.")
+            return {"query": body}
         if content_type == "application/json":
-            if b"\x00" in request.body:
-                raise ValueError("Request body contains NUL byte.")
-            body = orjson.loads(request.body)
+            body_str = request.body.decode("utf-8")
+            if FORBIDDEN_CONTROL_CHARS.search(body_str):
+                raise ValueError("Request body contains control characters.")
+            body = orjson.loads(body_str)
             if isinstance(body, dict) or isinstance(body, list):
                 return body
 


### PR DESCRIPTION
NUL byte validation lives on the DB layer, causing unhandled error when injected to the body. 

We can assume this is a rogue attempt of exploiting, so we can early reject such request.

Fixes https://saleor.sentry.io/issues/7476848715