### PR TITLE
Add and enable mechanism for limiting number of objects being deleted with bulk mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
   From Saleor 3.24, this app installation with `MANAGE_APPS` permission will be rejected.
   To safely upgrade, ensure that all installed apps do not have this permission.
+- `productBulkDelete` mutation now limits the number of `ids` per call (default 100, configurable via the `PRODUCT_BULK_DELETE_LIMIT` env var). Exceeding the limit returns an `INVALID` error.
 
 ### GraphQL API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
   From Saleor 3.24, this app installation with `MANAGE_APPS` permission will be rejected.
   To safely upgrade, ensure that all installed apps do not have this permission.
-- `productBulkDelete` mutation now limits the number of `ids` per call (default 100, configurable via the `PRODUCT_BULK_DELETE_LIMIT` env var). Exceeding the limit returns an `INVALID` error.
+- Bulk delete mutations now limit the number of `ids` per call (default 100, configurable via the `BULK_DELETE_LIMIT` env var). Exceeding the limit returns an `INVALID` error. This applies to all bulk delete mutations, including `productBulkDelete`, `productVariantBulkDelete`, `categoryBulkDelete`, `collectionBulkDelete`, `productTypeBulkDelete`, `productMediaBulkDelete`, `attributeBulkDelete`, `attributeValueBulkDelete`, `customerBulkDelete`, `staffBulkDelete`, `pageBulkDelete`, `pageTypeBulkDelete`, `menuBulkDelete`, `menuItemBulkDelete`, `giftCardBulkDelete`, `saleBulkDelete`, `voucherBulkDelete`, `promotionBulkDelete`, `shippingPriceBulkDelete`, `shippingZoneBulkDelete`, `draftOrderBulkDelete`, and `draftOrderLinesBulkDelete`.
 
 ### GraphQL API
 

--- a/saleor/graphql/account/bulk_mutations/customer_bulk_delete.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_delete.py
@@ -21,7 +21,7 @@ class UserBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of user IDs to delete. The number of items is limited. "
+                f"List of user IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )

--- a/saleor/graphql/account/bulk_mutations/customer_bulk_delete.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 
 from ....account import models
 from ....permission.enums import AccountPermissions
@@ -17,7 +18,12 @@ from ..types import User
 class UserBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of user IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of user IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -39,6 +45,7 @@ class CustomerBulkDelete(CustomerDeleteMixin, UserBulkDelete):
                 description="A customer account was deleted.",
             )
         ]
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def perform_mutation(cls, root, info: ResolveInfo, /, **data):

--- a/saleor/graphql/account/bulk_mutations/staff_bulk_delete.py
+++ b/saleor/graphql/account/bulk_mutations/staff_bulk_delete.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from ....account import models
@@ -33,11 +34,15 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
                 description="A staff account was deleted.",
             ),
         ]
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, ids, **data
     ):
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
+
         instances = cls.get_nodes_or_error(ids, "id", User)
         errors = cls.clean_instances(info, instances)
         count = len(instances)

--- a/saleor/graphql/account/tests/bulk_mutations/test_staff_bulk_delete.py
+++ b/saleor/graphql/account/tests/bulk_mutations/test_staff_bulk_delete.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import graphene
+from django.conf import settings
 
 from .....account.error_codes import AccountErrorCode
 from .....account.models import Group, User
@@ -46,6 +47,32 @@ def test_delete_staff_members(
         id__in=[user.id for user in [staff_1, staff_2]]
     ).exists()
     assert User.objects.filter(id__in=[user.id for user in users]).count() == len(users)
+
+
+def test_delete_staff_members_exceeding_max_input_size(
+    staff_api_client, user_list, permission_manage_staff
+):
+    # given
+    *_, staff_1, _staff_2 = user_list
+    query = STAFF_BULK_DELETE_MUTATION
+    limit = settings.BULK_DELETE_LIMIT
+    staff_id = graphene.Node.to_global_id("User", staff_1.id)
+    variables = {"ids": [staff_id] * (limit + 1)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_staff]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["staffBulkDelete"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == AccountErrorCode.INVALID.name
+    assert errors[0]["field"] == "ids"
+    assert data["count"] == 0
+    assert User.objects.filter(id=staff_1.id).exists()
 
 
 @patch("saleor.graphql.account.bulk_mutations.staff_bulk_delete.get_webhooks_for_event")

--- a/saleor/graphql/attribute/bulk_mutations.py
+++ b/saleor/graphql/attribute/bulk_mutations.py
@@ -27,7 +27,7 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of attribute IDs to delete. The number of items is limited. "
+                f"List of attribute IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )
@@ -102,7 +102,7 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
             required=True,
             description=(
                 "List of attribute value IDs to delete. The number of items is "
-                "limited. Exceeding the limit returns an `INVALID` error."
+                f"limited to {settings.BULK_DELETE_LIMIT} by default. Exceeding the limit returns an `INVALID` error."
             ),
         )
 

--- a/saleor/graphql/attribute/bulk_mutations.py
+++ b/saleor/graphql/attribute/bulk_mutations.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Exists, OuterRef, Q
 
@@ -23,7 +24,12 @@ from .types import Attribute, AttributeValue
 class AttributeBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of attribute IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of attribute IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -39,6 +45,7 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
                 description="An attribute was deleted.",
             ),
         ]
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
@@ -46,6 +53,8 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
     ):
         if not ids:
             return 0, {}
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
         _, attribute_pks = resolve_global_ids_to_primary_keys(ids, "Attribute")
         product_ids = cls.get_product_ids_to_update(attribute_pks)
         response = super().perform_mutation(root, info, ids=ids)
