### PR TITLE
Make OrderBulkCreateInput.status a required field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable, unreleased changes to this project will be documented in this file.
   To safely upgrade, ensure that all installed apps do not have this permission.
 - Bulk delete mutations now limit the number of `ids` per call (default 100, configurable via the `BULK_DELETE_LIMIT` env var). Exceeding the limit returns an `INVALID` error. This applies to all bulk delete mutations, including `productBulkDelete`, `productVariantBulkDelete`, `categoryBulkDelete`, `collectionBulkDelete`, `productTypeBulkDelete`, `productMediaBulkDelete`, `attributeBulkDelete`, `attributeValueBulkDelete`, `customerBulkDelete`, `staffBulkDelete`, `pageBulkDelete`, `pageTypeBulkDelete`, `menuBulkDelete`, `menuItemBulkDelete`, `giftCardBulkDelete`, `saleBulkDelete`, `voucherBulkDelete`, `promotionBulkDelete`, `shippingPriceBulkDelete`, `shippingZoneBulkDelete`, `draftOrderBulkDelete`, and `draftOrderLinesBulkDelete`.
 - Removed the deprecated `checkoutId` input argument from the `checkoutShippingAddressUpdate` and `checkoutBillingAddressUpdate` mutations. Use the `id` argument instead.
+- [Preview feature] The OrderBulkCreateInput.status input field in the orderBulkCreate is now a required field. - #19362 by @ayesha-waris
 
 ### GraphQL API
 

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -571,7 +571,7 @@ class OrderBulkCreateInput(BaseInputObjectType):
         required=True,
         description="The date, when the order was inserted to Saleor database.",
     )
-    status = OrderStatusEnum(description="Status of the order.")
+    status = OrderStatusEnum(description="Status of the order.", required=True)
     user = graphene.Field(
         OrderBulkCreateUserInput,
         required=True,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -28330,7 +28330,7 @@ input OrderBulkCreateInput @doc(category: "Orders") {
   createdAt: DateTime!
 
   """Status of the order."""
-  status: OrderStatus
+  status: OrderStatus!
 
   """Customer associated with the order."""
   user: OrderBulkCreateUserInput!


### PR DESCRIPTION
### What does this PR do?

Makes the `status` field on `OrderBulkCreateInput` a required field in the `orderBulkCreate` mutation.

Currently, omitting `status` from the input causes a `KeyError: 'status'` deep in the mutation, surfacing as an unhandled HTTP 500 instead of a clean validation error. By marking the field as required at the schema level, GraphQL rejects such requests up front with a proper validation error and the mutation no longer crashes.

```graphql
input OrderBulkCreateInput {
  ...
  status: OrderStatus!   # was: status: OrderStatus
}
```

### Why is this a breaking change, and why is it acceptable?

This is an intentional, schema-level breaking change. It is acceptable because `orderBulkCreate` is still a **preview feature**, as confirmed on the issue. The CHANGELOG entry is filed under **Breaking changes / Preview feature** using the maintainer's exact prescribed wording.

### Context / prior attempt

This supersedes the earlier abandoned attempt #14760. Addressing the points raised there:

- **Closes #14506.**
- **CHANGELOG wording:** uses the maintainer's exact prescribed phrasing, filed under Breaking changes and flagged as a Preview feature.
- **No schema-rejection unit test added:** required-ness is enforced by the GraphQL schema itself, so a dedicated rejection test would only re-test the GraphQL framework. This follows maintainer @maarcingebala's guidance on #14760.

### Testing

- Re-ran the existing `test_order_bulk_create` suite: **91 passed**.
- No test changes were needed: every existing order input already supplies `status` via the `order_bulk_input` fixture, so the now-required field is satisfied by the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)