### PR TITLE
fix: prevent transaction mutations failing when checkout is concurrently deleted

### DIFF
--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1683,7 +1683,16 @@ def get_source_object(
 
 def mark_checkout_search_index_dirty(checkout: Checkout):
     checkout.search_index_dirty = True
-    checkout.safe_update(update_fields=["search_index_dirty"])
+    try:
+        checkout.safe_update(update_fields=["search_index_dirty"])
+    except Checkout.DoesNotExist:
+        # The checkout was concurrently deleted (e.g. completed into an order or
+        # expired). Marking the search index as dirty is a best-effort operation, so
+        # there is nothing left to re-index and the failure can be safely ignored.
+        logger.info(
+            "Skipped marking checkout %s search index as dirty: checkout no longer exists.",
+            checkout.pk,
+        )
 
 
 def _prepare_manual_event(
@@ -1943,8 +1952,7 @@ def handle_transaction_initialize_session(
         )
     if isinstance(source_object, Checkout):
         # new transaction created, so we need to mark the checkout search index as dirty
-        source_object.search_index_dirty = True
-        source_object.safe_update(update_fields=["search_index_dirty"])
+        mark_checkout_search_index_dirty(source_object)
     data_to_return = response_data.get("data") if response_data else None
     return created_event.transaction, created_event, data_to_return
 
@@ -1985,8 +1993,7 @@ def handle_transaction_process_session(
         created_event, source_object, app.identifier
     )
     if isinstance(source_object, Checkout):
-        source_object.search_index_dirty = True
-        source_object.safe_update(update_fields=["search_index_dirty"])
+        mark_checkout_search_index_dirty(source_object)
     data_to_return = response_data.get("data") if response_data else None
     return created_event, data_to_return
 


### PR DESCRIPTION
> [!NOTE]
> This is 3.23 backport of #19332

The checkout search-index feature added in 3.23 (#18767) marks a checkout's search index as dirty at the end of the transaction flow via `Checkout.safe_update`. When the checkout row is concurrently deleted (e.g. another request completes it into an order through `delete_checkouts`), `safe_update` raises `Checkout.DoesNotExist`. This propagated up as an unhandled GraphQL error in `transactionProcess`/`transactionInitialize`, even though the transaction event had already been created and persisted.

This is a regression vs. 3.22, where this best-effort indexing step did not exist and the mutation succeeded.

- Route the duplicated `search_index_dirty` + `safe_update` blocks in `handle_transaction_initialize_session` and `handle_transaction_process_session` through the existing `mark_checkout_search_index_dirty` helper.
- Make `mark_checkout_search_index_dirty` resilient to a concurrently deleted checkout: swallow `Checkout.DoesNotExist` (logging at info level), since there is nothing left to re-index.