@@ -91,7 +100,10 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
         ids = NonNullList(
             graphene.ID,
             required=True,
-            description="List of attribute value IDs to delete.",
+            description=(
+                "List of attribute value IDs to delete. The number of items is "
+                "limited. Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -111,6 +123,7 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
                 description="An attribute was updated.",
             ),
         ]
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
@@ -118,6 +131,8 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
     ):
         if not ids:
             return 0, {}
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
         _, attribute_pks = resolve_global_ids_to_primary_keys(ids, "AttributeValue")
         product_ids = cls.get_product_ids_to_update(attribute_pks)
         response = super().perform_mutation(root, info, ids=ids)

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -1075,6 +1075,21 @@ class BaseBulkMutation(BaseMutation):
         raise NotImplementedError
 
     @classmethod
+    def validate_input_size(cls, ids, field="ids") -> ValidationError | None:
+        """Validate that the number of input items does not exceed the limit."""
+        max_input_size = cls._meta.max_input_size
+        if max_input_size is not None and len(ids) > max_input_size:
+            return ValidationError(
+                {
+                    field: ValidationError(
+                        f"The maximum number of items in {field} is {max_input_size}.",
+                        code="invalid",
+                    )
+                }
+            )
+        return None
+
+    @classmethod
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, ids, **data
     ) -> tuple[int, ValidationError | None]:
@@ -1083,16 +1098,8 @@ class BaseBulkMutation(BaseMutation):
         if not ids:
             return 0, None
 
-        if cls._meta.max_input_size is not None and len(ids) > cls._meta.max_input_size:
-            return 0, ValidationError(
-                {
-                    "ids": ValidationError(
-                        f"The maximum number of items in ids is "
-                        f"{cls._meta.max_input_size}.",
-                        code="invalid",
-                    )
-                }
-            )
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
 
         instance_model = cls._meta.model
         model_type = cls.get_type_for_model()
@@ -1158,16 +1165,8 @@ class BaseBulkWithRestrictedChannelAccessMutation(BaseBulkMutation):
         if not ids:
             return 0, None
 
-        if cls._meta.max_input_size is not None and len(ids) > cls._meta.max_input_size:
-            return 0, ValidationError(
-                {
-                    "ids": ValidationError(
-                        f"The maximum number of items in ids is "
-                        f"{cls._meta.max_input_size}.",
-                        code="invalid",
-                    )
-                }
-            )
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
 
         instance_model = cls._meta.model
         model_type = cls.get_type_for_model()

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -134,6 +134,7 @@ class ModelMutationOptions(MutationOptions):
     model = None
     object_type = None
     return_field_name = None
+    max_input_size = None
 
 
 MT = TypeVar("MT", bound=Model)
@@ -1007,7 +1008,7 @@ class BaseBulkMutation(BaseMutation):
 
     @classmethod
     def __init_subclass_with_meta__(  # type: ignore[override]
-        cls, model=None, object_type=None, _meta=None, **kwargs
+        cls, model=None, object_type=None, max_input_size=None, _meta=None, **kwargs
     ):
         if not model:
             raise ImproperlyConfigured("model is required for bulk mutation")
@@ -1016,6 +1017,7 @@ class BaseBulkMutation(BaseMutation):
 
         _meta.model = model
         _meta.object_type = object_type
+        _meta.max_input_size = max_input_size
 
         doc_category_key = f"{model._meta.app_label}.{model.__name__}"
         if "doc_category" not in kwargs and doc_category_key in DOC_CATEGORY_MAP:
@@ -1080,6 +1082,18 @@ class BaseBulkMutation(BaseMutation):
         # Allow to pass empty list for dummy mutation
         if not ids:
             return 0, None
+
+        if cls._meta.max_input_size is not None and len(ids) > cls._meta.max_input_size:
+            return 0, ValidationError(
+                {
+                    "ids": ValidationError(
+                        f"The maximum number of items in ids is "
+                        f"{cls._meta.max_input_size}.",
+                        code="invalid",
+                    )
+                }
+            )
+
         instance_model = cls._meta.model
         model_type = cls.get_type_for_model()
         if not model_type:
@@ -1143,6 +1157,18 @@ class BaseBulkWithRestrictedChannelAccessMutation(BaseBulkMutation):
         # Allow to pass empty list for dummy mutation
         if not ids:
             return 0, None
+
+        if cls._meta.max_input_size is not None and len(ids) > cls._meta.max_input_size:
+            return 0, ValidationError(
+                {
+                    "ids": ValidationError(
+                        f"The maximum number of items in ids is "
+                        f"{cls._meta.max_input_size}.",
+                        code="invalid",
+                    )
+                }
+            )
+
         instance_model = cls._meta.model
         model_type = cls.get_type_for_model()
         if not model_type:

--- a/saleor/graphql/discount/mutations/bulk_mutations.py
+++ b/saleor/graphql/discount/mutations/bulk_mutations.py
@@ -34,7 +34,7 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of sale IDs to delete. The number of items is limited. "
+                f"List of sale IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )
@@ -156,7 +156,7 @@ class VoucherBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of voucher IDs to delete. The number of items is limited. "
+                f"List of voucher IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )

--- a/saleor/graphql/discount/mutations/bulk_mutations.py
+++ b/saleor/graphql/discount/mutations/bulk_mutations.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import OuterRef, Subquery
@@ -30,7 +31,12 @@ from ..utils import convert_migrated_sale_predicate_to_catalogue_info
 class SaleBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of sale IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of sale IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -48,12 +54,16 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
                 description="A sale was deleted.",
             )
         ]
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, ids, **data
     ) -> tuple[int, ValidationError | None]:
         """Perform a mutation that deletes a list of model instances."""
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
+
         try:
             instances = cls.get_promotion_instances(ids)
         except ValidationError as error:
