### PR TITLE
Release 3.21.60

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.21.59",
+  "version": "3.21.60",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.21.59",
+      "version": "3.21.60",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.21.59",
+  "version": "3.21.60",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ help = "Run tests with db reuse to speed up testing time"
 
 [tool.poetry]
 name = "saleor"
-version = "3.21.59"
+version = "3.21.60"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.21.59"
+__version__ = "3.21.60"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
Changes:
- 108bd9f81991982b7a839559dc5be077eaad7e07  Mikail Kocak: release: v3.21.60
- 5b16284b7068faa9f3bdb8690a30b682d37e54c3  Mikail: chore: bump django to latest version (#19285)
- 9aa7eb6ceb57996fc303cb32f9496243a27f98d9  Marcin Wcisło: Fix TypeError when resolving default channel slug on product types (#19251) (#19278)
- b256dc6884aebb89310ffefbfbab1b15b919ac4e  Marcin Wcisło: Sentry's PII scrubber improvements (#19275)
- 04f9ef960a4cf691dc9d4c9de010972a4ac48448  Marcin Wcisło: Fix KeyError when resolving channel for channel-agnostic account events (#19253) (#19267)