### PR TITLE
Release 3.23.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.23.8",
+  "version": "3.23.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.23.8",
+      "version": "3.23.9",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.23.8",
+  "version": "3.23.9",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.23.8"
+version = "3.23.9"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,7 +1,7 @@
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.23.8"
+__version__ = "3.23.9"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.23.8"
+version = "3.23.9"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
* Release 3.23.9 (b961b2ade6)
* Fix uv (#19300) (187e9e68c7)
* fix(devcontainer): outdated dashboard version (#19301) (1e9388b47a)
* Skip JWT decode probe for opaque OIDC access tokens (#19286) (#19299) (ec94ba959e)
* Fix password login mode stripping staff access from third-party tokens (#19298) (688c1f056c)
* [3.23] Add support for editorJS table syntax (#19281) (a01807d1b2)
