### PR TITLE
Fix productVariantBulkUpdate 500 error on duplicate channel listing create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Removed the deprecated `variant` field from the `Product` type. Use the top-level `variant` query instead.
 - Removed the deprecated `note` field from the `Checkout` type. Use `customerNote` instead.
 - Removed the deprecated `isDigital` field from the `ProductType` type, the `isDigital` input from `ProductTypeInput`, the `DIGITAL` value from the `ProductTypeEnum` filter, and the `DIGITAL` value from `ProductTypeSortField`. These had no effect; use metadata or attributes instead (or `SHIPPING_REQUIRED` for sorting).
+- Fixed `productVariantBulkUpdate` returning a 500 error when `channelListings.create` targeted a channel the variant was already listed in. The mutation now returns a `DUPLICATED_INPUT_ITEM` error recommending the `update` field, and respects the selected `errorPolicy` - #19355 by @ayesha-waris
 
 ### Webhooks
 

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -394,7 +394,17 @@ class ProductVariantBulkCreate(BaseMutation):
         variant_index,
         index_error_map,
         path_prefix="channelListings",
+        existing_channel_ids=None,
     ):
+        """Validate channel listings to create for a variant.
+
+        ``existing_channel_ids`` holds the channel global IDs the variant is
+        already listed on (only relevant when updating). Listings targeting one
+        of them produce a ``DUPLICATED_INPUT_ITEM`` error and are dropped from
+        the result, so the unique ``(variant, channel)`` constraint never raises
+        an ``IntegrityError`` at insert time.
+        """
+        existing_channel_ids = existing_channel_ids or set()
         channel_ids = [
             channel_listing["channel_id"] for channel_listing in channel_listings
         ]
@@ -432,6 +442,22 @@ class ProductVariantBulkCreate(BaseMutation):
         for listing_index, channel_listing in enumerate(channel_listings):
             channel_id = channel_listing["channel_id"]
             errors_count_before_prices = len(index_error_map[variant_index])
+
+            if channel_id in existing_channel_ids:
+                index_error_map[variant_index].append(
+                    ProductVariantBulkError(
+                        field="channelId",
+                        path=f"{path_prefix}.{listing_index}.channelId",
+                        message=(
+                            "Channel listing already exists for this variant. "
+                            "Use the `update` field to modify an existing "
+                            "channel listing."
+                        ),
+                        code=ProductVariantBulkErrorCode.DUPLICATED_INPUT_ITEM.value,
+                        channels=[channel_id],
+                    )
+                )
+                continue
 
             if channel_id in channels_not_assigned_to_product:
                 code = ProductVariantBulkErrorCode.PRODUCT_NOT_ASSIGNED_TO_CHANNEL.value

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -228,50 +228,23 @@ class ProductVariantBulkUpdate(BaseMutation):
         index_error_map,
     ):
         if listings_data := cleaned_input["channel_listings"].get("create"):
-            used_channels = defaultdict(set)
-            for listing in listings_global_id_to_instance_map.values():
-                channel_global_id = graphene.Node.to_global_id(
-                    "Channel", listing.channel_id
-                )
-                used_channels[channel_global_id].add(listing.variant_id)
-
             variant = cleaned_input["id"]
-            existing_channels = set()
-            for listing_index, listing_data in enumerate(listings_data):
-                channel_id = listing_data["channel_id"]
-                if variant.id in used_channels.get(channel_id, set()):
-                    existing_channels.add(channel_id)
-                    index_error_map[variant_index].append(
-                        ProductVariantBulkError(
-                            field="channelId",
-                            path=f"channelListings.create.{listing_index}.channelId",
-                            message=(
-                                "Channel listing already exists for this variant. "
-                                "Use the `update` field to modify an existing "
-                                "channel listing."
-                            ),
-                            code=ProductVariantBulkErrorCode.DUPLICATED_INPUT_ITEM.value,
-                            channels=[channel_id],
-                        )
-                    )
-
-            # Pass the full list to the create validator so its reported error
-            # paths stay aligned with the input indices, then drop listings that
-            # already exist for this variant so they are not re-created (the unique
-            # (variant, channel) constraint would otherwise raise an IntegrityError).
-            cleaned_listings = ProductVariantBulkCreate.clean_channel_listings(
-                listings_data,
-                product_channel_global_id_to_instance_map,
-                None,
-                variant_index,
-                index_error_map,
-                "channelListings.create",
+            existing_channel_ids = {
+                graphene.Node.to_global_id("Channel", listing.channel_id)
+                for listing in listings_global_id_to_instance_map.values()
+                if listing.variant_id == variant.id
+            }
+            cleaned_input["channel_listings"]["create"] = (
+                ProductVariantBulkCreate.clean_channel_listings(
+                    listings_data,
+                    product_channel_global_id_to_instance_map,
+                    None,
+                    variant_index,
+                    index_error_map,
+                    "channelListings.create",
+                    existing_channel_ids=existing_channel_ids,
+                )
             )
-            cleaned_input["channel_listings"]["create"] = [
-                listing
-                for listing in cleaned_listings
-                if listing["channel_id"] not in existing_channels
-            ]
         if listings_data := cleaned_input["channel_listings"].get("update"):
             listings_to_update = []
             for index, listing_data in enumerate(listings_data):

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -228,9 +228,37 @@ class ProductVariantBulkUpdate(BaseMutation):
         index_error_map,
     ):
         if listings_data := cleaned_input["channel_listings"].get("create"):