@@ -143,7 +153,12 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
 class VoucherBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of voucher IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of voucher IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -159,6 +174,7 @@ class VoucherBulkDelete(ModelBulkDeleteMutation):
                 description="A voucher was deleted.",
             )
         ]
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):

--- a/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
@@ -25,7 +25,7 @@ class PromotionBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of promotion IDs to delete. The number of items is limited. "
+                f"List of promotion IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )

--- a/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 from django.db.models import Exists, OuterRef, QuerySet
 
 from .....discount import models
@@ -21,7 +22,12 @@ from ...types import Promotion
 class PromotionBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of promotion IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of promotion IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -37,6 +43,7 @@ class PromotionBulkDelete(ModelBulkDeleteMutation):
                 description="A promotion was deleted.",
             )
         ]
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):

--- a/saleor/graphql/discount/tests/mutations/test_sale_bulk_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_bulk_delete.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import graphene
+from django.conf import settings
 
 from .....discount.error_codes import DiscountErrorCode
 from .....discount.models import Promotion, PromotionRule
@@ -18,6 +19,34 @@ SALE_BULK_DELETE_MUTATION = """
         }
     }
     """
+
+
+def test_delete_sales_exceeding_max_input_size(
+    staff_api_client,
+    promotion_converted_from_sale,
+    permission_manage_discounts,
+):
+    # given
+    sale = promotion_converted_from_sale
+    query = SALE_BULK_DELETE_MUTATION
+    limit = settings.BULK_DELETE_LIMIT
+    sale_id = graphene.Node.to_global_id("Sale", sale.old_sale_id)
+    variables = {"ids": [sale_id] * (limit + 1)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["saleBulkDelete"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == DiscountErrorCode.INVALID.name
+    assert errors[0]["field"] == "ids"
+    assert data["count"] == 0
+    assert Promotion.objects.filter(id=sale.id).exists()
 
 
 @mock.patch("saleor.graphql.discount.mutations.bulk_mutations.get_webhooks_for_event")

--- a/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_delete.py
+++ b/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 
 from ....giftcard import models
 from ....permission.enums import GiftcardPermissions
@@ -15,7 +16,12 @@ from ..types import GiftCard
 class GiftCardBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of gift card IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of gift card IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -30,6 +36,7 @@ class GiftCardBulkDelete(ModelBulkDeleteMutation):
                 description="A gift card was deleted.",
             )
         ]
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):

--- a/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_delete.py
+++ b/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_delete.py
@@ -19,7 +19,7 @@ class GiftCardBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of gift card IDs to delete. The number of items is limited. "
+                f"List of gift card IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )

--- a/saleor/graphql/menu/bulk_mutations/menu_bulk_delete.py
+++ b/saleor/graphql/menu/bulk_mutations/menu_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 
 from ....menu import models
 from ....permission.enums import MenuPermissions
@@ -15,7 +16,12 @@ from ..types import Menu
 class MenuBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of menu IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of menu IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -31,6 +37,7 @@ class MenuBulkDelete(ModelBulkDeleteMutation):
                 description="A menu was deleted.",
             ),
         ]
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):

--- a/saleor/graphql/menu/bulk_mutations/menu_bulk_delete.py
+++ b/saleor/graphql/menu/bulk_mutations/menu_bulk_delete.py
@@ -19,7 +19,7 @@ class MenuBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of menu IDs to delete. The number of items is limited. "
+                f"List of menu IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )

--- a/saleor/graphql/menu/bulk_mutations/menu_item_bulk_delete.py
+++ b/saleor/graphql/menu/bulk_mutations/menu_item_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 
 from ....menu import models
 from ....permission.enums import MenuPermissions
@@ -15,7 +16,12 @@ from ..types import MenuItem
 class MenuItemBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of menu item IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of menu item IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -31,6 +37,7 @@ class MenuItemBulkDelete(ModelBulkDeleteMutation):
                 description="A menu item was deleted.",
             ),
         ]
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):

--- a/saleor/graphql/menu/bulk_mutations/menu_item_bulk_delete.py
+++ b/saleor/graphql/menu/bulk_mutations/menu_item_bulk_delete.py
@@ -19,7 +19,7 @@ class MenuItemBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of menu item IDs to delete. The number of items is limited. "
+                f"List of menu item IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )

