### PR TITLE
Add optional isActive filter to channels query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### GraphQL API
 
+- Added optional `isActive` argument to the `channels` query to filter channels by active status. When omitted or `null`, the query returns all channels (backward compatible).
+
 ### Webhooks
 
 ### Other changes

--- a/saleor/graphql/channel/resolvers.py
+++ b/saleor/graphql/channel/resolvers.py
@@ -30,7 +30,8 @@ def resolve_channel(info, id: str | None, slug: str | None):
     return None
 
 
-def resolve_channels(info):
-    return models.Channel.objects.using(
-        get_database_connection_name(info.context)
-    ).all()
+def resolve_channels(info, *, is_active: bool | None = None):
+    qs = models.Channel.objects.using(get_database_connection_name(info.context)).all()
+    if is_active is not None:
+        qs = qs.filter(is_active=is_active)
+    return qs

--- a/saleor/graphql/channel/schema.py
+++ b/saleor/graphql/channel/schema.py
@@ -33,7 +33,17 @@ class ChannelQueries(graphene.ObjectType):
     )
     channels = PermissionsField(
         NonNullList(Channel),
-        description="List of all channels.",
+        is_active=graphene.Argument(
+            graphene.Boolean,
+            description=(
+                "Filter channels by active status. When omitted, returns all channels."
+            ),
+            required=False,
+        ),
+        description=(
+            "List of channels. Use `isActive` to filter by active status; "
+            "when omitted, returns all channels."
+        ),
         permissions=[
             AuthorizationFilters.AUTHENTICATED_APP,
             AuthorizationFilters.AUTHENTICATED_STAFF_USER,
@@ -46,8 +56,8 @@ class ChannelQueries(graphene.ObjectType):
         return resolve_channel(info, id, slug)
 
     @staticmethod
-    def resolve_channels(_root, info: ResolveInfo, **kwargs):
-        return resolve_channels(info)
+    def resolve_channels(_root, info: ResolveInfo, *, is_active=None, **kwargs):
+        return resolve_channels(info, is_active=is_active)
 
 
 class ChannelMutations(graphene.ObjectType):

--- a/saleor/graphql/channel/tests/queries/test_channels.py
+++ b/saleor/graphql/channel/tests/queries/test_channels.py
@@ -147,3 +147,121 @@ def test_query_channels_with_has_orders_without_permission(
 
     # then
     assert_no_permission(response)
+
+
+QUERY_CHANNELS_FILTER_BY_IS_ACTIVE = """
+    query Channels($isActive: Boolean) {
+        channels(isActive: $isActive) {
+            slug
+            isActive
+        }
+    }
+"""
+
+
+def _deactivate_channel_pln(channel_PLN):
+    channel_PLN.is_active = False
+    channel_PLN.save(update_fields=["is_active"])
+
+
+def test_query_channels_filter_active_only(app_api_client, channel_USD, channel_PLN):
+    # given
+    _deactivate_channel_pln(channel_PLN)
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_CHANNELS_FILTER_BY_IS_ACTIVE, {"isActive": True}
+    )
+    content = get_graphql_content(response)
+
+    # then
+    channels = content["data"]["channels"]
+    assert len(channels) == 1
+    assert channels[0] == {"slug": channel_USD.slug, "isActive": True}
+
+
+def test_query_channels_filter_active_only_as_staff_user(
+    staff_api_client, channel_USD, channel_PLN
+):
+    # given
+    _deactivate_channel_pln(channel_PLN)
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_CHANNELS_FILTER_BY_IS_ACTIVE, {"isActive": True}
+    )
+    content = get_graphql_content(response)
+
+    # then
+    channels = content["data"]["channels"]
+    assert len(channels) == 1
+    assert channels[0] == {"slug": channel_USD.slug, "isActive": True}
+
+
+def test_query_channels_filter_inactive_only(app_api_client, channel_USD, channel_PLN):
+    # given
+    _deactivate_channel_pln(channel_PLN)
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_CHANNELS_FILTER_BY_IS_ACTIVE, {"isActive": False}
+    )
+    content = get_graphql_content(response)
+
+    # then
+    channels = content["data"]["channels"]
+    assert len(channels) == 1
+    assert channels[0] == {"slug": channel_PLN.slug, "isActive": False}
+
+
+def test_query_channels_filter_inactive_only_when_all_active_returns_empty_list(
+    app_api_client, channel_USD, channel_PLN
+):
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_CHANNELS_FILTER_BY_IS_ACTIVE, {"isActive": False}
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["channels"] == []
+
+
+def test_query_channels_without_is_active_filter_returns_all_channels(
+    app_api_client, channel_USD, channel_PLN
+):
+    # given
+    _deactivate_channel_pln(channel_PLN)
+
+    # when
+    response = app_api_client.post_graphql(QUERY_CHANNELS_FILTER_BY_IS_ACTIVE, {})
+    content = get_graphql_content(response)
+
+    # then
+    channels = content["data"]["channels"]
+    assert len(channels) == 2
+    assert {channel["slug"] for channel in channels} == {
+        channel_USD.slug,
+        channel_PLN.slug,
+    }
+
+
+def test_query_channels_with_null_is_active_filter_returns_all_channels(
+    app_api_client, channel_USD, channel_PLN
+):
+    # given
+    _deactivate_channel_pln(channel_PLN)
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_CHANNELS_FILTER_BY_IS_ACTIVE, {"isActive": None}
+    )
+    content = get_graphql_content(response)
+
+    # then
+    channels = content["data"]["channels"]
+    assert len(channels) == 2
+    assert {channel["slug"] for channel in channels} == {
+        channel_USD.slug,
+        channel_PLN.slug,
+    }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1376,11 +1376,14 @@ type Query {
   ): Channel @doc(category: "Channels")
 
   """
-  List of all channels.
+  List of channels. Use `isActive` to filter by active status; when omitted, returns all channels.
   
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
-  channels: [Channel!] @doc(category: "Channels")
+  channels(
+    """Filter channels by active status. When omitted, returns all channels."""
+    isActive: Boolean
+  ): [Channel!] @doc(category: "Channels")
 
   """List of the shop's attributes."""
   attributes(


### PR DESCRIPTION
Let storefronts request only active channels via
`channels(isActive: true)` instead of filtering client-side after fetching every channel.

Backward compatible: when the argument is omitted or null, all channels are returned, so Dashboard channel management is unchanged.

Includes tests for active/inactive filters, null/omitted argument, empty results, and staff/app callers.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
