### PR TITLE
Fix TypeError when resolving default channel slug on product types

### DIFF
--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -3216,3 +3216,30 @@ def test_applies_limit_on_product_assigned_attributes(
         content["data"]["product"]["assignedAttributes"][0]["attribute"]["slug"]
         == first_attribute.slug
     )
+
+
+CHANNEL_FIELD_QUERY = """
+query getProduct($id: ID!) {
+    product(id: $id) {
+        id
+        channel
+    }
+}
+"""
+
+
+def test_channel_field_with_default_channel_anonymous(api_client, product, channel_USD):
+    """No `channel` argument is passed and the anonymous requestor has no product permissions, so the resolver falls back to the lazy default channel slug."""
+
+    # given
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {"id": product_id}
+
+    # when
+    response = api_client.post_graphql(CHANNEL_FIELD_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["product"]
+    assert data["id"] == product_id
+    assert data["channel"] == channel_USD.slug

--- a/saleor/graphql/product/tests/queries/test_variant_query.py
+++ b/saleor/graphql/product/tests/queries/test_variant_query.py
@@ -1143,3 +1143,30 @@ def test_stocks_resolver_ignores_shipping_zones_excluded_from_stock_calculations
     stocks_without_country = content["data"]["productVariant"]["stocksWithoutCountry"]
     assert len(stocks_with_country) == expected_stock_count
     assert len(stocks_without_country) == expected_stock_count
+
+
+CHANNEL_FIELD_QUERY = """
+query getProductVariant($id: ID!) {
+    productVariant(id: $id) {
+        id
+        channel
+    }
+}
+"""
+
+
+def test_channel_field_with_default_channel_anonymous(api_client, variant, channel_USD):
+    """No `channel` argument is passed and the anonymous requestor has no product permissions, so the resolver falls back to the lazy default channel slug."""
+
+    # given
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {"id": variant_id}
+
+    # when
+    response = api_client.post_graphql(CHANNEL_FIELD_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data["id"] == variant_id
+    assert data["channel"] == channel_USD.slug

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -489,7 +489,7 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
 
     @staticmethod
     def resolve_channel(root: ChannelContext[models.Product], _info):
-        return root.channel_slug
+        return str(root.channel_slug) if root.channel_slug else None
 
     @staticmethod
     @load_site_callback
@@ -1139,7 +1139,7 @@ class Product(ChannelContextType[models.Product]):
 
     @staticmethod
     def resolve_channel(root: ChannelContext[models.Product], _info):
-        return root.channel_slug
+        return str(root.channel_slug) if root.channel_slug else None
 
     @staticmethod
     def resolve_default_variant(root: ChannelContext[models.Product], info):


### PR DESCRIPTION
To be backported.

The `channel` field on `Product` and `ProductVariant` returned `root.channel_slug` directly. When no `channel` argument is provided by a requestor without product permissions, the slug is a lazily-evaluated `SimpleLazyObject` (from `get_default_channel_slug_or_graphql_error`). This object leaked into the GraphQL response and broke JSON serialization in `JsonResponse`, raising a 500 (`TypeError: Type is not JSON serializable: SimpleLazyObject`).

Fixes SALEOR-CORE-857.
