### PR TITLE
Make sentry scrubber recursive and add customer field

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -857,6 +857,11 @@ def SENTRY_INIT(dsn: str, sentry_opts: dict):
         "street_address_1",
         "street_address_2",
         "user_email",
+        # Order/customer filter input (`customer` CharFilter) accepts a raw
+        # email or name fragment as a scalar string value, so the PII lives
+        # directly under the `customer` key rather than a nested `email` key.
+        # It must be denylisted by name; recursion alone won't redact it.
+        "customer",
     ]
 
     sentry_sdk.init(
@@ -864,7 +869,9 @@ def SENTRY_INIT(dsn: str, sentry_opts: dict):
         release=__version__,
         send_default_pii=False,
         event_scrubber=EventScrubber(
-            denylist=SALEOR_DENYLIST, pii_denylist=SALEOR_PII_DENYLIST
+            denylist=SALEOR_DENYLIST,
+            pii_denylist=SALEOR_PII_DENYLIST,
+            recursive=True,
         ),
         **sentry_opts,
     )


### PR DESCRIPTION
1. Scrubber was not recursive, so nested fields like filters were not working 
2. `customer` field was not part of sensitive keys, but for filters it holds an email string