### PR TITLE
Add translation field on AssignedSwatchAttributeValue

### DIFF
--- a/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
+++ b/saleor/graphql/attribute/tests/queries/test_selected_attribute.py
@@ -1558,6 +1558,58 @@ def test_assigned_swatch_file_attribute(staff_api_client, page, swatch_attribute
     assert attr_value_data["file"]["contentType"] == attr_value.content_type
 
 
+ASSIGNED_SWATCH_ATTRIBUTE_TRANSLATION_QUERY = """
+query PageQuery($id: ID) {
+  page(id: $id) {
+    assignedAttributes(limit:10) {
+      ... on AssignedSwatchAttribute {
+        value {
+          name
+          slug
+          translation(languageCode: FR)
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_assigned_swatch_attribute_translation(
+    staff_api_client,
+    page,
+    swatch_attribute,
+):
+    # given
+    swatch_attribute.type = AttributeType.PAGE_TYPE
+    swatch_attribute.save()
+
+    page_type = page.page_type
+    page_type.page_attributes.set([swatch_attribute])
+
+    attr_value = swatch_attribute.values.first()
+    translation = AttributeValueTranslation.objects.create(
+        language_code="fr",
+        attribute_value=attr_value,
+        name="French Red",
+    )
+
+    associate_attribute_values_to_instance(page, {swatch_attribute.pk: [attr_value]})
+
+    # when
+    response = staff_api_client.post_graphql(
+        ASSIGNED_SWATCH_ATTRIBUTE_TRANSLATION_QUERY,
+        variables={"id": graphene.Node.to_global_id("Page", page.pk)},
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    assert len(content["data"]["page"]["assignedAttributes"]) == 1
+    attr_value_data = content["data"]["page"]["assignedAttributes"][0]["value"]
+    assert attr_value_data["translation"] == translation.name
+
+
 ASSIGNED_BOOLEAN_ATTRIBUTE_QUERY = """
 query PageQuery($id: ID) {
   page(id: $id) {

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -1496,6 +1496,14 @@ class AssignedSwatchAttributeValue(BaseObjectType):
     file = graphene.Field(
         File, description="File associated with the attribute.", required=False
     )
+    translation = graphene.String(
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            required=True,
+        ),
+        description="Translation of the name." + ADDED_IN_322,
+        required=False,
+    )
 
     @staticmethod
     def resolve_hex_color(
@@ -1510,6 +1518,16 @@ class AssignedSwatchAttributeValue(BaseObjectType):
         if not root.file_url:
             return None
         return File(url=root.file_url, content_type=root.content_type)
+
+    @staticmethod
+    def resolve_translation(
+        root: models.AttributeValue, info: ResolveInfo, *, language_code
+    ) -> Promise[str | None] | None:
+        return (
+            AttributeValueTranslationByIdAndLanguageCodeLoader(info.context)
+            .load((root.id, language_code))
+            .then(lambda translation: translation.name if translation else None)
+        )
 
     class Meta:
         description = "Represents a single swatch value." + ADDED_IN_322

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -37934,6 +37934,13 @@ type AssignedSwatchAttributeValue @doc(category: "Attributes") {
 
   """File associated with the attribute."""
   file: File
+
+  """
+  Translation of the name.
+  
+  Added in Saleor 3.22.
+  """
+  translation(languageCode: LanguageCodeEnum!): String
 }
 
 """


### PR DESCRIPTION
Expose a `translation` field on the `AssignedSwatchAttributeValue` GraphQL type so clients can fetch the translated swatch value name, matching the pattern already used by `AssignedChoiceAttributeValue`.

The resolver loads the translation via
AttributeValueTranslationByIdAndLanguageCodeLoader and returns the translated name. Field is tagged ADDED_IN_322. Schema regenerated and a translation test added for the swatch attribute.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
