### PR TITLE
Instead letting Django set null on all objects in related table(s) do it in batches in order to prevent statement timeouts

### DIFF
--- a/saleor/app/tasks.py
+++ b/saleor/app/tasks.py
@@ -2,20 +2,43 @@ import logging
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Exists, Model, OuterRef, Q
 from django.utils import timezone
 from requests import HTTPError, RequestException
 
 from .. import celeryconf
+from ..account.models import CustomerEvent
 from ..core import JobStatus
 from ..core.db.connection import allow_writer
 from ..core.models import EventDelivery, EventDeliveryAttempt, EventPayload
 from ..core.tasks import delete_files_from_private_storage_task
+from ..csv.models import ExportEvent
+from ..discount.models import PromotionEvent
+from ..giftcard.models import GiftCard, GiftCardEvent
+from ..invoice.models import InvoiceEvent
+from ..order.models import OrderEvent, OrderGrantedRefund
+from ..payment.models import TransactionEvent, TransactionItem
 from ..webhook.models import Webhook
 from .installation_utils import AppInstallationError, install_app
 from .models import App, AppExtension, AppInstallation, AppToken
 
 logger = logging.getLogger(__name__)
+
+# Models with a SET_NULL foreign key to App. Django's cascade nulls these in a
+# single un-batched UPDATE during ``app.delete()``, which times out on large
+# tables (e.g. payment and order events). They are nulled in batches instead.
+APP_SET_NULL_MODELS: tuple[type[Model], ...] = (
+    TransactionEvent,
+    TransactionItem,
+    OrderEvent,
+    OrderGrantedRefund,
+    GiftCard,
+    GiftCardEvent,
+    PromotionEvent,
+    ExportEvent,
+    CustomerEvent,
+    InvoiceEvent,
+)
 
 
 @celeryconf.app.task
@@ -86,6 +109,24 @@ def _raw_remove_deliveries(deliveries_ids):
     payloads._raw_delete(payloads.db)
 
 
+def _batch_set_app_null(model, app_id, batch_size=1000):
+    """Null out ``app_id`` references on ``model`` in batches.
+
+    Django's cascade SET_NULL issues a single un-batched UPDATE over the whole
+    related table when an App is deleted, which exceeds the database statement
+    timeout on large tables. Nulling in batches keeps each statement small.
+    """
+    while True:
+        ids = list(
+            model.objects.filter(app_id=app_id).values_list("pk", flat=True)[
+                :batch_size
+            ]
+        )
+        if not ids:
+            break
+        model.objects.filter(pk__in=ids).update(app_id=None)
+
+
 @celeryconf.app.task
 @allow_writer()
 def remove_apps_task():
@@ -120,4 +161,11 @@ def remove_apps_task():
         webhooks.delete()
         AppToken.objects.filter(app_id=app.id).delete()
         AppExtension.objects.filter(app_id=app.id).delete()
+
+        # Saleor nulls SET_NULL references in batches to prevent timeouts on
+        # database. Django's cascade would otherwise null each related table in
+        # a single un-batched UPDATE, which times out on large tables.
+        for model in APP_SET_NULL_MODELS:
+            _batch_set_app_null(model, app.id)
+
         app.delete()

--- a/saleor/app/tests/test_app_tasks.py
+++ b/saleor/app/tests/test_app_tasks.py
@@ -8,10 +8,11 @@ from requests_hardened import HTTPSession
 
 from ...core import JobStatus, private_storage
 from ...core.models import EventDelivery, EventDeliveryAttempt, EventPayload
+from ...giftcard.models import GiftCard
 from ...webhook.models import Webhook
 from ..installation_utils import AppInstallationError
 from ..models import App, AppExtension, AppInstallation, AppToken
-from ..tasks import install_app_task, remove_apps_task
+from ..tasks import _batch_set_app_null, install_app_task, remove_apps_task
 
 
 @pytest.mark.vcr
@@ -156,6 +157,61 @@ def test_remove_app_task_not_remove_not_own_payloads(
 
     # then
     assert EventPayload.objects.count() == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_remove_app_task_nulls_set_null_references(removed_app, gift_card):
+    # given
+    gift_card.app = removed_app
+    gift_card.save(update_fields=["app"])
+
+    # when
+    remove_apps_task()
+
+    # then
+    assert App.objects.count() == 0
+    gift_card.refresh_from_db()
+    assert gift_card.app_id is None
+
+
+def test_batch_set_app_null_nulls_all_rows_in_batches(removed_app, gift_card_list):
+    # given
+    batch_size = 2
+    GiftCard.objects.filter(
+        id__in=[gift_card.id for gift_card in gift_card_list]
+    ).update(app=removed_app)
+    gift_card_ids = [gift_card.id for gift_card in gift_card_list]
+
+    # when
+    _batch_set_app_null(GiftCard, removed_app.id, batch_size=batch_size)
+
+    # then
+    assert GiftCard.objects.filter(app_id=removed_app.id).count() == 0
+    assert GiftCard.objects.filter(
+        id__in=gift_card_ids, app_id__isnull=True
+    ).count() == len(gift_card_ids)
+
+
+def test_batch_set_app_null_leaves_other_apps_untouched(
+    removed_app, app, gift_card, gift_card_expiry_date
+):
+    # given
+    own_gift_card = gift_card
+    own_gift_card.app = removed_app
+    own_gift_card.save(update_fields=["app"])
+
+    other_gift_card = gift_card_expiry_date
+    other_gift_card.app = app
+    other_gift_card.save(update_fields=["app"])
+
+    # when
+    _batch_set_app_null(GiftCard, removed_app.id)
+
+    # then
+    own_gift_card.refresh_from_db()
+    other_gift_card.refresh_from_db()
+    assert own_gift_card.app_id is None
+    assert other_gift_card.app_id == app.id
 
 
 def test_remove_app_task_no_app_to_remove(app):


### PR DESCRIPTION
To be backported.

Resolves SALEOR-CORE-800.