### PR TITLE
Release 3.23.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.23.5",
+  "version": "3.23.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.23.5",
+      "version": "3.23.6",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.23.5",
+  "version": "3.23.6",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.23.5"
+version = "3.23.6"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,7 +1,7 @@
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.23.5"
+__version__ = "3.23.6"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2512,7 +2512,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.23.5"
+version = "3.23.6"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
* Release 3.23.6 (4e3c2f4ccc)
* [3.23] Fix: checkout deliveries invalidation (#19229) (ae9c4e52eb)
* fix: crash when telemetry is disabled and lifespan is enabled (#19227) (66d6c26d51)
* Reject empty-string channel ID in channelDelete mutation (#19223) (2392ae0f35)
* Gracefully handle invalid json string (#19206) (06836d538d)
