### PR TITLE
chore: upgrade pyjwt to v2.13.0 & bump idna

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update \
   # Required to allows to identify file types when handling file uploads
   media-types
 
-COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.8@sha256:3b7b60a81d3c57ef471703e5c83fd4aaa33abcd403596fb22ab07db85ae91347 \
+  /uv /uvx /bin/
 ENV UV_COMPILE_BYTECODE=1 UV_SYSTEM_PYTHON=1 UV_PROJECT_ENVIRONMENT=/usr/local
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,8 +56,7 @@ repos:
         - --quiet
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    # uv version.
-    rev: 0.8.14
+    rev: 659a7789596d520c849e9c96525119e9fbaa731f # frozen: 0.11.8
     hooks:
       - id: uv-lock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get -y update \
 
 # Install Python dependencies
 WORKDIR /app
-COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.8@sha256:3b7b60a81d3c57ef471703e5c83fd4aaa33abcd403596fb22ab07db85ae91347 \
+  /uv /uvx /bin/
 ENV UV_COMPILE_BYTECODE=1 UV_SYSTEM_PYTHON=1 UV_PROJECT_ENVIRONMENT=/usr/local
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
   "prices~=1.0",
   "promise~=2.3",
   "pybars3>=0.9.7,<0.10",
-  "pyjwt>=2.10.1,<3",
+  "pyjwt>=2.13.0,<3",
   "python-dateutil>=2.8.2,<3",
   "python-http-client>=3.3.7,<4",
   "python-json-logger>=0.1.11,<3.3.0",
@@ -85,7 +85,7 @@ dependencies = [
   "python-magic>=0.4.27,<0.5 ; sys_platform != 'win32'",
   "python-magic-bin>=0.4.14,<0.5 ; sys_platform == 'win32'",
   "nh3>=0.3.2",
-  "idna>=3.10"
+  "idna>=3.15"
 ]
 
   [[project.authors]]
@@ -189,6 +189,14 @@ help = "Run tests with db reuse to speed up testing time"
 [tool.uv]
 environments = [ "platform_python_implementation != 'PyPy'" ]
 package = false
+exclude-newer = "3 weeks"
+
+[tool.uv.exclude-newer-package]
+# To customize on a per-package basis, for example you can do this:
+# setuptools = "2026-04-07T14:30:00Z"
+django = "2026-05-05T13:57:31Z" # https://pypi.org/pypi/django/5.2.14/json
+pyjwt = "2026-05-21T19:54:36" # https://github.com/jpadilla/pyjwt/releases/tag/2.13.0
+idna = "2026-05-12T22:45:57" # https://github.com/advisories/GHSA-65pc-fj4g-8rjx/
 
 [tool.deptry]
 extend_exclude = [ "conftest\\.py", ".*/conftest\\.py", ".*/tests/.*" ]

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,15 @@ supported-markers = [
     "platform_python_implementation != 'PyPy'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3W"
+
+[options.exclude-newer-package]
+pyjwt = "2026-05-22T00:00:00Z"
+django = "2026-05-05T13:57:31Z"
+idna = "2026-05-13T00:00:00Z"
+
 [[package]]
 name = "adyen"
 version = "4.0.0"
@@ -1172,11 +1181,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -2122,11 +2131,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]
@@ -2702,7 +2711,7 @@ requires-dist = [
     { name = "graphql-core", specifier = ">=2.3.2,<3" },
     { name = "graphql-relay", specifier = ">=2.0.1,<3" },
     { name = "html-to-draftjs", specifier = ">=1.0.1,<2" },
-    { name = "idna", specifier = ">=3.10" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "kombu", extras = ["sqs"], specifier = ">=4.6.11,<6.0.0" },
     { name = "lxml", specifier = ">=4.9.3,<5" },
     { name = "markdown", specifier = ">=3.1.1,<4" },
@@ -2725,7 +2734,7 @@ requires-dist = [
     { name = "pybars3", specifier = ">=0.9.7,<0.10" },
     { name = "pydantic", specifier = ">=2.11.0,<3" },
     { name = "pydantic-core", specifier = ">=2.33.0,<3" },
-    { name = "pyjwt", specifier = ">=2.10.1,<3" },
+    { name = "pyjwt", specifier = ">=2.13.0,<3" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3" },
     { name = "python-http-client", specifier = ">=3.3.7,<4" },
     { name = "python-json-logger", specifier = ">=0.1.11,<3.3.0" },


### PR DESCRIPTION
Closes ENG-1572 by upgrading pyjwt to v2.13.0, as well as ENG-1578 for IDNA



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
