### PR TITLE
Fix `OrderShippingMethodsByOrderIdAndWebhookSyncLoader` issues when querying for non-existent and/or multiple orders

### DIFF
--- a/saleor/graphql/order/dataloaders.py
+++ b/saleor/graphql/order/dataloaders.py
@@ -417,32 +417,44 @@ class OrderShippingMethodsByOrderIdAndWebhookSyncLoader(
         orders = OrderByIdLoader(self.context).load_many([order for (order, _) in keys])
 
         def with_orders(orders: list[Order]):
-            def with_listings(channel_listings):
-                results: list[Promise[list[ShippingMethodData]]] = []
-                with allow_writer_in_context(self.context):
-                    for order, listings, (_, allow_sync_webhooks) in zip(
-                        orders, channel_listings, keys, strict=True
-                    ):
-                        result = get_valid_shipping_methods_for_order(
-                            order,
-                            listings,
-                            requestor=requestor,
-                            database_connection_name=self.database_connection_name,
-                            allow_sync_webhooks=allow_sync_webhooks,
-                        )
-                    results.append(result)
-                return Promise.all(results)
+            channel_ids = [order.channel_id for order in orders if order is not None]
 
             def with_channels(channels):
+                channel_slug_by_id = {channel.id: channel.slug for channel in channels}
+
+                def with_listings(channel_listings):
+                    listings_by_channel_id = dict(
+                        zip(channel_ids, channel_listings, strict=True)
+                    )
+                    results: list[Promise[list[ShippingMethodData]]] = []
+                    with allow_writer_in_context(self.context):
+                        for order, (_, allow_sync_webhooks) in zip(
+                            orders, keys, strict=True
+                        ):
+                            if order is None:
+                                results.append(Promise.resolve([]))
+                                continue
+                            result = get_valid_shipping_methods_for_order(
+                                order,
+                                listings_by_channel_id[order.channel_id],
+                                requestor=requestor,
+                                database_connection_name=self.database_connection_name,
+                                allow_sync_webhooks=allow_sync_webhooks,
+                            )
+                            results.append(result)
+                    return Promise.all(results)
+
                 return (
                     ShippingMethodChannelListingByChannelSlugLoader(self.context)
-                    .load_many([c.slug for c in channels])
+                    .load_many(
+                        [channel_slug_by_id[channel_id] for channel_id in channel_ids]
+                    )
                     .then(with_listings)
                 )
 
             return (
                 ChannelByIdLoader(self.context)
-                .load_many([order.channel_id for order in orders if order is not None])
+                .load_many(channel_ids)
                 .then(with_channels)
             )
 

--- a/saleor/graphql/order/tests/dataloaders/test_order_shipping_methods.py
+++ b/saleor/graphql/order/tests/dataloaders/test_order_shipping_methods.py
@@ -1,0 +1,61 @@
+import uuid
+
+from .....shipping.interface import ShippingMethodData
+from ....context import SaleorContext
+from ...dataloaders import OrderShippingMethodsByOrderIdAndWebhookSyncLoader
+
+
+def _build_context():
+    context = SaleorContext()
+    context.app = None
+    context.user = None
+    context.allow_replica = False
+    return context
+
+
+def test_batch_load_single_order(order_with_lines):
+    # given
+    order = order_with_lines
+    keys = [(order.id, True)]
+    context = _build_context()
+    loader = OrderShippingMethodsByOrderIdAndWebhookSyncLoader(context)
+
+    # when
+    result = loader.batch_load(keys).get()
+
+    # then
+    assert len(result) == 1
+    assert all(isinstance(method, ShippingMethodData) for method in result[0])
+
+
+def test_batch_load_missing_order_returns_empty_list(order_with_lines):
+    # given
+    # key references an order that does not exist, so the loader resolves it to None
+    missing_order_id = uuid.uuid4()
+    keys = [(missing_order_id, True)]
+    context = _build_context()
+    loader = OrderShippingMethodsByOrderIdAndWebhookSyncLoader(context)
+
+    # when
+    result = loader.batch_load(keys).get()
+
+    # then
+    assert len(result) == 1
+    assert result[0] == []
+
+
+def test_batch_load_mixed_existing_and_missing_orders(order_with_lines):
+    # given
+    order = order_with_lines
+    missing_order_id = uuid.uuid4()
+    keys = [(missing_order_id, True), (order.id, True)]
+    context = _build_context()
+    loader = OrderShippingMethodsByOrderIdAndWebhookSyncLoader(context)
+
+    # when
+    result = loader.batch_load(keys).get()
+
+    # then
+    assert len(result) == len(keys)
+    assert result[0] == []
+    assert all(isinstance(method, ShippingMethodData) for method in result[1])


### PR DESCRIPTION
To be backported.

Fixes: https://saleor.sentry.io/issues/7511169651/?project=6417854&query=is%3Aunresolved&referrer=issue-stream and https://saleor.sentry.io/issues/7365964871/?project=6417854&query=is%3Aunresolved&referrer=issue-stream.