### PR TITLE
Fix password login mode stripping staff access from third-party tokens

### DIFF
--- a/saleor/core/auth_backend.py
+++ b/saleor/core/auth_backend.py
@@ -152,11 +152,17 @@ def load_user_from_request(request):
             "Invalid token. Create new one by using tokenCreate mutation."
         )
 
-    site_settings = get_site_promise(request).get().settings
-    password_login_mode = site_settings.password_login_mode
-
-    if password_login_mode != PasswordLoginMode.ENABLED:
-        return _resolve_user_for_password_login_restriction(user, password_login_mode)
+    # Password login mode only restricts first-party access tokens, which are the
+    # tokens minted from a password login. Third-party access tokens are issued for
+    # apps and app extensions on behalf of an already-authenticated user (e.g. logged
+    # in via OIDC), so they must not have their staff access stripped here.
+    if jwt_type == JWT_ACCESS_TYPE:
+        site_settings = get_site_promise(request).get().settings
+        password_login_mode = site_settings.password_login_mode
+        if password_login_mode != PasswordLoginMode.ENABLED:
+            return _resolve_user_for_password_login_restriction(
+                user, password_login_mode
+            )
 
     if permissions is not None:
         token_permissions = get_permissions_from_names(permissions)

--- a/saleor/core/tests/test_auth_backend_default_header.py
+++ b/saleor/core/tests/test_auth_backend_default_header.py
@@ -272,3 +272,53 @@ def test_staff_user_disabled_mode(prefix, rf, staff_user, site_settings):
     # then
     with pytest.raises(InvalidTokenError):
         backend.authenticate(request)
+
+
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_staff_user_app_access_token_customers_only_mode(
+    prefix, rf, staff_user, app, permission_manage_products, site_settings
+):
+    """Third-party tokens keep staff access regardless of password login mode.
+
+    App and app-extension access tokens are issued on behalf of an already
+    authenticated staff user (e.g. logged in via OIDC), so the password login
+    restriction must not strip their staff access.
+    """
+    # given
+    site_settings.password_login_mode = PasswordLoginMode.CUSTOMERS_ONLY
+    site_settings.save(update_fields=["password_login_mode"])
+    staff_user.user_permissions.add(permission_manage_products)
+    app.permissions.add(permission_manage_products)
+    access_token_for_app = create_access_token_for_app(app, staff_user)
+
+    # when
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {access_token_for_app}")
+    backend = JSONWebTokenBackend()
+    user = backend.authenticate(request)
+
+    # then
+    assert user == staff_user
+    assert user.is_staff is True
+    assert set(user.effective_permissions) == {permission_manage_products}
+
+
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_staff_user_app_access_token_disabled_mode(
+    prefix, rf, staff_user, app, permission_manage_products, site_settings
+):
+    # given
+    site_settings.password_login_mode = PasswordLoginMode.DISABLED
+    site_settings.save(update_fields=["password_login_mode"])
+    staff_user.user_permissions.add(permission_manage_products)
+    app.permissions.add(permission_manage_products)
+    access_token_for_app = create_access_token_for_app(app, staff_user)
+
+    # when
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {access_token_for_app}")
+    backend = JSONWebTokenBackend()
+    user = backend.authenticate(request)
+
+    # then
+    assert user == staff_user
+    assert user.is_staff is True
+    assert set(user.effective_permissions) == {permission_manage_products}


### PR DESCRIPTION
Password login mode restriction in load_user_from_request was applied to every Saleor-issued JWT, including third-party access tokens minted for apps and app extensions (JWT_THIRDPARTY_ACCESS_TYPE). These tokens are issued on behalf of an already-authenticated user (e.g. logged in via OIDC), not from a password login, so under CUSTOMERS_ONLY mode their staff access was wrongly stripped and under DISABLED mode they were rejected outright.

This broke the `app { extensions { accessToken } }` flow for staff users authenticated via OIDC: the returned token failed with PermissionDenied.

Scope the restriction to first-party access tokens (JWT_ACCESS_TYPE), which are the only tokens minted from a password login. Add regression tests covering app access tokens under CUSTOMERS_ONLY and DISABLED modes.
