### PR TITLE
Fix missing validation for weight values in WeightScalar

### DIFF
--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -96,6 +96,8 @@ class WeightScalar(graphene.Scalar):
     @staticmethod
     def parse_value(value):
         if isinstance(value, dict):
+            if value.get("value") is None:
+                return None
             weight = Weight(**{value["unit"]: value["value"]})
         else:
             weight = WeightScalar.parse_decimal(value)

--- a/saleor/graphql/core/tests/test_scalars_weight.py
+++ b/saleor/graphql/core/tests/test_scalars_weight.py
@@ -1,0 +1,17 @@
+import pytest
+
+from ..scalars import WeightScalar
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"unit": "kg", "value": None},
+        {"unit": "g", "value": None},
+        {"unit": "lb", "value": None},
+        {"unit": "oz", "value": None},
+    ],
+)
+def test_weight_scalar_parse_value_with_none_value(value):
+    result = WeightScalar.parse_value(value)
+    assert result is None


### PR DESCRIPTION
## What

Add a None check for the weight value in `WeightScalar.parse_value` to prevent a `TypeError` when a GraphQL mutation receives `{"unit": "KG", "value": null}`.

## Why

The Sentry error shows:
```
TypeError: float() argument must be a string or a real number, not 'NoneType'
File "saleor/graphql/core/scalars.py", line 99, in parse_value
  weight = Weight(**{value["unit"]: value["value"]})
```

When `value["value"]` is `None`, it gets passed as `Weight(KG=None)` which the `measurement` library cannot handle.

## How

Added a guard clause: if `value.get("value")` is `None`, return `None` immediately instead of constructing a `Weight`.

Fixes #18680
