### PR TITLE
ci: pin actions/github-script to commit SHA

### DIFF
--- a/.github/workflows/create-tag-with-release-pr.yml
+++ b/.github/workflows/create-tag-with-release-pr.yml
@@ -53,7 +53,7 @@ jobs:
             echo "IS_LATEST=false" >> $GITHUB_OUTPUT
           fi
       - name: Create tag
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           VERSION: ${{ steps.set-version.outputs.VERSION }}
         with:

--- a/.github/workflows/test-env-cleanup-cron.yml
+++ b/.github/workflows/test-env-cleanup-cron.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Get branches from open PRs with "test deployment" label and slugify
         id: get-branches-and-slugify
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // 1. Get all open PRs - pagination is needed or otherwise we would retrieve only first 30

--- a/.github/workflows/test-env-cleanup.yml
+++ b/.github/workflows/test-env-cleanup.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Generate GITHUB_HEAD_REF_SLUG_URL
         id: slugify-branch-name
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           result-encoding: string # by default results are JSON-encoded
           script: |

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Generate GITHUB_HEAD_REF_SLUG_URL
         id: slugify-branch-name
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           result-encoding: string # by default results are JSON-encoded
           script: |

--- a/.github/workflows/test-migrations-compatibility.yml
+++ b/.github/workflows/test-migrations-compatibility.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           apt-get install -y libpq-dev
 
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v6.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
Pin all remaining `actions/github-script@v9` references to the v9.0.0 commit SHA across the release and test-env workflows, and correct the `astral-sh/setup-uv` version comment to v8.1.0.
