### PR TITLE
Fix/Raise logger error when sync webhook is called inside db transaction

### DIFF
--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -117,13 +117,20 @@ class WeightScalar(graphene.Scalar):
             unit = value.get("unit")
             value_amount = value.get("value")
             return WeightScalar.create_validated_weight(unit, value_amount)
+
         if isinstance(value, (int, float, str)):
-            if isinstance(value, (int, float)) and value < 0:
-                raise GraphQLError("Weight value cannot be negative.")
+            try:
+                numeric_val = float(value)
+                if numeric_val < 0:
+                    raise GraphQLError("Weight value cannot be negative.")
+            except (ValueError, TypeError):
+                raise GraphQLError("Invalid weight format provided.")
+
             weight = WeightScalar.parse_decimal(value)
             if weight is None:
                 raise GraphQLError("Invalid weight format provided.")
             return weight
+
         raise GraphQLError(
             "Invalid weight format provided. Expected an object or a number."
         )

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -4,6 +4,7 @@ import decimal
 import graphene
 from graphene.types.generic import GenericScalar
 from graphql.language import ast
+from graphql import GraphQLError
 from measurement.measures import Weight
 
 from ...core.weight import (
@@ -94,12 +95,38 @@ class JSON(GenericScalar):
 
 class WeightScalar(graphene.Scalar):
     @staticmethod
+    def create_validated_weight(unit, value_amount):
+        if value_amount is None:
+            raise GraphQLError("Weight value cannot be null.")
+        if not unit:
+            raise GraphQLError("Weight unit cannot be null or empty.")
+        try:
+            numeric_value = float(value_amount)
+            if numeric_value < 0:
+                raise GraphQLError("Weight value cannot be negative.")
+        except (ValueError, TypeError):
+            raise GraphQLError("Weight value must be a valid number.")
+        try:
+            return Weight(**{unit: value_amount})
+        except TypeError:
+            raise GraphQLError(f"Unsupported weight unit: '{unit}'.")
+
+    @staticmethod
     def parse_value(value):
         if isinstance(value, dict):
-            weight = Weight(**{value["unit"]: value["value"]})
-        else:
+            unit = value.get("unit")
+            value_amount = value.get("value")
+            return WeightScalar.create_validated_weight(unit, value_amount)
+        if isinstance(value, (int, float, str)):
+            if isinstance(value, (int, float)) and value < 0:
+                raise GraphQLError("Weight value cannot be negative.")
             weight = WeightScalar.parse_decimal(value)
-        return weight
+            if weight is None:
+                raise GraphQLError("Invalid weight format provided.")
+            return weight
+        raise GraphQLError(
+            "Invalid weight format provided. Expected an object or a number."
+        )
 
     @staticmethod
     def serialize(weight):

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -117,7 +117,6 @@ class WeightScalar(graphene.Scalar):
             unit = value.get("unit")
             value_amount = value.get("value")
             return WeightScalar.create_validated_weight(unit, value_amount)
-
         if isinstance(value, (int, float, str)):
             try:
                 numeric_val = float(value)
@@ -125,12 +124,10 @@ class WeightScalar(graphene.Scalar):
                     raise GraphQLError("Weight value cannot be negative.")
             except (ValueError, TypeError):
                 raise GraphQLError("Invalid weight format provided.")
-
             weight = WeightScalar.parse_decimal(value)
             if weight is None:
                 raise GraphQLError("Invalid weight format provided.")
             return weight
-
         raise GraphQLError(
             "Invalid weight format provided. Expected an object or a number."
         )

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -37,20 +37,37 @@ def test_parser():
         "Function unexpectedly returned None for a valid numeric string"
     )
 
-    invalid_input = "not_a_number"
     with pytest.raises(GraphQLError) as exc_info:
-        WeightScalar.parse_value(invalid_input)
+        WeightScalar.parse_value("not_a_number")
     assert "Invalid weight format provided." in str(exc_info.value)
 
-    invalid_input = -10
     with pytest.raises(GraphQLError) as exc_info:
-        WeightScalar.parse_value(invalid_input)
-    assert str(exc_info.value) == "Weight value cannot be negative."
+        WeightScalar.parse_value(-10)
+    assert "Weight value cannot be negative." in str(exc_info.value)
 
-    invalid_input = [10, "kg"]
     with pytest.raises(GraphQLError) as exc_info:
-        WeightScalar.parse_value(invalid_input)
+        WeightScalar.parse_value("-10")
+    assert "Weight value cannot be negative." in str(exc_info.value)
+
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value([10, "kg"])
     assert "Expected an object or a number" in str(exc_info.value)
