### PR TITLE
Log error when sync webhook is triggered inside a db transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other changes
 
+- Log an error when a sync webhook is triggered inside a database transaction, to help locate callers that need to be moved outside of transactions - #15138 by @ayesha-waris
+
 #### Search improvements
 
 ### Deprecations

--- a/saleor/webhook/transport/synchronous/tests/test_transport.py
+++ b/saleor/webhook/transport/synchronous/tests/test_transport.py
@@ -12,7 +12,7 @@ from ...metrics import (
     METRIC_EXTERNAL_REQUEST_DURATION,
 )
 from ...utils import WebhookResponse
-from ..transport import _send_webhook_request_sync
+from ..transport import _send_webhook_request_sync, send_webhook_request_sync
 
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_using_http")
@@ -269,3 +269,58 @@ def test_send_webhook_request_sync_record_external_request_with_unknown_webhook_
     assert external_request_content_length.attributes == attributes
     assert external_request_content_length.count == 1
     assert external_request_content_length.sum == payload_size
+
+
+@patch("saleor.webhook.transport.synchronous.transport._send_webhook_request_sync")
+@patch("saleor.webhook.transport.synchronous.transport.transaction.get_connection")
+def test_send_webhook_request_sync_logs_error_when_called_inside_transaction(
+    mock_get_connection,
+    mock_send_webhook_request_sync,
+    event_delivery_payload_in_database,
+    caplog,
+):
+    # given
+    mock_get_connection.return_value.in_atomic_block = True
+    response = MagicMock(spec=WebhookResponse)
+    response.status = EventDeliveryStatus.SUCCESS
+    response_data = {"key": "value"}
+    mock_send_webhook_request_sync.return_value = (response, response_data)
+    delivery = event_delivery_payload_in_database
+
+    # when
+    result = send_webhook_request_sync(delivery)
+
+    # then
+    mock_send_webhook_request_sync.assert_called_once()
+    assert result == response_data
+    error_records = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert len(error_records) == 1
+    assert error_records[0].message == (
+        f"Sync webhook was triggered inside a database transaction: {delivery.event_type}"
+    )
+
+
+@patch("saleor.webhook.transport.synchronous.transport._send_webhook_request_sync")
+@patch("saleor.webhook.transport.synchronous.transport.transaction.get_connection")
+def test_send_webhook_request_sync_no_error_when_called_outside_transaction(
+    mock_get_connection,
+    mock_send_webhook_request_sync,
+    event_delivery_payload_in_database,
+    caplog,
+):
+    # given
+    mock_get_connection.return_value.in_atomic_block = False
+    response = MagicMock(spec=WebhookResponse)
+    response.status = EventDeliveryStatus.SUCCESS
+    response_data = {"key": "value"}
+    mock_send_webhook_request_sync.return_value = (response, response_data)
+    delivery = event_delivery_payload_in_database
+
+    # when
+    result = send_webhook_request_sync(delivery)
+
+    # then
+    mock_send_webhook_request_sync.assert_called_once()
+    assert result == response_data
+    error_records = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert len(error_records) == 0

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -195,6 +195,17 @@ def _send_webhook_request_sync(
 def send_webhook_request_sync(
     delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
 ) -> dict[Any, Any] | None:
+    if transaction.get_connection().in_atomic_block:
+        # Sync webhooks should be triggered outside of any database transaction.
+        # Running them inside one keeps the DB connection open for the duration of an
+        # external HTTP request, which can exhaust the connection pool and lead to
+        # deadlocks. The stack trace pinpoints the call site so the offending caller can
+        # be moved out of the transaction.
+        logger.error(
+            "Sync webhook was triggered inside a database transaction: %s",
+            delivery.event_type,
+            stack_info=True,
+        )
     response, response_data = _send_webhook_request_sync(delivery, timeout)
     return response_data if response.status == EventDeliveryStatus.SUCCESS else None
 


### PR DESCRIPTION
## What

Adds a `logger.error` that fires when a synchronous webhook is triggered inside an open database transaction.

Closes #15138.

## Why

Sync webhooks must be triggered **outside** of any database transaction. Running them inside one holds the DB connection open for the duration of an external HTTP request, which can exhaust the connection pool and lead to deadlocks. Today there is no signal when this happens, so problematic call sites are hard to find.

This mirrors the existing check in the async transport (`saleor/webhook/transport/asynchronous/transport.py`), which already warns when async webhooks are triggered inside a transaction.

## How

- The check lives in `send_webhook_request_sync`, the single generic entry point all sync webhook sends funnel through, so it covers existing and future sync webhooks without per-event wiring.
- It logs at `error` level (per the issue) and passes `stack_info=True` so the log pinpoints the offending call site.

> Note on the previous attempt (#17617): the earlier review suggested `logger.exception`. Since this code path runs outside any `except` block, `logger.exception` would attach no traceback (`exc_info` is empty). `logger.error(..., stack_info=True)` keeps the requested `error` level while still capturing the call-site stack, which is what's actually needed to locate callers. The original PR also targeted `trigger_webhook_sync`, which has since been refactored away; `send_webhook_request_sync` is its current equivalent.

## Tests

Added two tests in `saleor/webhook/transport/synchronous/tests/test_transport.py`:
- logs the error (once) when called inside a transaction, and still performs the send;
- logs nothing when called outside a transaction.