### PR TITLE
ci: upgrade graphql-inspector action to v5.0.21 for Node 24

### DIFF
--- a/.github/workflows/graphql-inspector.yml
+++ b/.github/workflows/graphql-inspector.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: kamilkisiela/graphql-inspector@v3.4.0
+      - uses: graphql-hive/graphql-inspector@8733c10560f98b868d3eb4db1325c8edf64936b3 # @graphql-inspector/action@5.0.21
         with:
           schema: "3.22:saleor/graphql/schema.graphql"


### PR DESCRIPTION
GitHub deprecated Node 20 on its Actions runners and now executes node20-declared actions on Node 24 by default. The previously pinned graphql-inspector 5.0.19 (84c610fa) declares `runs.using: node20` and its bundle crashes on Node 24 with a TypeError from the legacy `global.navigator` assignment, failing the GraphQL Inspector check.

Bump the pin to @graphql-inspector/action@5.0.21 (8733c105), which sets `runs.using: node24` and regenerates the bundle to fix Node 24 compatibility.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

# Conflicts:
#	.github/workflows/graphql-inspector.yml

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
