### PR TITLE
Release 3.23.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.23.7",
+  "version": "3.23.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.23.7",
+      "version": "3.23.8",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.23.7",
+  "version": "3.23.8",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.23.7"
+version = "3.23.8"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,7 +1,7 @@
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.23.7"
+__version__ = "3.23.8"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.23.7"
+version = "3.23.8"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
Changes:
- 6802c436c212c5cca9b413a20348efc0e25e1fcb  Mikail Kocak: release: v3.23.8
- 522016a1fe2f480e59416fe760e7985924f977ec  Mikail: chore: bump django and urllib3 to latest versions (#19283)
- 0c0dbacc6985575e812a04453dede268aedd2eaa  Marcin Wcisło: Fix TypeError when resolving default channel slug on product types (#19251) (#19276)
- 0ea9b58e77812f21b21b6f3f77c940714a32527e  Marcin Wcisło: Sentry's PII scrubber improvements (#19273)
- d059dd9802802dd37bda08feddab61f2abe7f05d  Marcin Wcisło: Fix KeyError when resolving channel for channel-agnostic account events (#19253) (#19265)
- de83ffc69e44cfe2e8ab4efd7351cf3c55ccf2a2  Marcin Wcisło: Fix saving language code in customerUpdate mutation (#19254) (#19261)