### PR TITLE
Remove deprecated checkoutId input from checkout address update mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
   From Saleor 3.24, this app installation with `MANAGE_APPS` permission will be rejected.
   To safely upgrade, ensure that all installed apps do not have this permission.
 - Bulk delete mutations now limit the number of `ids` per call (default 100, configurable via the `BULK_DELETE_LIMIT` env var). Exceeding the limit returns an `INVALID` error. This applies to all bulk delete mutations, including `productBulkDelete`, `productVariantBulkDelete`, `categoryBulkDelete`, `collectionBulkDelete`, `productTypeBulkDelete`, `productMediaBulkDelete`, `attributeBulkDelete`, `attributeValueBulkDelete`, `customerBulkDelete`, `staffBulkDelete`, `pageBulkDelete`, `pageTypeBulkDelete`, `menuBulkDelete`, `menuItemBulkDelete`, `giftCardBulkDelete`, `saleBulkDelete`, `voucherBulkDelete`, `promotionBulkDelete`, `shippingPriceBulkDelete`, `shippingZoneBulkDelete`, `draftOrderBulkDelete`, and `draftOrderLinesBulkDelete`.
+- Removed the deprecated `checkoutId` input argument from the `checkoutShippingAddressUpdate` and `checkoutBillingAddressUpdate` mutations. Use the `id` argument instead.
 
 ### GraphQL API
 

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -33,12 +33,6 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
             description=f"Checkout token.{DEPRECATED_IN_3X_INPUT} Use `id` instead.",
             required=False,
         )
-        checkout_id = graphene.ID(
-            required=False,
-            description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use `id` instead."
-            ),
-        )
         billing_address = AddressInput(
             required=True, description="The billing address of the checkout."
         )
@@ -81,11 +75,10 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
         billing_address,
         save_address,
         validation_rules=None,
-        checkout_id=None,
         token=None,
         id=None,
     ):
-        checkout = get_checkout(cls, info, checkout_id=checkout_id, token=token, id=id)
+        checkout = get_checkout(cls, info, token=token, id=id)
 
         address_validation_rules = validation_rules or {}
         billing_address = cls.validate_address(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -55,12 +55,6 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
             description=f"Checkout token.{DEPRECATED_IN_3X_INPUT} Use `id` instead.",
             required=False,
         )
-        checkout_id = graphene.ID(
-            required=False,
-            description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use `id` instead."
-            ),
-        )
         shipping_address = AddressInput(
             required=True,
             description="The mailing address to where the checkout will be shipped.",
@@ -133,14 +127,12 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
         shipping_address,
         save_address,
         validation_rules=None,
-        checkout_id=None,
         token=None,
         id=None,
     ):
         checkout = get_checkout(
             cls,
             info,
-            checkout_id=checkout_id,
             token=token,
             id=id,
             qs=models.Checkout.objects.prefetch_related(

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_billing_address_update.py
@@ -5,9 +5,8 @@ from ....tests.utils import get_graphql_content
 
 MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE = """
     mutation checkoutBillingAddressUpdate(
-            $checkoutId: ID, $token: UUID, $id: ID, $billingAddress: AddressInput!) {
+            $token: UUID, $id: ID, $billingAddress: AddressInput!) {
         checkoutBillingAddressUpdate(
-                checkoutId: $checkoutId,
                 token: $token,
                 id: $id
                 billingAddress: $billingAddress
@@ -36,7 +35,7 @@ def test_checkout_billing_address_update_by_id(
     query = MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE
     billing_address = graphql_address_data
 
-    variables = {"checkoutId": checkout_id, "billingAddress": billing_address}
+    variables = {"id": checkout_id, "billingAddress": billing_address}
 
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -120,7 +119,7 @@ def test_checkout_billing_address_update_both_token_and_id_given(
     variables = {
         "billingAddress": billing_address,
         "token": checkout_with_item.token,
-        "checkoutId": checkout_id,
+        "id": checkout_id,
     }
 
     response = user_api_client.post_graphql(query, variables)

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_address_update.py
@@ -10,9 +10,9 @@ from ...mutations.utils import mark_checkout_deliveries_as_stale_if_needed
 
 MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE = """
     mutation checkoutShippingAddressUpdate(
-            $checkoutId: ID, $token: UUID, $shippingAddress: AddressInput!) {
+            $id: ID, $token: UUID, $shippingAddress: AddressInput!) {
         checkoutShippingAddressUpdate(
-                checkoutId: $checkoutId,
+                id: $id,
                 token: $token,
                 shippingAddress: $shippingAddress
         ) {
@@ -45,7 +45,7 @@ def test_checkout_shipping_address_update_by_id(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
 
     shipping_address = graphql_address_data
-    variables = {"checkoutId": checkout_id, "shippingAddress": shipping_address}
+    variables = {"id": checkout_id, "shippingAddress": shipping_address}
 
     response = user_api_client.post_graphql(
         MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE, variables
@@ -150,7 +150,7 @@ def test_checkout_shipping_address_update_both_token_and_id_given(
 
     shipping_address = graphql_address_data
     variables = {
-        "checkoutId": checkout_id,
+        "id": checkout_id,
         "token": checkout.token,
         "shippingAddress": shipping_address,
     }

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -17,7 +17,6 @@ from ..utils import assert_address_data
 
 MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE = """
     mutation checkoutBillingAddressUpdate(
-            $checkoutId: ID,
             $id: ID,
             $billingAddress: AddressInput!
             $saveAddress: Boolean
@@ -25,7 +24,6 @@ MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE = """
         ) {
         checkoutBillingAddressUpdate(
                 id: $id,
-                checkoutId: $checkoutId,
                 billingAddress: $billingAddress
                 validationRules: $validationRules
                 saveAddress: $saveAddress

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20673,9 +20673,6 @@ type Mutation {
     """The billing address of the checkout."""
     billingAddress: AddressInput!
 
-    """The ID of the checkout."""
-    checkoutId: ID @deprecated(reason: "Use `id` instead.")
-
     """The checkout's ID."""
     id: ID
 
@@ -20977,9 +20974,6 @@ type Mutation {
   - CHECKOUT_UPDATED (async): A checkout was updated.
   """
   checkoutShippingAddressUpdate(
-    """The ID of the checkout."""
-    checkoutId: ID @deprecated(reason: "Use `id` instead.")
-
     """The checkout's ID."""
     id: ID
 


### PR DESCRIPTION
Removed the deprecated `checkoutId` input argument from the `checkoutShippingAddressUpdate` and `checkoutBillingAddressUpdate` mutations. The non-deprecated `id` argument should be used instead.

- Dropped the `checkout_id` argument and parameter from both mutations (the shared `get_checkout` helper still supports it for other mutations).
- Migrated tests that relied on `checkoutId` to use `id`.
- Regenerated the GraphQL schema.
- Added a breaking-change changelog entry.


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [x] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