--- a/saleor/graphql/order/bulk_mutations/draft_orders.py
+++ b/saleor/graphql/order/bulk_mutations/draft_orders.py
@@ -29,7 +29,7 @@ class DraftOrderBulkDelete(
             graphene.ID,
             required=True,
             description=(
-                "List of draft order IDs to delete. The number of items is limited. "
+                f"List of draft order IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )
@@ -166,7 +166,7 @@ class DraftOrderLinesBulkDelete(
             graphene.ID,
             required=True,
             description=(
-                "List of order lines IDs to delete. The number of items is limited. "
+                f"List of order lines IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )

--- a/saleor/graphql/order/bulk_mutations/draft_orders.py
+++ b/saleor/graphql/order/bulk_mutations/draft_orders.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 from uuid import UUID
 
 import graphene
+from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from ....channel import models as channel_models
@@ -25,7 +26,12 @@ class DraftOrderBulkDelete(
 ):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of draft order IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of draft order IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -35,6 +41,7 @@ class DraftOrderBulkDelete(
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def get_ids_with_related_objects(cls, ids, /):
@@ -124,6 +131,10 @@ class DraftOrderBulkDelete(
         """Perform a mutation that deletes a list of model instances."""
         if not ids:
             return 0, None
+
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
+
         try:
             instances = cls.get_nodes_or_error(ids, "id", Order, schema=info.schema)
         except ValidationError as error:
@@ -152,7 +163,12 @@ class DraftOrderLinesBulkDelete(
 ):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of order lines IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of order lines IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -162,6 +178,7 @@ class DraftOrderLinesBulkDelete(
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def clean_instance(cls, _info: ResolveInfo, instance):

--- a/saleor/graphql/order/tests/mutations/test_draft_order_bulk_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 
 from .....discount.models import VoucherCode
 from .....order import OrderStatus
@@ -45,6 +46,36 @@ def test_delete_draft_orders(
     assert order_models.Order.objects.filter(
         id__in=[order.id for order in orders]
     ).count() == len(orders)
+
+
+def test_delete_draft_orders_exceeding_max_input_size(
+    staff_api_client, order_list, permission_group_manage_orders
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order_1, order_2, *_ = order_list
+    order_1.status = OrderStatus.DRAFT
+    order_2.status = OrderStatus.DRAFT
+    order_1.save()
+    order_2.save()
+
+    query = DRAFT_ORDER_BULK_DELETE
+    limit = settings.BULK_DELETE_LIMIT
+    order_id = graphene.Node.to_global_id("Order", order_1.id)
+    variables = {"ids": [order_id] * (limit + 1)}
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderBulkDelete"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == OrderErrorCode.INVALID.name
+    assert errors[0]["field"] == "ids"
+    assert data["count"] == 0
+    assert order_models.Order.objects.filter(id=order_1.id).exists()
 
 
 def test_delete_draft_orders_by_user_no_channel_access(

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -29,7 +29,7 @@ class PageBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of page IDs to delete. The number of items is limited. "
+                f"List of page IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )
@@ -127,7 +127,7 @@ class PageTypeBulkDelete(ModelBulkDeleteMutation):
         ids = NonNullList(
             graphene.ID,
             description=(
-                "List of page type IDs to delete. The number of items is limited. "
+                f"List of page type IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
             required=True,

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Exists, OuterRef
@@ -25,7 +26,12 @@ from .types import Page, PageType
 class PageBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of page IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of page IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -35,12 +41,15 @@ class PageBulkDelete(ModelBulkDeleteMutation):
         permissions = (PagePermissions.MANAGE_PAGES,)
         error_type_class = PageError
         error_type_field = "page_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     @traced_atomic_transaction()
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, ids
     ):
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
         try:
             pks = cls.get_global_ids_or_error(ids, only_type=Page, field="pk")
         except ValidationError as error:
@@ -117,7 +126,10 @@ class PageTypeBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
             graphene.ID,
-            description="List of page type IDs to delete",
+            description=(
+                "List of page type IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
             required=True,
         )
 
@@ -128,12 +140,15 @@ class PageTypeBulkDelete(ModelBulkDeleteMutation):
         permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
         error_type_class = PageError
         error_type_field = "page_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     @traced_atomic_transaction()
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, ids
     ):
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
         try:
             pks = cls.get_global_ids_or_error(ids, only_type=PageType, field="pk")
         except ValidationError as error:

--- a/saleor/graphql/product/bulk_mutations/category_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/category_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 
 from ....permission.enums import ProductPermissions
 from ....product import models
@@ -12,7 +13,12 @@ from ..types import Category
 class CategoryBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of category IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of category IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -22,6 +28,7 @@ class CategoryBulkDelete(ModelBulkDeleteMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = ProductError
         error_type_field = "product_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def bulk_action(cls, info, queryset):

--- a/saleor/graphql/product/bulk_mutations/category_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/category_bulk_delete.py
@@ -16,7 +16,7 @@ class CategoryBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of category IDs to delete. The number of items is limited. "
+                f"List of category IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )

--- a/saleor/graphql/product/bulk_mutations/collection_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/collection_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 from django.db.models import Exists, OuterRef
 
 from ....discount.utils.promotion import mark_active_catalogue_promotion_rules_as_dirty
@@ -16,7 +17,12 @@ from ..types import Collection
 class CollectionBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of collection IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of collection IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -26,6 +32,7 @@ class CollectionBulkDelete(ModelBulkDeleteMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = CollectionError
         error_type_field = "collection_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def bulk_action(cls, info, queryset):

--- a/saleor/graphql/product/bulk_mutations/collection_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/collection_bulk_delete.py
@@ -20,7 +20,7 @@ class CollectionBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of collection IDs to delete. The number of items is limited. "
+                f"List of collection IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )

--- a/saleor/graphql/product/bulk_mutations/product_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_delete.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 import graphene
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models.expressions import Exists, OuterRef
@@ -27,7 +28,12 @@ from ..utils import get_draft_order_lines_data_for_variants
 class ProductBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
-            graphene.ID, required=True, description="List of product IDs to delete."
+            graphene.ID,
+            required=True,
+            description=(
+                "List of product IDs to delete. The number of items is limited. "
+                "Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -37,6 +43,7 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = ProductError
         error_type_field = "product_errors"
+        max_input_size = settings.PRODUCT_BULK_DELETE_LIMIT
 
     @classmethod
     @traced_atomic_transaction()

--- a/saleor/graphql/product/bulk_mutations/product_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_delete.py
@@ -31,7 +31,7 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
             graphene.ID,
             required=True,
             description=(
-                "List of product IDs to delete. The number of items is limited. "
+                f"List of product IDs to delete. The number of items is limited to {settings.BULK_DELETE_LIMIT} by default. "
                 "Exceeding the limit returns an `INVALID` error."
             ),
         )

--- a/saleor/graphql/product/bulk_mutations/product_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_delete.py
@@ -43,13 +43,15 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = ProductError
         error_type_field = "product_errors"
-        max_input_size = settings.PRODUCT_BULK_DELETE_LIMIT
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     @traced_atomic_transaction()
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, ids
     ):
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
         try:
             pks = cls.get_global_ids_or_error(ids, Product)
         except ValidationError as error:

--- a/saleor/graphql/product/bulk_mutations/product_media_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_media_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 
 from ....permission.enums import ProductPermissions
 from ....product import models
@@ -12,7 +13,10 @@ class ProductMediaBulkDelete(ModelBulkDeleteMutation):
         ids = NonNullList(
             graphene.ID,
             required=True,
-            description="List of product media IDs to delete.",
+            description=(
+                "List of product media IDs to delete. The number of items is "
+                "limited. Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -22,3 +26,4 @@ class ProductMediaBulkDelete(ModelBulkDeleteMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = ProductError
         error_type_field = "product_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT

--- a/saleor/graphql/product/bulk_mutations/product_media_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_media_bulk_delete.py
@@ -15,7 +15,7 @@ class ProductMediaBulkDelete(ModelBulkDeleteMutation):
             required=True,
             description=(
                 "List of product media IDs to delete. The number of items is "
-                "limited. Exceeding the limit returns an `INVALID` error."
+                f"limited to {settings.BULK_DELETE_LIMIT} by default. Exceeding the limit returns an `INVALID` error."
             ),
         )
 

--- a/saleor/graphql/product/bulk_mutations/product_type_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_type_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.db.models.expressions import Exists, OuterRef
@@ -19,7 +20,10 @@ class ProductTypeBulkDelete(ModelBulkDeleteMutation):
         ids = NonNullList(
             graphene.ID,
             required=True,
-            description="List of product type IDs to delete.",
+            description=(
+                "List of product type IDs to delete. The number of items is "
+                "limited. Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -29,12 +33,15 @@ class ProductTypeBulkDelete(ModelBulkDeleteMutation):
         permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
         error_type_class = ProductError
         error_type_field = "product_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     @traced_atomic_transaction()
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, ids
     ):
+        if size_error := cls.validate_input_size(ids):
+            return 0, size_error
         try:
             pks = cls.get_global_ids_or_error(ids, ProductType)
         except ValidationError as error:

--- a/saleor/graphql/product/bulk_mutations/product_type_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_type_bulk_delete.py
@@ -22,7 +22,7 @@ class ProductTypeBulkDelete(ModelBulkDeleteMutation):
             required=True,
             description=(
                 "List of product type IDs to delete. The number of items is "
-                "limited. Exceeding the limit returns an `INVALID` error."
+                f"limited to {settings.BULK_DELETE_LIMIT} by default. Exceeding the limit returns an `INVALID` error."
             ),
         )
 

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 
 import graphene
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Exists, OuterRef, Subquery
@@ -35,12 +36,18 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
         ids = NonNullList(
             graphene.ID,
             required=False,
-            description="List of product variant IDs to delete.",
+            description=(
+                "List of product variant IDs to delete. The number of items is "
+                "limited. Exceeding the limit returns an `INVALID` error."
+            ),
         )
         skus = NonNullList(
             graphene.String,
             required=False,
-            description="List of product variant SKUs to delete.",
+            description=(
+                "List of product variant SKUs to delete. The number of items is "
+                "limited. Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -50,6 +57,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = ProductError
         error_type_field = "product_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def post_save_actions(cls, info, variants):
@@ -73,6 +81,10 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
     @traced_atomic_transaction()
     def perform_mutation(cls, _root, info: ResolveInfo, /, ids=None, skus=None, **data):
         validate_one_of_args_is_in_mutation("skus", skus, "ids", ids)
+
+        size_field = "ids" if ids else "skus"
+        if size_error := cls.validate_input_size(ids or skus or [], field=size_field):
+            return 0, size_error
 
         if ids:
             try:

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
@@ -38,7 +38,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
             required=False,
             description=(
                 "List of product variant IDs to delete. The number of items is "
-                "limited. Exceeding the limit returns an `INVALID` error."
+                f"limited to {settings.BULK_DELETE_LIMIT} by default. Exceeding the limit returns an `INVALID` error."
             ),
         )
         skus = NonNullList(
@@ -46,7 +46,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
             required=False,
             description=(
                 "List of product variant SKUs to delete. The number of items is "
-                "limited. Exceeding the limit returns an `INVALID` error."
+                f"limited to {settings.BULK_DELETE_LIMIT} by default. Exceeding the limit returns an `INVALID` error."
             ),
         )
 

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -29,6 +29,7 @@ from ....product.models import (
 )
 from ....thumbnail.models import Thumbnail
 from ...tests.utils import get_graphql_content
+from ..bulk_mutations.product_bulk_delete import ProductBulkDelete
 
 MUTATION_CATEGORY_BULK_DELETE = """
     mutation categoryBulkDelete($ids: [ID!]!) {
@@ -576,6 +577,31 @@ def test_delete_products_invalid_object_typed_of_given_ids(
     assert errors[0]["code"] == ProductErrorCode.GRAPHQL_ERROR.name
     assert errors[0]["field"] == "ids"
     assert data["count"] == 0
+
+
+def test_delete_products_exceeding_max_input_size(
+    staff_api_client, product, permission_manage_products
+):
+    # given
+    query = DELETE_PRODUCTS_MUTATION
+    limit = ProductBulkDelete._meta.max_input_size
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    variables = {"ids": [product_id] * (limit + 1)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["productBulkDelete"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == ProductErrorCode.INVALID.name
+    assert errors[0]["field"] == "ids"
+    assert data["count"] == 0
+    assert Product.objects.filter(id=product.id).exists()
 
 
 @patch("saleor.product.signals.delete_from_storage_task.delay")

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -30,6 +30,7 @@ from ....product.models import (
 from ....thumbnail.models import Thumbnail
 from ...tests.utils import get_graphql_content
 from ..bulk_mutations.product_bulk_delete import ProductBulkDelete
+from ..bulk_mutations.product_variant_bulk_delete import ProductVariantBulkDelete
 
 MUTATION_CATEGORY_BULK_DELETE = """
     mutation categoryBulkDelete($ids: [ID!]!) {
@@ -1073,6 +1074,30 @@ def test_delete_product_variants_by_sku_task_for_recalculate_product_prices_call
     mocked_recalculate_orders_task.assert_not_called()
     for rule in get_active_catalogue_promotion_rules():
         assert rule.variants_dirty
+
+
+def test_delete_product_variants_by_sku_exceeding_max_input_size(
+    staff_api_client, variant, permission_manage_products
+):
+    # given
+    query = PRODUCT_VARIANT_BULK_DELETE_BY_SKU_MUTATION
+    limit = ProductVariantBulkDelete._meta.max_input_size
+    variables = {"skus": [variant.sku] * (limit + 1)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkDelete"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == ProductErrorCode.INVALID.name
+    assert errors[0]["field"] == "skus"
+    assert data["count"] == 0
+    assert ProductVariant.objects.filter(id=variant.id).exists()
 
 
 PRODUCT_VARIANT_BULK_DELETE_MUTATION = """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17860,7 +17860,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingPriceBulkDelete(
-    """List of shipping price IDs to delete."""
+    """
+    List of shipping price IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): ShippingPriceBulkDelete @doc(category: "Shipping")
 
@@ -17945,7 +17947,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_SHIPPING.
   """
   shippingZoneBulkDelete(
-    """List of shipping zone IDs to delete."""
+    """
+    List of shipping zone IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): ShippingZoneBulkDelete @doc(category: "Shipping")
 
@@ -18032,7 +18036,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   categoryBulkDelete(
-    """List of category IDs to delete."""
+    """
+    List of category IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): CategoryBulkDelete @doc(category: "Products")
 
@@ -18117,7 +18123,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   collectionBulkDelete(
-    """List of collection IDs to delete."""
+    """
+    List of collection IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): CollectionBulkDelete @doc(category: "Products")
 
@@ -18325,7 +18333,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productMediaBulkDelete(
-    """List of product media IDs to delete."""
+    """
+    List of product media IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): ProductMediaBulkDelete @doc(category: "Products")
 
@@ -18381,7 +18391,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   productTypeBulkDelete(
-    """List of product type IDs to delete."""
+    """
+    List of product type IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): ProductTypeBulkDelete @doc(category: "Products")
 
@@ -18494,10 +18506,14 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantBulkDelete(
-    """List of product variant IDs to delete."""
+    """
+    List of product variant IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]
 
-    """List of product variant SKUs to delete."""
+    """
+    List of product variant SKUs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     skus: [String!]
   ): ProductVariantBulkDelete @doc(category: "Products")
 
@@ -19108,7 +19124,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PAGES.
   """
   pageBulkDelete(
-    """List of page IDs to delete."""
+    """
+    List of page IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): PageBulkDelete @doc(category: "Pages")
 
@@ -19193,7 +19211,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
   pageTypeBulkDelete(
-    """List of page type IDs to delete"""
+    """
+    List of page type IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): PageTypeBulkDelete @doc(category: "Pages")
 
@@ -19291,7 +19311,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   draftOrderBulkDelete(
-    """List of draft order IDs to delete."""
+    """
+    List of draft order IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): DraftOrderBulkDelete @doc(category: "Orders")
 
@@ -19301,7 +19323,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_ORDERS.
   """
   draftOrderLinesBulkDelete(
-    """List of order lines IDs to delete."""
+    """
+    List of order lines IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): DraftOrderLinesBulkDelete @doc(category: "Orders") @deprecated
 
@@ -19796,7 +19820,9 @@ type Mutation {
   - MENU_DELETED (async): A menu was deleted.
   """
   menuBulkDelete(
-    """List of menu IDs to delete."""
+    """
+    List of menu IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): MenuBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_DELETED], syncEvents: [])
 
@@ -19853,7 +19879,9 @@ type Mutation {
   - MENU_ITEM_DELETED (async): A menu item was deleted.
   """
   menuItemBulkDelete(
-    """List of menu item IDs to delete."""
+    """
+    List of menu item IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): MenuItemBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_DELETED], syncEvents: [])
 
@@ -20107,7 +20135,9 @@ type Mutation {
   - GIFT_CARD_DELETED (async): A gift card was deleted.
   """
   giftCardBulkDelete(
-    """List of gift card IDs to delete."""
+    """
+    List of gift card IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): GiftCardBulkDelete @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [GIFT_CARD_DELETED], syncEvents: [])
 
@@ -20297,7 +20327,9 @@ type Mutation {
   - PROMOTION_DELETED (async): A promotion was deleted.
   """
   promotionBulkDelete(
-    """List of promotion IDs to delete."""
+    """
+    List of promotion IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): PromotionBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [PROMOTION_DELETED], syncEvents: [])
 
@@ -20336,7 +20368,9 @@ type Mutation {
   - SALE_DELETED (async): A sale was deleted.
   """
   saleBulkDelete(
-    """List of sale IDs to delete."""
+    """
+    List of sale IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): SaleBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [SALE_DELETED], syncEvents: [])
 
@@ -20454,7 +20488,9 @@ type Mutation {
   - VOUCHER_DELETED (async): A voucher was deleted.
   """
   voucherBulkDelete(
-    """List of voucher IDs to delete."""
+    """
+    List of voucher IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): VoucherBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_DELETED], syncEvents: [])
 
@@ -21270,7 +21306,9 @@ type Mutation {
   - ATTRIBUTE_DELETED (async): An attribute was deleted.
   """
   attributeBulkDelete(
-    """List of attribute IDs to delete."""
+    """
+    List of attribute IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): AttributeBulkDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_DELETED], syncEvents: [])
 
