### PR TITLE
Fix KeyError when resolving channel for channel-agnostic account events

### DIFF
--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -185,8 +185,13 @@ class AccountOperationBase(AbstractType):
     @staticmethod
     def resolve_channel(root, info: ResolveInfo):
         _, data = root
-        return Channel.objects.using(get_database_connection_name(info.context)).get(
-            slug=data["channel_slug"]
+        channel_slug = data.get("channel_slug")
+        if not channel_slug:
+            return None
+        return (
+            Channel.objects.using(get_database_connection_name(info.context))
+            .filter(slug=channel_slug)
+            .first()
         )
 
     @staticmethod

--- a/saleor/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -55,6 +55,29 @@ ACCOUNT_CONFIRMED = (
 """
 )
 
+ACCOUNT_CONFIRMED_WITH_CHANNEL = (
+    fragments.CUSTOMER_DETAILS
+    + fragments.RECIPIENT_APP_DETAILS
+    + """
+    subscription{
+      event{
+        recipient{
+          ...Recipient
+        }
+        ...on AccountConfirmed{
+          user{
+            ...CustomerDetails
+          }
+          channel{
+            slug
+            id
+          }
+        }
+      }
+    }
+"""
+)
+
 
 ACCOUNT_CHANGE_EMAIL_REQUESTED = (
     fragments.CUSTOMER_DETAILS

--- a/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -148,6 +148,30 @@ def test_account_confirmed(customer_user, subscription_account_confirmed_webhook
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_account_confirmed_query_channel_without_channel_slug_in_payload(
+    customer_user, subscription_webhook
+):
+    # given
+    webhook = subscription_webhook(
+        subscription_queries.ACCOUNT_CONFIRMED_WITH_CHANNEL,
+        WebhookEventAsyncType.ACCOUNT_CONFIRMED,
+    )
+    webhooks = [webhook]
+    event_type = WebhookEventAsyncType.ACCOUNT_CONFIRMED
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, {"user": customer_user}, webhooks
+    )
+
+    # then
+    payload = json.loads(deliveries[0].payload.get_payload())
+    assert "errors" not in payload
+    assert payload["channel"] is None
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
 def test_account_change_email_requested(
     customer_user, channel_USD, subscription_account_change_email_requested_webhook
 ):


### PR DESCRIPTION
To be back-ported.

The `channel` field on `AccountOperationBase` resolved `data["channel_slug"]`
unconditionally, but completed-action events (AccountConfirmed,
AccountEmailChanged, AccountDeleted) are dispatched without a channel_slug,
raising KeyError when a subscription query selected `channel`.

Resolve `channel` to null when no channel slug is present.

Fixes SALEOR-CORE-5A8