### PR TITLE
fix(tests): slow tests caused by pytest-socket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ dev = [
     "pytest-memray>=1.5.0,<2",
     "pytest-mock>=3.6.1,<4",
     "pytest-recording>=0.13.0,<0.14",
-    "pytest-socket>=0.7.0,<0.8",
+    "pytest-socket>=0.8.0,<1",
     "pytest-xdist>=3.0.2,<4",
     "pywatchman>=2.0.0,<3",
     "ruff>=0.12.2,<0.13",
@@ -152,6 +152,7 @@ exclude-newer = "3 weeks"
 django = "2026-06-03T13:03:35Z" # https://pypi.org/pypi/django/5.2.15/json
 pyjwt = "2026-05-21T19:54:36Z" # https://github.com/jpadilla/pyjwt/releases/tag/2.13.0
 idna = "2026-05-12T22:45:57Z" # https://github.com/advisories/GHSA-65pc-fj4g-8rjx/
+pytest-socket = "2026-05-21T16:50:22Z" # Fixes slow fixtures caused by lack of cache https://github.com/miketheman/pytest-socket/pull/369
 
 [tool.poe.tasks]
 start.help = "Start development server with hot reload"

--- a/uv.lock
+++ b/uv.lock
@@ -13,9 +13,10 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P3W"
 
 [options.exclude-newer-package]
-pyjwt = "2026-05-21T19:54:36Z"
-django = "2026-06-03T13:03:35Z"
 idna = "2026-05-12T22:45:57Z"
+pytest-socket = "2026-05-21T16:50:22Z"
+django = "2026-06-03T13:03:35Z"
+pyjwt = "2026-05-21T19:54:36Z"
 
 [[package]]
 name = "amqp"
@@ -2262,14 +2263,14 @@ wheels = [
 
 [[package]]
 name = "pytest-socket"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/ff/90c7e1e746baf3d62ce864c479fd53410b534818b9437413903596f81580/pytest_socket-0.7.0.tar.gz", hash = "sha256:71ab048cbbcb085c15a4423b73b619a8b35d6a307f46f78ea46be51b1b7e11b3", size = 12389, upload-time = "2024-01-28T20:17:23.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/3c/f9b58e57830e58980dbe8867d0e348f45701d3f3ea065672d448f4366da5/pytest_socket-0.8.0.tar.gz", hash = "sha256:af9bb5f487da72be63573a6194cfac033b6c7a1c1561e150521105970f9e99f2", size = 13912, upload-time = "2026-05-21T16:50:22.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/58/5d14cb5cb59409e491ebe816c47bf81423cd03098ea92281336320ae5681/pytest_socket-0.7.0-py3-none-any.whl", hash = "sha256:7e0f4642177d55d317bbd58fc68c6bd9048d6eadb2d46a89307fa9221336ce45", size = 6754, upload-time = "2024-01-28T20:17:22.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e8/4a8568580bae3dcd678599ed8e86a82d505a44df71c1ced4246c1aa14b4b/pytest_socket-0.8.0-py3-none-any.whl", hash = "sha256:81821ba59f07d7600fe2b551d8714f40b068bd46e8b6704c48664e9d60cdacb8", size = 8414, upload-time = "2026-05-21T16:50:21.022Z" },
 ]
 
 [[package]]
@@ -2737,7 +2738,7 @@ dev = [
     { name = "pytest-memray", specifier = ">=1.5.0,<2" },
     { name = "pytest-mock", specifier = ">=3.6.1,<4" },
     { name = "pytest-recording", specifier = ">=0.13.0,<0.14" },
-    { name = "pytest-socket", specifier = ">=0.7.0,<0.8" },
+    { name = "pytest-socket", specifier = ">=0.8.0,<1" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4" },
     { name = "pywatchman", specifier = ">=2.0.0,<3" },
     { name = "ruff", specifier = ">=0.12.2,<0.13" },


### PR DESCRIPTION
This fixes an issue with pytest-socket could cause each test to take 4 seconds to initialize due to the following configuration in the `setup.cfg` file:

```
--allow-hosts 127.0.0.1,::1,cache
```

Whenever `pytest-socket` attempted to resolve the `cache` hostname and that hostname times out (because it doesn't resolve to an IP), it would take 4 seconds per each test case in the `setup` phase (i.e., when pytest prepares to run the test case). See the "Durations Logs" section below

This is caused by the `pytest-socket` dependency which will resolve all hosts to IPs at the beginning of each test[^1] without caching the results, thus never remembering the fact that the network call is timing out.

This is resolved by upgrading to `pytest-socket` v0.8.0 which adds caching.

**Before:**

```shell
$ time -p uv run pytest -n0 --reuse-db saleor/plugins/tests/test_email_common.py -qqq
[TRUNCATED]
....................... [100%]
real 94.93
user 4.45
sys 0.16
```

**After:**

```shell
$ time -p uv run pytest -n0 --reuse-db saleor/plugins/tests/test_email_common.py -qqq
....................... [100%]
[TRUNCATED]
real 8.15
user 4.19
sys 0.22
```

[^1]: https://github.com/miketheman/pytest-socket/blob/93f704bc7989cee1df10024e0344c08e16055300/pytest_socket.py#L150

## Durations Logs

This is the output from `pytest --durations=0` which shows the issue: each test takes 4 seconds to be setup/initialized:

```
time -p uv run pytest -n0 --reuse-db saleor/plugins/tests/test_email_common.py -qqq --durations=0
Uninstalled 1 package in 0.45ms
░░░░░░░░░░░░░░░░░░░░ [0/1] Installing wheels...                                                                                                                                                                                                                warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
Installed 1 package in 4ms
.......................                                                                                                                                                                                                                                 [100%]
====================================================================================================================== slowest durations ======================================================================================================================
4.24s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_bad_email[this_is_not_an_email]
4.04s setup    saleor/plugins/tests/test_email_common.py::test_get_product_image_thumbnail
4.00s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_missing_smtp_values[config6-expected_fields6]
4.00s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_bad_email[.@.test]
4.00s setup    saleor/plugins/tests/test_email_common.py::test_get_plain_text_message_for_email[<html>Hello World!</html>-Hello World!]
4.00s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_missing_smtp_values[config4-expected_fields4]
4.00s setup    saleor/plugins/tests/test_email_common.py::test_get_plain_text_message_for_email[-]
4.00s setup    saleor/plugins/tests/test_email_common.py::test_get_plain_text_message_for_email[<p>Hello World!</p>-Hello World!]
4.00s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_missing_smtp_values[config0-expected_fields0]
4.00s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_missing_smtp_values[config7-expected_fields7]
4.00s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_missing_smtp_values[config3-expected_fields3]
4.00s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_missing_smtp_values[config5-expected_fields5]
4.00s setup    saleor/plugins/tests/test_email_common.py::test_get_product_image_thumbnail_image_missing
3.99s setup    saleor/plugins/tests/test_email_common.py::test_send_email
3.98s setup    saleor/plugins/tests/test_email_common.py::test_get_product_image_thumbnail_simulate_json_dump_and_load
3.97s setup    saleor/plugins/tests/test_email_common.py::test_get_plain_text_message_for_email[<html><head><style type="text/css">#outlook a { padding:0; }body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }p { display:block;margin:13px 0; }</style></head><body><p>Hello World!</p></body></html>-Hello World!]
3.87s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_bad_email[@]
3.83s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_correct_email
3.76s setup    saleor/plugins/tests/test_email_common.py::test_get_plain_text_message_for_email[Hello World!-Hello World!]
3.75s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_missing_smtp_values[config2-expected_fields2]
3.75s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_backend_raises
3.75s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_missing_smtp_values[config1-expected_fields1]
3.65s setup    saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_bad_email[almost_correct_email@]
0.02s call     saleor/plugins/tests/test_email_common.py::test_validate_default_email_configuration_bad_email[almost_correct_email@]

(45 durations < 0.005s hidden.  Use -vv to show these durations.)
real 94.75
user 4.51
sys 0.20
```


<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
