### PR TITLE
Release 3.22.52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.51",
+  "version": "3.22.52",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.51",
+      "version": "3.22.52",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.51",
+  "version": "3.22.52",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.22.51"
+version = "3.22.52"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.51"
+__version__ = "3.22.52"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2558,7 +2558,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.22.51"
+version = "3.22.52"
 source = { virtual = "." }
 dependencies = [
     { name = "adyen", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
Changes:
- 27432b36081699ce6ed452e1e8869fa75a0ee794  Mikail Kocak: release: v3.22.52
- 58946aa9b8c94d454ee6f640b110143d52b6e14b  Mikail: chore: bump django and urllib3 to latest versions (#19284)
- d6e17d9b67fdae4837da94f29067f9f7e464b768  Marcin Wcisło: Fix TypeError when resolving default channel slug on product types (#19251) (#19277)
- 9c2d945b5eb2948c790402a65061981128772f47  Marcin Wcisło: Sentry's PII scrubber improvements (#19274)
- cf0bb6a8138c25a388ea2ce23e0c30df55040d4f  Marcin Wcisło: Fix KeyError when resolving channel for channel-agnostic account events (#19253) (#19266)
- 93719fd5d05a4cb5bca1969b11e4f4fc92761240  Marcin Wcisło: Fix saving language code in customerUpdate mutation (#19254) (#19262)