### PR TITLE
ci: pin changelog-enforcer action to v3.7.0

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -15,6 +15,6 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: dangoslen/changelog-enforcer@83e1e992a730c447cca6e9ecf8e7b21cb9a7463e
+    - uses: dangoslen/changelog-enforcer@8b5e9dc3121363bb7c0115f8533404d92af382de # v3.7.0
       with:
         skipLabels: "skip changelog,dependencies,bot"


### PR DESCRIPTION
GitHub Actions is deprecating the Node 20 runtime, so actions still running on it need to be upgraded. Bump dangoslen/changelog-enforcer to commit 8b5e9dc (v3.7.0), which runs on the newer Node runtime, and annotate the pinned SHA with its version tag for clarity.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
