### PR TITLE
Add support for editorJS table syntax

### DIFF
--- a/saleor/core/editorjs/models.py
+++ b/saleor/core/editorjs/models.py
@@ -169,6 +169,29 @@ class EditorJSImageDataModel(SizeDataModel):
     url: URL | None = None
 
 
+class EditorJSTableDataModel(StrictBaseModel):
+    """Match the data payload for an EditorJS table block.
+
+    Each cell goes through ``Text`` so inline HTML produced by the table's
+    inline toolbar (bold, italic, strikethrough, link) is sanitized with nh3.
+
+    Example:
+        {
+            "withHeadings": true,
+            "stretched": false,
+            "content": [
+                ["<b>Name</b>", "Qty"],
+                ["Apples", "3 pcs"]
+            ]
+        }
+
+    """
+
+    withHeadings: bool | None = None
+    stretched: bool | None = None
+    content: list[list[Text]] | None = None
+
+
 class EditorJSNestedListItemModel(StrictBaseModel):
     """Match an EditorJS nested list item object.
 
@@ -425,13 +448,50 @@ class EditorJSImageBlockModel(EditorJSBlock):
         return text
 
 
+class EditorJSTableBlockModel(EditorJSBlock):
+    """Match an EditorJS table block object.
+
+    Produced by the ``@editorjs/table`` tool.
+
+    Example:
+        {
+            "type": "table",
+            "data": {
+                "withHeadings": true,
+                "stretched": false,
+                "content": [
+                    ["Name", "Qty"],
+                    ["Apples", "3 pcs"]
+                ]
+            }
+        }
+
+    """
+
+    type: Literal["table"]
+    data: EditorJSTableDataModel
+    id: Text | None = None
+
+    def to_text(self) -> str:
+        if not self.data.content:
+            return ""
+
+        parts = []
+        for row in self.data.content:
+            for cell in row:
+                if cell:
+                    parts.append(cell)
+        return " ".join(parts)
+
+
 EditorJSBlockModel = Annotated[
     EditorJSParagraphBlockModel
     | EditorJSHeaderBlockModel
     | EditorJSListBlockModel
     | EditorJSQuoteBlockModel
     | EditorJSEmbedBlockModel
-    | EditorJSImageBlockModel,
+    | EditorJSImageBlockModel
+    | EditorJSTableBlockModel,
     Field(discriminator="type"),
 ]
 

--- a/saleor/core/editorjs/tests/test_editorjs.py
+++ b/saleor/core/editorjs/tests/test_editorjs.py
@@ -1437,3 +1437,119 @@ def test_converts_exceptions_to_django(
     input_data = {"blocks": 1}
     with pytest.raises(expected_exception_cls):
         clean_editorjs(input_data, for_django=for_django)
+
+
+def test_clean_editorjs_table(no_link_rel):
+    # given
+    data = {
+        "blocks": [
+            {
+                "id": "lTBAOSyrNn",
+                "type": "table",
+                "data": {
+                    "withHeadings": True,
+                    "stretched": False,
+                    "content": [
+                        ["<s>asdf</s>", "asdf"],
+                        ["<i>asdf</i>", '<a href="http://google.com">asdf</a>'],
+                        ["<b>asdf</b>", "<s>asdf</s>"],
+                    ],
+                },
+            }
+        ]
+    }
+
+    # when
+    result = clean_editorjs(data, for_django=False)
+
+    # then
+    assert result == data
+
+
+def test_clean_editorjs_table_cleans_cell_content():
+    """Inline HTML inside table cells must be sanitized with nh3."""
+
+    # given
+    data = {
+        "blocks": [
+            {
+                "type": "table",
+                "data": {"content": [[DIRTY, "<b>safe</b>"]]},
+            }
+        ]
+    }
+
+    # when
+    result = clean_editorjs(data, for_django=False)
+
+    # then
+    cell = result["blocks"][0]["data"]["content"][0]
+    assert cell == [CLEAN, "<b>safe</b>"]
+
+
+def test_clean_editorjs_table_cleans_cell_url():
+    # given
+    url_invalid = "javascript:alert('Saleor')"
+    data = {
+        "blocks": [
+            {
+                "type": "table",
+                "data": {"content": [[f'<a href="{url_invalid}">link</a>']]},
+            }
+        ]
+    }
+
+    # when
+    result = clean_editorjs(data, for_django=False)
+
+    # then
+    cell = result["blocks"][0]["data"]["content"][0][0]
+    assert "javascript:" not in cell
+
+
+def test_clean_editorjs_table_drops_extra_fields():
+    """Unknown fields in a table block must be dropped (XSS protection)."""
+
+    # given
+    data = {
+        "blocks": [
+            {
+                "type": "table",
+                "data": {
+                    "content": [["a"]],
+                    DIRTY: DIRTY,
+                },
+            }
+        ]
+    }
+    expected = {"blocks": [{"type": "table", "data": {"content": [["a"]]}}]}
+
+    # when
+    result = clean_editorjs(data, for_django=False)
+
+    # then
+    assert result == expected
+
+
+def test_editorjs_to_text_table():
+    # given
+    data = {
+        "blocks": [
+            {
+                "type": "table",
+                "data": {
+                    "withHeadings": True,
+                    "content": [
+                        ["Name", "Qty"],
+                        ["<b>Apples</b>", "3 pcs"],
+                    ],
+                },
+            }
+        ]
+    }
+
+    # when
+    result = editorjs_to_text(data)
+
+    # then
+    assert result == "Name Qty Apples 3 pcs"

--- a/saleor/core/editorjs/tests/test_editorjs.py
+++ b/saleor/core/editorjs/tests/test_editorjs.py
@@ -1459,11 +1459,15 @@ def test_clean_editorjs_table(no_link_rel):
         ]
     }
 
+    # Capture the expectation before cleaning so a mutation of ``data`` can't make
+    # the assertion pass silently.
+    expected = deepcopy(data)
+
     # when
-    result = clean_editorjs(data, for_django=False)
+    actual = clean_editorjs(data, for_django=False)
 
     # then
-    assert result == data
+    assert actual == expected
 
 
 def test_clean_editorjs_table_cleans_cell_content():
@@ -1487,7 +1491,7 @@ def test_clean_editorjs_table_cleans_cell_content():
     assert cell == [CLEAN, "<b>safe</b>"]
 
 
-def test_clean_editorjs_table_cleans_cell_url():
+def test_clean_editorjs_table_cleans_cell_url(no_link_rel):
     # given
     url_invalid = "javascript:alert('Saleor')"
     data = {
@@ -1503,8 +1507,9 @@ def test_clean_editorjs_table_cleans_cell_url():
     result = clean_editorjs(data, for_django=False)
 
     # then
+    # The disallowed `javascript:` href is dropped entirely, leaving a bare anchor.
     cell = result["blocks"][0]["data"]["content"][0][0]
-    assert "javascript:" not in cell
+    assert cell == "<a>link</a>"
 
 
 def test_clean_editorjs_table_drops_extra_fields():


### PR DESCRIPTION
Allow  product description (EditorJS format) to accept new `table` field. Effectively user can add WYSIWYG tables

Dashboard
https://github.com/saleor/saleor-dashboard/pull/6613

Port to 3.23
https://github.com/saleor/saleor/pull/19281/changes