+
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value(None)
+    assert "Expected an object or a number" in str(exc_info.value)
+
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value({})
+    assert "Weight value cannot be null." in str(exc_info.value)
+
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value({"unit": "kg"})
+    assert "Weight value cannot be null." in str(exc_info.value)
+
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value({"value": 70})
+    assert "Weight unit cannot be null or empty." in str(exc_info.value)
 
 
 def test_uuid_scalar_value_passed_as_variable(api_client, checkout):

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -6,6 +6,8 @@ from ....order.models import Order
 from ....payment.interface import PaymentGatewayData
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
 from ..utils import to_global_id_or_none
+from graphql import GraphQLError
+from ..scalars import WeightScalar
 
 QUERY_CHECKOUT = """
 query getCheckout($token: UUID!) {
@@ -14,6 +16,41 @@ query getCheckout($token: UUID!) {
     }
 }
 """
+
+
+def test_parser():
+    valid_input = {"unit": "kg", "value": 70}
+    result = WeightScalar.parse_value(valid_input)
+    assert result is not None, (
+        "Function unexpectedly returned None for a valid dictionary"
+    )
+
+    valid_input = 150.5
+    result = WeightScalar.parse_value(valid_input)
+    assert result is not None, (
+        "Function unexpectedly returned None for a valid plain number"
+    )
+
+    valid_input = "70.5"
+    result = WeightScalar.parse_value(valid_input)
+    assert result is not None, (
+        "Function unexpectedly returned None for a valid numeric string"
+    )
+
+    invalid_input = "not_a_number"
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value(invalid_input)
+    assert "Invalid weight format provided." in str(exc_info.value)
+
+    invalid_input = -10
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value(invalid_input)
+    assert str(exc_info.value) == "Weight value cannot be negative."
+
+    invalid_input = [10, "kg"]
+    with pytest.raises(GraphQLError) as exc_info:
+        WeightScalar.parse_value(invalid_input)
+    assert "Expected an object or a number" in str(exc_info.value)
 
 
 def test_uuid_scalar_value_passed_as_variable(api_client, checkout):

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -66,6 +66,9 @@ R = TypeVar("R")
 logger = logging.getLogger(__name__)
 
 
+"""Logs an error if a synchronous webhook is triggered inside an atomic block."""
+
+
 @app.task(
     bind=True,
     retry_backoff=10,
@@ -282,6 +285,7 @@ def create_delivery_for_subscription_sync_event(
     :param allow_replica: use replica database.
     :return: List of event deliveries to send via webhook tasks.
     """
+
     if event_type not in WEBHOOK_TYPES_MAP:
         logger.info(
             "Skipping subscription webhook. Event %s is not subscribable.", event_type
@@ -348,6 +352,7 @@ def create_promise_delivery_for_subscription_sync_event(
     :param allow_replica: use replica database.
     :return: List of event deliveries to send via webhook tasks.
     """
+
     if event_type not in WEBHOOK_TYPES_MAP:
         logger.info(
             "Skipping subscription webhook. Event %s is not subscribable.", event_type
@@ -407,6 +412,8 @@ def trigger_webhook_sync_promise(
     requestor: Union["App", "User", None] = None,
 ) -> Promise[dict[Any, Any] | None]:
     """Send a synchronous webhook request."""
+
+    check_sync_webhook_transaction(event_type)
 
     def trigger_sync_for_delivery(
         delivery: EventDelivery | None,
@@ -476,6 +483,8 @@ def trigger_transaction_request(
         )
         return
 
+    check_sync_webhook_transaction(event_type)
+
     if webhook.subscription_query:
         delivery = None
         try:
@@ -514,3 +523,14 @@ def trigger_transaction_request(
         delivery.id,
         transaction_data.event.id,
     )
+
+
+def check_sync_webhook_transaction(event_type: str):
+    # Ensure this is a sync event type (adjust mapping name to match your codebase)
+    if event_type in WebhookEventSyncType.ALL:
+        if transaction.get_connection().in_atomic_block:
+            logger.error(
+                "Sync webhook '%s' is being processed inside an atomic transaction! "
+                "This can block DB connections and cause thread exhaustion.",
+                event_type,
+            )


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
It uses a helper function by using logger.error when any SyncWebhookEvent happens in a transaction. check_sync_webhook_transaction is placled in trigger_webhook_sync_promise and trigger_transaction_request. The unit tests cover with mock logger but the WebhookEventSyncType.py containing all the sync evetns can be used.
<!-- GitHub issue number is required for external contributions. -->
# Closes #19293
# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ x] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ x] The changes are covered by test cases
- [ x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
