### PR TITLE
Fix uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ exclude-newer = "3 weeks"
 # setuptools = "2026-04-07T14:30:00Z"
 django = "2026-06-03T13:03:35Z" # https://pypi.org/pypi/django/5.2.15/json
 pyjwt = "2026-05-21T19:54:36" # https://github.com/jpadilla/pyjwt/releases/tag/2.13.0
-idna = "2026-05-12T22:45:57" # https://github.com/advisories/GHSA-65pc-fj4g-8rjx/
+idna = "2026-05-12T22:45:57Z" # https://github.com/advisories/GHSA-65pc-fj4g-8rjx/
 
 [tool.deptry]
 extend_exclude = [ "conftest\\.py", ".*/conftest\\.py", ".*/tests/.*" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ exclude-newer = "3 weeks"
 # To customize on a per-package basis, for example you can do this:
 # setuptools = "2026-04-07T14:30:00Z"
 django = "2026-06-03T13:03:35Z" # https://pypi.org/pypi/django/5.2.15/json
-pyjwt = "2026-05-21T19:54:36" # https://github.com/jpadilla/pyjwt/releases/tag/2.13.0
+pyjwt = "2026-05-21T19:54:36Z" # https://github.com/jpadilla/pyjwt/releases/tag/2.13.0
 idna = "2026-05-12T22:45:57Z" # https://github.com/advisories/GHSA-65pc-fj4g-8rjx/
 
 [tool.deptry]

--- a/uv.lock
+++ b/uv.lock
@@ -13,9 +13,9 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P3W"
 
 [options.exclude-newer-package]
-pyjwt = "2026-05-22T00:00:00Z"
+pyjwt = "2026-05-21T22:00:00Z"
 django = "2026-06-03T13:03:35Z"
-idna = "2026-05-13T00:00:00Z"
+idna = "2026-05-12T22:45:57Z"
 
 [[package]]
 name = "amqp"

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P3W"
 
 [options.exclude-newer-package]
-pyjwt = "2026-05-21T22:00:00Z"
+pyjwt = "2026-05-21T19:54:36Z"
 django = "2026-06-03T13:03:35Z"
 idna = "2026-05-12T22:45:57Z"
 


### PR DESCRIPTION
```
uv sync
Resolving despite existing lockfile due to change of exclude newer timestamp from `2026-05-13T00:00:00Z` to `2026-05-12T22:00:00Z` for package `idna`
  × No solution found when resolving dependencies for split (markers: python_full_version == '3.12.*' and platform_python_implementation != 'PyPy'):
  ╰─▶ Because idna==3.15 was published after the exclude newer time and only idna<=3.14 is available, we can conclude that idna>=3.15 cannot be used.
      And because your project depends on idna>=3.15, we can conclude that your project's requirements are unsatisfiable.

hint: `idna` was filtered by `exclude-newer-package` to only include packages uploaded before 2026-05-12T22:00:00Z. The latest version satisfying the requirement is v3.18, published at 2026-06-02T14:34:06.319Z. Consider removing the setting or updating it to a later date.%   
```

This PR fixes installation by fixing timestamp