@@ -21284,7 +21322,9 @@ type Mutation {
   - ATTRIBUTE_UPDATED (async): An attribute was updated.
   """
   attributeValueBulkDelete(
-    """List of attribute value IDs to delete."""
+    """
+    List of attribute value IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): AttributeValueBulkDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_VALUE_DELETED, ATTRIBUTE_UPDATED], syncEvents: [])
 
@@ -22035,7 +22075,9 @@ type Mutation {
   - CUSTOMER_DELETED (async): A customer account was deleted.
   """
   customerBulkDelete(
-    """List of user IDs to delete."""
+    """
+    List of user IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): CustomerBulkDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_DELETED], syncEvents: [])
 
@@ -22109,7 +22151,9 @@ type Mutation {
   - STAFF_DELETED (async): A staff account was deleted.
   """
   staffBulkDelete(
-    """List of user IDs to delete."""
+    """
+    List of user IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): StaffBulkDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [STAFF_DELETED], syncEvents: [])
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17861,7 +17861,7 @@ type Mutation {
   """
   shippingPriceBulkDelete(
     """
-    List of shipping price IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of shipping price IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): ShippingPriceBulkDelete @doc(category: "Shipping")
@@ -17948,7 +17948,7 @@ type Mutation {
   """
   shippingZoneBulkDelete(
     """
-    List of shipping zone IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of shipping zone IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): ShippingZoneBulkDelete @doc(category: "Shipping")
@@ -18037,7 +18037,7 @@ type Mutation {
   """
   categoryBulkDelete(
     """
-    List of category IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of category IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): CategoryBulkDelete @doc(category: "Products")
@@ -18124,7 +18124,7 @@ type Mutation {
   """
   collectionBulkDelete(
     """
-    List of collection IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of collection IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): CollectionBulkDelete @doc(category: "Products")
@@ -18227,7 +18227,7 @@ type Mutation {
   """
   productBulkDelete(
     """
-    List of product IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of product IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): ProductBulkDelete @doc(category: "Products")
@@ -18334,7 +18334,7 @@ type Mutation {
   """
   productMediaBulkDelete(
     """
-    List of product media IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of product media IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): ProductMediaBulkDelete @doc(category: "Products")
@@ -18392,7 +18392,7 @@ type Mutation {
   """
   productTypeBulkDelete(
     """
-    List of product type IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of product type IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): ProductTypeBulkDelete @doc(category: "Products")
@@ -18507,12 +18507,12 @@ type Mutation {
   """
   productVariantBulkDelete(
     """
-    List of product variant IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of product variant IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]
 
     """
-    List of product variant SKUs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of product variant SKUs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     skus: [String!]
   ): ProductVariantBulkDelete @doc(category: "Products")
@@ -19125,7 +19125,7 @@ type Mutation {
   """
   pageBulkDelete(
     """
-    List of page IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of page IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): PageBulkDelete @doc(category: "Pages")
@@ -19212,7 +19212,7 @@ type Mutation {
   """
   pageTypeBulkDelete(
     """
-    List of page type IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of page type IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): PageTypeBulkDelete @doc(category: "Pages")
@@ -19312,7 +19312,7 @@ type Mutation {
   """
   draftOrderBulkDelete(
     """
-    List of draft order IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of draft order IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): DraftOrderBulkDelete @doc(category: "Orders")
@@ -19324,7 +19324,7 @@ type Mutation {
   """
   draftOrderLinesBulkDelete(
     """
-    List of order lines IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of order lines IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): DraftOrderLinesBulkDelete @doc(category: "Orders") @deprecated
@@ -19821,7 +19821,7 @@ type Mutation {
   """
   menuBulkDelete(
     """
-    List of menu IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of menu IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): MenuBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_DELETED], syncEvents: [])
@@ -19880,7 +19880,7 @@ type Mutation {
   """
   menuItemBulkDelete(
     """
-    List of menu item IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of menu item IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): MenuItemBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_DELETED], syncEvents: [])
@@ -20136,7 +20136,7 @@ type Mutation {
   """
   giftCardBulkDelete(
     """
-    List of gift card IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of gift card IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): GiftCardBulkDelete @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [GIFT_CARD_DELETED], syncEvents: [])
@@ -20328,7 +20328,7 @@ type Mutation {
   """
   promotionBulkDelete(
     """
-    List of promotion IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of promotion IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): PromotionBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [PROMOTION_DELETED], syncEvents: [])
@@ -20369,7 +20369,7 @@ type Mutation {
   """
   saleBulkDelete(
     """
-    List of sale IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of sale IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): SaleBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [SALE_DELETED], syncEvents: [])
@@ -20489,7 +20489,7 @@ type Mutation {
   """
   voucherBulkDelete(
     """
-    List of voucher IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of voucher IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): VoucherBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_DELETED], syncEvents: [])
@@ -21307,7 +21307,7 @@ type Mutation {
   """
   attributeBulkDelete(
     """
-    List of attribute IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of attribute IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): AttributeBulkDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_DELETED], syncEvents: [])
@@ -21323,7 +21323,7 @@ type Mutation {
   """
   attributeValueBulkDelete(
     """
-    List of attribute value IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of attribute value IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): AttributeValueBulkDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_VALUE_DELETED, ATTRIBUTE_UPDATED], syncEvents: [])
@@ -22076,7 +22076,7 @@ type Mutation {
   """
   customerBulkDelete(
     """
-    List of user IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of user IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): CustomerBulkDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_DELETED], syncEvents: [])
@@ -22152,7 +22152,7 @@ type Mutation {
   """
   staffBulkDelete(
     """
-    List of user IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    List of user IDs to delete. The number of items is limited to 100 by default. Exceeding the limit returns an `INVALID` error.
     """
     ids: [ID!]!
   ): StaffBulkDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [STAFF_DELETED], syncEvents: [])

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -18218,7 +18218,9 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productBulkDelete(
-    """List of product IDs to delete."""
+    """
+    List of product IDs to delete. The number of items is limited. Exceeding the limit returns an `INVALID` error.
+    """
     ids: [ID!]!
   ): ProductBulkDelete @doc(category: "Products")
 

--- a/saleor/graphql/shipping/bulk_mutations/shipping_price_bulk_delete.py
+++ b/saleor/graphql/shipping/bulk_mutations/shipping_price_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 
 from ....permission.enums import ShippingPermissions
 from ....shipping import models
@@ -16,7 +17,10 @@ class ShippingPriceBulkDelete(ModelBulkDeleteMutation):
         ids = NonNullList(
             graphene.ID,
             required=True,
-            description="List of shipping price IDs to delete.",
+            description=(
+                "List of shipping price IDs to delete. The number of items is "
+                "limited. Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -26,6 +30,7 @@ class ShippingPriceBulkDelete(ModelBulkDeleteMutation):
         permissions = (ShippingPermissions.MANAGE_SHIPPING,)
         error_type_class = ShippingError
         error_type_field = "shipping_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def get_nodes_or_error(

--- a/saleor/graphql/shipping/bulk_mutations/shipping_price_bulk_delete.py
+++ b/saleor/graphql/shipping/bulk_mutations/shipping_price_bulk_delete.py
@@ -19,7 +19,7 @@ class ShippingPriceBulkDelete(ModelBulkDeleteMutation):
             required=True,
             description=(
                 "List of shipping price IDs to delete. The number of items is "
-                "limited. Exceeding the limit returns an `INVALID` error."
+                f"limited to {settings.BULK_DELETE_LIMIT} by default. Exceeding the limit returns an `INVALID` error."
             ),
         )
 

--- a/saleor/graphql/shipping/bulk_mutations/shipping_zone_bulk_delete.py
+++ b/saleor/graphql/shipping/bulk_mutations/shipping_zone_bulk_delete.py
@@ -19,7 +19,7 @@ class ShippingZoneBulkDelete(ModelBulkDeleteMutation):
             required=True,
             description=(
                 "List of shipping zone IDs to delete. The number of items is "
-                "limited. Exceeding the limit returns an `INVALID` error."
+                f"limited to {settings.BULK_DELETE_LIMIT} by default. Exceeding the limit returns an `INVALID` error."
             ),
         )
 

--- a/saleor/graphql/shipping/bulk_mutations/shipping_zone_bulk_delete.py
+++ b/saleor/graphql/shipping/bulk_mutations/shipping_zone_bulk_delete.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 
 from ....permission.enums import ShippingPermissions
 from ....shipping import models
@@ -16,7 +17,10 @@ class ShippingZoneBulkDelete(ModelBulkDeleteMutation):
         ids = NonNullList(
             graphene.ID,
             required=True,
-            description="List of shipping zone IDs to delete.",
+            description=(
+                "List of shipping zone IDs to delete. The number of items is "
+                "limited. Exceeding the limit returns an `INVALID` error."
+            ),
         )
 
     class Meta:
@@ -26,6 +30,7 @@ class ShippingZoneBulkDelete(ModelBulkDeleteMutation):
         permissions = (ShippingPermissions.MANAGE_SHIPPING,)
         error_type_class = ShippingError
         error_type_field = "shipping_errors"
+        max_input_size = settings.BULK_DELETE_LIMIT
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -884,6 +884,9 @@ GRAPHQL_MUTATION_COUNT_LIMIT: int = int(
     os.environ.get("GRAPHQL_MUTATION_COUNT_LIMIT", 4)
 )
 
+# Maximum number of product IDs accepted by the productBulkDelete mutation
+PRODUCT_BULK_DELETE_LIMIT: int = int(os.environ.get("PRODUCT_BULK_DELETE_LIMIT", 100))
+
 # Set GRAPHQL_QUERY_MAX_COMPLEXITY=0 in env to disable (not recommended)
 GRAPHQL_QUERY_MAX_COMPLEXITY = int(
     os.environ.get("GRAPHQL_QUERY_MAX_COMPLEXITY", 50000)

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -884,8 +884,8 @@ GRAPHQL_MUTATION_COUNT_LIMIT: int = int(
     os.environ.get("GRAPHQL_MUTATION_COUNT_LIMIT", 4)
 )
 
-# Maximum number of product IDs accepted by the productBulkDelete mutation
-PRODUCT_BULK_DELETE_LIMIT: int = int(os.environ.get("PRODUCT_BULK_DELETE_LIMIT", 100))
+# Maximum number of IDs accepted by a single bulk delete mutation call
+BULK_DELETE_LIMIT: int = int(os.environ.get("BULK_DELETE_LIMIT", 100))
 
 # Set GRAPHQL_QUERY_MAX_COMPLEXITY=0 in env to disable (not recommended)
 GRAPHQL_QUERY_MAX_COMPLEXITY = int(


### PR DESCRIPTION
> [!WARNING]
> This has to be documented in the docs as breaking change (https://github.com/saleor/saleor-docs/pull/1794).
> This will not be back-ported to already released versions.

It gives Saleor a chance not to run into issues like SALEOR-CORE-858 where removing large number of products may cause database statement timeout error. In these cases the timeout is caused by vast number of related objects related to products being deleted (which are either deleted too or their relationship to deleted products is set to `NULL`).

~~The mechanism is common for all bulk delete mutations but it's only enabled for this one mutation. My intention is to gradually enabled that if and when we see any performance related issues with the other mutations.~~