### PR TITLE
Ensure CheckoutDeliveries are deleted before deleting Checkouts

### DIFF
--- a/saleor/core/management/commands/clearorders.py
+++ b/saleor/core/management/commands/clearorders.py
@@ -8,7 +8,12 @@ configuration, such as: warehouses, shipping zones, staff accounts, plugin confi
 from django.core.management.base import BaseCommand
 
 from ....account.models import Address, CustomerEvent, CustomerNote, User
-from ....checkout.models import Checkout, CheckoutLine, CheckoutMetadata
+from ....checkout.models import (
+    Checkout,
+    CheckoutDelivery,
+    CheckoutLine,
+    CheckoutMetadata,
+)
 from ....discount.models import (
     CheckoutDiscount,
     CheckoutLineDiscount,
@@ -89,6 +94,9 @@ class Command(BaseCommand):
 
         checkout_lines = CheckoutLine.objects.all()
         checkout_lines._raw_delete(checkout_lines.db)
+
+        checkout_deliveries = CheckoutDelivery.objects.all()
+        checkout_deliveries._raw_delete(checkout_deliveries.db)
 
         checkout = Checkout.objects.all()
         checkout._raw_delete(checkout.db)

--- a/saleor/core/tests/commands/test_clearorders.py
+++ b/saleor/core/tests/commands/test_clearorders.py
@@ -1,0 +1,19 @@
+import pytest
+from django.core.management import call_command
+
+from ....checkout.models import Checkout, CheckoutDelivery
+
+
+@pytest.mark.django_db
+def test_delete_checkouts_with_checkout_delivery(checkout, checkout_delivery):
+    # given
+    delivery = checkout_delivery(checkout)
+    assert Checkout.objects.filter(pk=checkout.pk).exists()
+    assert CheckoutDelivery.objects.filter(pk=delivery.pk).exists()
+
+    # when
+    call_command("clearorders")
+
+    # then
+    assert not Checkout.objects.filter(pk=checkout.pk).exists()
+    assert not CheckoutDelivery.objects.filter(pk=delivery.pk).exists()


### PR DESCRIPTION
To be backported to `3.23`.

The command would fail if it attempted to remove `Checkout` that is referenced by `CheckoutDelivery`.