+            used_channels = defaultdict(list)
+            for listing in listings_global_id_to_instance_map.values():
+                channel_global_id = graphene.Node.to_global_id(
+                    "Channel", listing.channel_id
+                )
+                used_channels[channel_global_id].append(listing.variant_id)
+
+            variant = cleaned_input["id"]
+            surviving_listings = []
+            for listing_index, listing_data in enumerate(listings_data):
+                channel_id = listing_data["channel_id"]
+                if variant.id in used_channels.get(channel_id, []):
+                    index_error_map[variant_index].append(
+                        ProductVariantBulkError(
+                            field="channelId",
+                            path=f"channelListings.create.{listing_index}.channelId",
+                            message=(
+                                "Channel listing already exists for this variant. "
+                                "Use the `update` field to modify an existing "
+                                "channel listing."
+                            ),
+                            code=ProductVariantBulkErrorCode.DUPLICATED_INPUT_ITEM.value,
+                            channels=[channel_id],
+                        )
+                    )
+                    continue
+                surviving_listings.append(listing_data)
+
             cleaned_input["channel_listings"]["create"] = (
                 ProductVariantBulkCreate.clean_channel_listings(
-                    listings_data,
+                    surviving_listings,
                     product_channel_global_id_to_instance_map,
                     None,
                     variant_index,

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -228,18 +228,19 @@ class ProductVariantBulkUpdate(BaseMutation):
         index_error_map,
     ):
         if listings_data := cleaned_input["channel_listings"].get("create"):
-            used_channels = defaultdict(list)
+            used_channels = defaultdict(set)
             for listing in listings_global_id_to_instance_map.values():
                 channel_global_id = graphene.Node.to_global_id(
                     "Channel", listing.channel_id
                 )
-                used_channels[channel_global_id].append(listing.variant_id)
+                used_channels[channel_global_id].add(listing.variant_id)
 
             variant = cleaned_input["id"]
-            surviving_listings = []
+            existing_channels = set()
             for listing_index, listing_data in enumerate(listings_data):
                 channel_id = listing_data["channel_id"]
-                if variant.id in used_channels.get(channel_id, []):
+                if variant.id in used_channels.get(channel_id, set()):
+                    existing_channels.add(channel_id)
                     index_error_map[variant_index].append(
                         ProductVariantBulkError(
                             field="channelId",
@@ -253,19 +254,24 @@ class ProductVariantBulkUpdate(BaseMutation):
                             channels=[channel_id],
                         )
                     )
-                    continue
-                surviving_listings.append(listing_data)
 
-            cleaned_input["channel_listings"]["create"] = (
-                ProductVariantBulkCreate.clean_channel_listings(
-                    surviving_listings,
-                    product_channel_global_id_to_instance_map,
-                    None,
-                    variant_index,
-                    index_error_map,
-                    "channelListings.create",
-                )
+            # Pass the full list to the create validator so its reported error
+            # paths stay aligned with the input indices, then drop listings that
+            # already exist for this variant so they are not re-created (the unique
+            # (variant, channel) constraint would otherwise raise an IntegrityError).
+            cleaned_listings = ProductVariantBulkCreate.clean_channel_listings(
+                listings_data,
+                product_channel_global_id_to_instance_map,
+                None,
+                variant_index,
+                index_error_map,
+                "channelListings.create",
             )
+            cleaned_input["channel_listings"]["create"] = [
+                listing
+                for listing in cleaned_listings
+                if listing["channel_id"] not in existing_channels
+            ]
         if listings_data := cleaned_input["channel_listings"].get("update"):
             listings_to_update = []
             for index, listing_data in enumerate(listings_data):

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -612,6 +612,77 @@ def test_product_variant_bulk_update_create_already_existing_channel_listing_err
         assert variant.name != new_name
 
 
+def test_product_variant_bulk_update_create_duplicate_and_invalid_channel_listing_error_paths(
+    staff_api_client,
+    variant,
+    permission_manage_products,
+    channel_USD,
+    channel_PLN,
+):
+    # given
+    # The variant is already listed on channel_USD, and its product is NOT
+    # assigned to channel_PLN. The `create` list mixes:
+    #   index 0 -> duplicate listing for channel_USD (caught by the new check)
+    #   index 1 -> a listing for channel_PLN (product not assigned to that channel)
+    # so two different input entries each produce an error, and their reported
+    # `path` indices must stay aligned with the input positions.
+    product = variant.product
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    assert variant.channel_listings.count() == 1
+    usd_global_id = graphene.Node.to_global_id("Channel", channel_USD.pk)
+    pln_global_id = graphene.Node.to_global_id("Channel", channel_PLN.pk)
+
+    variants = [
+        {
+            "id": variant_id,
+            "channelListings": {
+                "create": [
+                    {"price": 50.0, "channelId": usd_global_id},  # index 0: duplicate
+                    {
+                        "price": 20.0,
+                        "channelId": pln_global_id,
+                    },  # index 1: not assigned
+                ]
+            },
+        }
+    ]
+
+    variables = {"productId": product_id, "variants": variants}
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkUpdate"]
+
+    # then
+    errors = data["results"][0]["errors"]
+    assert len(errors) == 2
+
+    errors_by_code = {error["code"]: error for error in errors}
+
+    duplicate_error = errors_by_code[
+        ProductVariantBulkErrorCode.DUPLICATED_INPUT_ITEM.name
+    ]
+    assert duplicate_error["path"] == "channelListings.create.0.channelId"
+    assert duplicate_error["channels"] == [usd_global_id]
+
+    not_assigned_error = errors_by_code[
+        ProductVariantBulkErrorCode.PRODUCT_NOT_ASSIGNED_TO_CHANNEL.name
+    ]
+    # The entry was at input index 1; the reported path must keep that index even
+    # though the duplicate at index 0 was dropped before creation.
+    assert not_assigned_error["path"] == "channelListings.create.1.channelId"
+    assert not_assigned_error["channels"] == [pln_global_id]
+
+    assert data["count"] == 0
+    assert variant.channel_listings.count() == 1
+
+
 def test_product_variant_bulk_update_and_remove_stock(
     staff_api_client,
     variant_with_many_stocks,

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -474,6 +474,144 @@ def test_product_variant_bulk_update_create_already_existing_stock(
     assert errors[0]["warehouses"] == [warehouse_global_id]
 
 
+def test_product_variant_bulk_update_create_already_existing_channel_listing(
+    staff_api_client,
+    variant,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    product = variant.product
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    existing_listing = variant.channel_listings.get(channel=channel_USD)
+    existing_price = existing_listing.price_amount
+    assert variant.channel_listings.count() == 1
+    channel_global_id = graphene.Node.to_global_id("Channel", channel_USD.pk)
+
+    new_price = 50.0
+    variants = [
+        {
+            "id": variant_id,
+            "channelListings": {
+                "create": [
+                    {
+                        "price": new_price,
+                        "channelId": channel_global_id,
+                    }
+                ]
+            },
+        }
+    ]
+
+    variables = {"productId": product_id, "variants": variants}
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkUpdate"]
+
+    # then
+    errors = data["results"][0]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "channelId"
+    assert errors[0]["path"] == "channelListings.create.0.channelId"
+    assert errors[0]["code"] == ProductVariantBulkErrorCode.DUPLICATED_INPUT_ITEM.name
+    assert errors[0]["message"] == (
+        "Channel listing already exists for this variant. "
+        "Use the `update` field to modify an existing channel listing."
+    )
+    assert errors[0]["channels"] == [channel_global_id]
+    assert data["count"] == 0
+    assert variant.channel_listings.count() == 1
+    existing_listing.refresh_from_db()
+    assert existing_listing.price_amount == existing_price
+
+
+@pytest.mark.parametrize(
+    "error_policy",
+    [
+        ErrorPolicyEnum.REJECT_EVERYTHING.name,
+        ErrorPolicyEnum.REJECT_FAILED_ROWS.name,
+        ErrorPolicyEnum.IGNORE_FAILED.name,
+    ],
+)
+def test_product_variant_bulk_update_create_already_existing_channel_listing_error_policy(
+    error_policy,
+    staff_api_client,
+    variant,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    product = variant.product
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    existing_listing = variant.channel_listings.get(channel=channel_USD)
+    existing_price = existing_listing.price_amount
+    assert variant.channel_listings.count() == 1
+    channel_global_id = graphene.Node.to_global_id("Channel", channel_USD.pk)
+
+    new_name = "Updated variant name"
+    new_price = 50.0
+    variants = [
+        {
+            "id": variant_id,
+            "name": new_name,
+            "channelListings": {
+                "create": [
+                    {
+                        "price": new_price,
+                        "channelId": channel_global_id,
+                    }
+                ]
+            },
+        }
+    ]
+
+    variables = {
+        "productId": product_id,
+        "variants": variants,
+        "errorPolicy": error_policy,
+    }
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkUpdate"]
+
+    # then
+    errors = data["results"][0]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == ProductVariantBulkErrorCode.DUPLICATED_INPUT_ITEM.name
+
+    variant.refresh_from_db()
+    existing_listing.refresh_from_db()
+
+    # no duplicate channel listing is ever created
+    assert variant.channel_listings.count() == 1
+    assert existing_listing.price_amount == existing_price
+
+    if error_policy == ErrorPolicyEnum.IGNORE_FAILED.name:
+        # the variant is updated, only the offending listing entry is dropped
+        assert data["count"] == 1
+        assert data["results"][0]["productVariant"]["name"] == new_name
+        assert variant.name == new_name
+    else:
+        # REJECT_EVERYTHING / REJECT_FAILED_ROWS save nothing for the row
+        assert data["count"] == 0
+        assert not data["results"][0]["productVariant"]
+        assert variant.name != new_name
+
+
 def test_product_variant_bulk_update_and_remove_stock(
     staff_api_client,
     variant_with_many_stocks,


### PR DESCRIPTION
## What

`productVariantBulkUpdate` with a `channelListings.create` entry targeting a channel the variant is **already** listed in returned an HTTP **500**. The DB raised an `IntegrityError` from the unique `variant + channel` constraint, which was never caught and surfaced as a structured GraphQL error.

This PR makes the mutation return a structured per-row error instead of crashing.

## Why / How

The duplicate is now detected during the **clean phase**, mirroring how `clean_stocks` already handles duplicate warehouse stocks:

- For each row, channels in `channelListings.create` that the variant is already listed in produce a per-row `ProductVariantBulkError` with the existing `DUPLICATED_INPUT_ITEM` code, a message recommending the `update` field instead, and `channels=[channelId]`.
- It **reuses the already-fetched existing-listings map** — no new database queries are introduced.
- Surviving rows flow on to the existing channel-listing validator, so `errorPolicy` is respected end to end.

## Addressing prior review feedback (closed PR #17955)

The previous attempt (#17955) was closed after maintainer review (@maarcingebala) because it caught the `IntegrityError` at `bulk_create` time. That approach still crashed under `REJECT_EVERYTHING` — the failed insert aborted the surrounding transaction, so the whole operation broke rather than producing a clean per-row error.

This PR deliberately **validates in the clean phase rather than catching the `IntegrityError` at insert time**, so no failing write is ever attempted. As a result all three error policies behave correctly:

- **REJECT_EVERYTHING** — nothing is saved when any row has a duplicate listing.
- **REJECT_FAILED_ROWS** — the failing row is skipped; the rest are applied.
- **IGNORE_FAILED** — the variant is applied and only the offending duplicate listing is dropped.

## Tests

Two tests in `test_product_variant_bulk_update.py`:

- One asserts the error shape (code `DUPLICATED_INPUT_ITEM`, message recommending `update`, `channels=[channelId]`) and that no duplicate listing is created.
- One parametrized across all three error policies (`REJECT_EVERYTHING`, `REJECT_FAILED_ROWS`, `IGNORE_FAILED`) asserting the per-policy save behavior.

Closes #17899