### PR TITLE
Refactored WeightScalar parse_value to not accept NoneType and added unit test.

### DIFF
--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -117,13 +117,20 @@ class WeightScalar(graphene.Scalar):
             unit = value.get("unit")
             value_amount = value.get("value")
             return WeightScalar.create_validated_weight(unit, value_amount)
+
         if isinstance(value, (int, float, str)):
-            if isinstance(value, (int, float)) and value < 0:
-                raise GraphQLError("Weight value cannot be negative.")
+            try:
+                numeric_val = float(value)
+                if numeric_val < 0:
+                    raise GraphQLError("Weight value cannot be negative.")
+            except (ValueError, TypeError):
+                raise GraphQLError("Invalid weight format provided.")
+
             weight = WeightScalar.parse_decimal(value)
             if weight is None:
                 raise GraphQLError("Invalid weight format provided.")
             return weight
+
         raise GraphQLError(
             "Invalid weight format provided. Expected an object or a number."
         )

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -4,6 +4,7 @@ import decimal
 import graphene
 from graphene.types.generic import GenericScalar
 from graphql.language import ast
+from graphql import GraphQLError
 from measurement.measures import Weight
 
 from ...core.weight import (
@@ -94,12 +95,38 @@ class JSON(GenericScalar):
 
 class WeightScalar(graphene.Scalar):
     @staticmethod
+    def create_validated_weight(unit, value_amount):
+        if value_amount is None:
+            raise GraphQLError("Weight value cannot be null.")
+        if not unit:
+            raise GraphQLError("Weight unit cannot be null or empty.")
+        try:
+            numeric_value = float(value_amount)
+            if numeric_value < 0:
+                raise GraphQLError("Weight value cannot be negative.")
+        except (ValueError, TypeError):
+            raise GraphQLError("Weight value must be a valid number.")
+        try:
+            return Weight(**{unit: value_amount})
+        except TypeError:
+            raise GraphQLError(f"Unsupported weight unit: '{unit}'.")
+
+    @staticmethod
     def parse_value(value):
         if isinstance(value, dict):
-            weight = Weight(**{value["unit"]: value["value"]})
-        else:
+            unit = value.get("unit")
+            value_amount = value.get("value")
+            return WeightScalar.create_validated_weight(unit, value_amount)
+        if isinstance(value, (int, float, str)):
+            if isinstance(value, (int, float)) and value < 0:
+                raise GraphQLError("Weight value cannot be negative.")
             weight = WeightScalar.parse_decimal(value)
-        return weight
+            if weight is None:
+                raise GraphQLError("Invalid weight format provided.")
+            return weight
+        raise GraphQLError(
+            "Invalid weight format provided. Expected an object or a number."
+        )
 
     @staticmethod
     def serialize(weight):

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -117,7 +117,6 @@ class WeightScalar(graphene.Scalar):
             unit = value.get("unit")
             value_amount = value.get("value")
             return WeightScalar.create_validated_weight(unit, value_amount)
-
         if isinstance(value, (int, float, str)):
             try:
                 numeric_val = float(value)
@@ -125,12 +124,10 @@ class WeightScalar(graphene.Scalar):
                     raise GraphQLError("Weight value cannot be negative.")
             except (ValueError, TypeError):
                 raise GraphQLError("Invalid weight format provided.")
-
             weight = WeightScalar.parse_decimal(value)
             if weight is None:
                 raise GraphQLError("Invalid weight format provided.")
             return weight
-
         raise GraphQLError(
             "Invalid weight format provided. Expected an object or a number."
         )

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -37,20 +37,37 @@ def test_parser():
         "Function unexpectedly returned None for a valid numeric string"
     )
 
-    invalid_input = "not_a_number"
     with pytest.raises(GraphQLError) as exc_info:
-        WeightScalar.parse_value(invalid_input)
+        WeightScalar.parse_value("not_a_number")
     assert "Invalid weight format provided." in str(exc_info.value)
 
-    invalid_input = -10
     with pytest.raises(GraphQLError) as exc_info:
-        WeightScalar.parse_value(invalid_input)
-    assert str(exc_info.value) == "Weight value cannot be negative."
+        WeightScalar.parse_value(-10)
+    assert "Weight value cannot be negative." in str(exc_info.value)
 
-    invalid_input = [10, "kg"]
     with pytest.raises(GraphQLError) as exc_info:
-        WeightScalar.parse_value(invalid_input)
+        WeightScalar.parse_value("-10")
+    assert "Weight value cannot be negative." in str(exc_info.value)
+
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value([10, "kg"])
     assert "Expected an object or a number" in str(exc_info.value)
+
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value(None)
+    assert "Expected an object or a number" in str(exc_info.value)
+
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value({})
+    assert "Weight value cannot be null." in str(exc_info.value)
+
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value({"unit": "kg"})
+    assert "Weight value cannot be null." in str(exc_info.value)
+
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value({"value": 70})
+    assert "Weight unit cannot be null or empty." in str(exc_info.value)
 
 
 def test_uuid_scalar_value_passed_as_variable(api_client, checkout):

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -6,6 +6,8 @@ from ....order.models import Order
 from ....payment.interface import PaymentGatewayData
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
 from ..utils import to_global_id_or_none
+from graphql import GraphQLError
+from ..scalars import WeightScalar
 
 QUERY_CHECKOUT = """
 query getCheckout($token: UUID!) {
@@ -14,6 +16,41 @@ query getCheckout($token: UUID!) {
     }
 }
 """
+
+
+def test_parser():
+    valid_input = {"unit": "kg", "value": 70}
+    result = WeightScalar.parse_value(valid_input)
+    assert result is not None, (
+        "Function unexpectedly returned None for a valid dictionary"
+    )
+
+    valid_input = 150.5
+    result = WeightScalar.parse_value(valid_input)
+    assert result is not None, (
+        "Function unexpectedly returned None for a valid plain number"
+    )
+
+    valid_input = "70.5"
+    result = WeightScalar.parse_value(valid_input)
+    assert result is not None, (
+        "Function unexpectedly returned None for a valid numeric string"
+    )
+
+    invalid_input = "not_a_number"
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value(invalid_input)
+    assert "Invalid weight format provided." in str(exc_info.value)
+
+    invalid_input = -10
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value(invalid_input)
+    assert str(exc_info.value) == "Weight value cannot be negative."
+
+    invalid_input = [10, "kg"]
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value(invalid_input)
+    assert "Expected an object or a number" in str(exc_info.value)
 
 
 def test_uuid_scalar_value_passed_as_variable(api_client, checkout):


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
Fixed parse_value to not return NoneType and to safely be used without crashing.
It validates the data in the create_validated_weight function.
Both functions raise graphqlerror instead of returning them.
<!-- GitHub issue number is required for external contributions. -->
Closes #18680
# Impact

- [ x] Removed API types, fields, or mutations
- [ x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] New migrations
# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ x] Database queries are optimized and the number of queries is constant
- [ x] The changes are covered by test cases
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
