### PR TITLE
fix(build): missing timezone in uv cooldowns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,8 +195,8 @@ exclude-newer = "3 weeks"
 # To customize on a per-package basis, for example you can do this:
 # setuptools = "2026-04-07T14:30:00Z"
 django = "2026-06-03T13:03:35Z" # https://pypi.org/pypi/django/5.2.15/json
-pyjwt = "2026-05-21T19:54:36" # https://github.com/jpadilla/pyjwt/releases/tag/2.13.0
-idna = "2026-05-12T22:45:57" # https://github.com/advisories/GHSA-65pc-fj4g-8rjx/
+pyjwt = "2026-05-21T19:54:36Z" # https://github.com/jpadilla/pyjwt/releases/tag/2.13.0
+idna = "2026-05-12T22:45:57Z" # https://github.com/advisories/GHSA-65pc-fj4g-8rjx/
 
 [tool.deptry]
 extend_exclude = [ "conftest\\.py", ".*/conftest\\.py", ".*/tests/.*" ]

--- a/uv.lock
+++ b/uv.lock
@@ -13,9 +13,9 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P3W"
 
 [options.exclude-newer-package]
-pyjwt = "2026-05-22T00:00:00Z"
+pyjwt = "2026-05-21T19:54:36Z"
 django = "2026-06-03T13:03:35Z"
-idna = "2026-05-13T00:00:00Z"
+idna = "2026-05-12T22:45:57Z"
 
 [[package]]
 name = "adyen"


### PR DESCRIPTION
Ports the fixes from https://github.com/saleor/saleor/commit/c0a1ccab0ea78c161f82a61888183005626c5f7b which fixes `uv` using the local timezone instead of UTC due to missing `Z` at the end of the timestamps



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
