### PR TITLE
ci: upgrade graphql-inspector action to v5.0.21 for Node 24

### DIFF
--- a/.github/workflows/graphql-inspector.yml
+++ b/.github/workflows/graphql-inspector.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: graphql-hive/graphql-inspector@84c610fac649e0379643da772e77e775c6aeaf56 # release-1769448022768
+      - uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
         with:
           schema: "${{ github.event.pull_request.base.sha }}:saleor/graphql/schema.graphql"


### PR DESCRIPTION
GitHub deprecated Node 20 on its Actions runners and now executes node20-declared actions on Node 24 by default. The previously pinned graphql-inspector 5.0.19 (84c610fa) declares `runs.using: node20` and its bundle crashes on Node 24 with a TypeError from the legacy `global.navigator` assignment, failing the GraphQL Inspector check.

Bump the pin to @graphql-inspector/action@5.0.21 (8733c105), which sets `runs.using: node24` and regenerates the bundle to fix Node 24 compatibility.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

https://github.com/graphql-hive/graphql-inspector/releases/tag/release-1781692943029