### PR TITLE
Add sortBy and filter to User.checkouts - closes #12520

### DIFF
--- a/saleor/graphql/account/tests/queries/test_me.py
+++ b/saleor/graphql/account/tests/queries/test_me.py
@@ -859,3 +859,126 @@ def test_me_orders_where_filter_by_metadata(user_api_client, order_list):
     assert orders_data["edges"][0]["node"]["id"] == graphene.Node.to_global_id(
         "Order", order_list[0].pk
     )
+QUERY_ME_CHECKOUTS_WITH_SORT_AND_FILTER = """
+    query Me($sortBy: CheckoutSortingInput, $filter: CheckoutFilterInput) {
+        me {
+            checkouts(first: 10, sortBy: $sortBy, filter: $filter) {
+                edges {
+                    node {
+                        id
+                        created
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def test_me_checkouts_sort_by_creation_date_asc(user_api_client, checkout, checkout_JPY):
+    # given
+    user = user_api_client.user
+    checkout.user = checkout_JPY.user = user
+    checkout.save()
+    checkout_JPY.save()
+
+    # when
+    variables = {"sortBy": {"field": "CREATION_DATE", "direction": "ASC"}}
+    response = user_api_client.post_graphql(
+        QUERY_ME_CHECKOUTS_WITH_SORT_AND_FILTER, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    edges = content["data"]["me"]["checkouts"]["edges"]
+    assert len(edges) == 2
+    assert edges[0]["node"]["id"] == graphene.Node.to_global_id("Checkout", checkout.pk)
+    assert edges[1]["node"]["id"] == graphene.Node.to_global_id(
+        "Checkout", checkout_JPY.pk
+    )
+
+
+def test_me_checkouts_sort_by_creation_date_desc(user_api_client, checkout, checkout_JPY):
+    # given
+    user = user_api_client.user
+    checkout.user = checkout_JPY.user = user
+    checkout.save()
+    checkout_JPY.save()
+
+    # when
+    variables = {"sortBy": {"field": "CREATION_DATE", "direction": "DESC"}}
+    response = user_api_client.post_graphql(
+        QUERY_ME_CHECKOUTS_WITH_SORT_AND_FILTER, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    edges = content["data"]["me"]["checkouts"]["edges"]
+    assert len(edges) == 2
+    assert edges[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Checkout", checkout_JPY.pk
+    )
+    assert edges[1]["node"]["id"] == graphene.Node.to_global_id("Checkout", checkout.pk)
+
+
+def test_me_checkouts_filter_by_channel(user_api_client, checkout, checkout_JPY):
+    # given
+    user = user_api_client.user
+    checkout.user = checkout_JPY.user = user
+    checkout.save()
+    checkout_JPY.save()
+    channel_id = graphene.Node.to_global_id("Channel", checkout.channel.pk)
+
+    # when
+    variables = {"filter": {"channels": [channel_id]}}
+    response = user_api_client.post_graphql(
+        QUERY_ME_CHECKOUTS_WITH_SORT_AND_FILTER, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    edges = content["data"]["me"]["checkouts"]["edges"]
+    assert len(edges) == 1
+    assert edges[0]["node"]["id"] == graphene.Node.to_global_id("Checkout", checkout.pk)
+
+
+def test_me_checkouts_sort_and_filter_combined(user_api_client, checkout, checkout_JPY):
+    # given
+    user = user_api_client.user
+    checkout.user = checkout_JPY.user = user
+    checkout.save()
+    checkout_JPY.save()
+    channel_id = graphene.Node.to_global_id("Channel", checkout.channel.pk)
+
+    # when
+    variables = {
+        "sortBy": {"field": "CREATION_DATE", "direction": "DESC"},
+        "filter": {"channels": [channel_id]},
+    }
+    response = user_api_client.post_graphql(
+        QUERY_ME_CHECKOUTS_WITH_SORT_AND_FILTER, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    edges = content["data"]["me"]["checkouts"]["edges"]
+    assert len(edges) == 1
+    assert edges[0]["node"]["id"] == graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    
+def test_me_checkouts_sort_by_rank_without_search(user_api_client):
+    # given
+    variables = {"sortBy": {"field": "RANK", "direction": "DESC"}}
+
+    # when
+    response = user_api_client.post_graphql(
+        QUERY_ME_CHECKOUTS_WITH_SORT_AND_FILTER, variables
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert "errors" in content
+    assert (
+        content["errors"][0]["message"]
+        == "Sorting by RANK is available only when using a search filter."
+    )

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -26,6 +26,8 @@ from ..app.types import App
 from ..channel.dataloaders.by_self import ChannelBySlugLoader
 from ..channel.types import Channel
 from ..checkout.dataloaders import CheckoutByUserAndChannelLoader, CheckoutByUserLoader
+from ..checkout.filters import CheckoutFilterInput
+from ..checkout.sorters import CheckoutSortField, CheckoutSortingInput
 from ..checkout.types import Checkout, CheckoutCountableConnection
 from ..core import ResolveInfo
 from ..core.connection import (
@@ -35,11 +37,12 @@ from ..core.connection import (
     filter_connection_queryset,
 )
 from ..core.context import SyncWebhookControlContext, get_database_connection_name
-from ..core.descriptions import ADDED_IN_322, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_322, ADDED_IN_324, PREVIEW_FEATURE
 from ..core.doc_category import DOC_CATEGORY_USERS
 from ..core.enums import LanguageCodeEnum
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import ConnectionField, FilterConnectionField, PermissionsField
+from ..core.utils import validate_and_apply_search_rank_sorting
 from ..core.scalars import UUID, DateTime
 from ..core.tracing import traced_resolver
 from ..core.types import (
@@ -367,13 +370,15 @@ class User(ModelObjectType[models.User]):
             description="Slug of a channel for which the data should be returned."
         ),
     )
-    checkouts = ConnectionField(
+    checkouts = FilterConnectionField(
         CheckoutCountableConnection,
+        sort_by=CheckoutSortingInput(description="Sort checkouts." + ADDED_IN_324),
+        filter=CheckoutFilterInput(description="Filtering options for checkouts." + ADDED_IN_324),
         description=(
-            "Returns checkouts assigned to this user. The query will not initiate any "
-            "external requests, including fetching external shipping methods, "
-            "filtering available shipping methods, or performing external tax "
-            "calculations."
+            "Returns checkouts assigned to this user. The query will not "
+            "initiate any external requests, including fetching external "
+            "shipping methods, filtering available shipping methods, or "
+            "performing external tax calculations."
         ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
@@ -556,10 +561,30 @@ class User(ModelObjectType[models.User]):
             .load((root.id, channel))
             .then(return_checkout_ids)
         )
-
     @staticmethod
     def resolve_checkouts(root: models.User, info: ResolveInfo, **kwargs):
+        validate_and_apply_search_rank_sorting(
+            kwargs, CheckoutSortField.RANK, "CheckoutSortingInput", info
+        )
+
         def _resolve_checkouts(checkouts):
+            from ...checkout.models import Checkout
+
+            if kwargs.get("sort_by") or kwargs.get("filter"):
+                checkout_ids = [c.pk for c in checkouts]
+                checkouts = Checkout.objects.using(
+                    get_database_connection_name(info.context)
+                ).filter(pk__in=checkout_ids)
+                qs = filter_connection_queryset(
+                    checkouts, kwargs, allow_replica=info.context.allow_replica
+                )
+                return create_connection_slice_for_sync_webhook_control_context(
+                    qs,
+                    info,
+                    kwargs,
+                    CheckoutCountableConnection,
+                    allow_sync_webhooks=False,
+                )
             return create_connection_slice_for_sync_webhook_control_context(
                 checkouts,
                 info,
@@ -594,7 +619,7 @@ class User(ModelObjectType[models.User]):
         return (
             GiftCardsByUserLoader(info.context).load(root.id).then(_resolve_gift_cards)
         )
-
+    
     @staticmethod
     def resolve_user_permissions(root: models.User, info: ResolveInfo):
         if is_newly_created_user(root):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3291,6 +3291,20 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   Returns checkouts assigned to this user. The query will not initiate any external requests, including fetching external shipping methods, filtering available shipping methods, or performing external tax calculations.
   """
   checkouts(
+    """
+    Sort checkouts.
+    
+    Added in Saleor 3.24.
+    """
+    sortBy: CheckoutSortingInput
+
+    """
+    Filtering options for checkouts.
+    
+    Added in Saleor 3.24.
+    """
+    filter: CheckoutFilterInput
+
     """Slug of a channel for which the data should be returned."""
     channel: String
 
@@ -13484,6 +13498,41 @@ type CheckoutCountableEdge @doc(category: "Checkout") {
   cursor: String!
 }
 
+input CheckoutSortingInput @doc(category: "Checkout") {
+  """Specifies the direction in which to sort checkouts."""
+  direction: OrderDirection!
+
+  """Sort checkouts by the selected field."""
+  field: CheckoutSortField!
+}
+
+enum CheckoutSortField @doc(category: "Checkout") {
+  """Sort checkouts by creation date."""
+  CREATION_DATE
+
+  """Sort checkouts by customer."""
+  CUSTOMER
+
+  """Sort checkouts by payment."""
+  PAYMENT
+
+  """
+  Sort checkouts by rank. Note: This option is available only with the `search` filter.
+  """
+  RANK
+}
+
+input CheckoutFilterInput @doc(category: "Checkout") {
+  customer: String
+  created: DateRangeInput
+  search: String
+  metadata: [MetadataFilter!]
+  channels: [ID!]
+  updatedAt: DateRangeInput
+  authorizeStatus: [CheckoutAuthorizeStatusEnum!]
+  chargeStatus: [CheckoutChargeStatusEnum!]
+}
+
 type GiftCardCountableConnection @doc(category: "Gift cards") {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
@@ -16943,41 +16992,6 @@ enum ExportFileSortField {
   CREATED_AT
   UPDATED_AT @deprecated(reason: "Use `LAST_MODIFIED_AT` instead.")
   LAST_MODIFIED_AT
-}
-
-input CheckoutSortingInput @doc(category: "Checkout") {
-  """Specifies the direction in which to sort checkouts."""
-  direction: OrderDirection!
-
-  """Sort checkouts by the selected field."""
-  field: CheckoutSortField!
-}
-
-enum CheckoutSortField @doc(category: "Checkout") {
-  """Sort checkouts by creation date."""
-  CREATION_DATE
-
-  """Sort checkouts by customer."""
-  CUSTOMER
-
-  """Sort checkouts by payment."""
-  PAYMENT
-
-  """
-  Sort checkouts by rank. Note: This option is available only with the `search` filter.
-  """
-  RANK
-}
-
-input CheckoutFilterInput @doc(category: "Checkout") {
-  customer: String
-  created: DateRangeInput
-  search: String
-  metadata: [MetadataFilter!]
-  channels: [ID!]
-  updatedAt: DateRangeInput
-  authorizeStatus: [CheckoutAuthorizeStatusEnum!]
-  chargeStatus: [CheckoutChargeStatusEnum!]
 }
 
 type CheckoutLineCountableConnection @doc(category: "Checkout") {


### PR DESCRIPTION
I want to merge this change because the `User.checkouts` field is missing `sortBy` and `filter` arguments that already exist on the root-level `checkouts` query. This inconsistency makes the API harder to use — developers can sort and filter checkouts globally but not when querying checkouts for a specific user. This PR brings `User.checkouts` to parity by reusing the existing `CheckoutFilterInput` and `CheckoutSortingInput` classes already used by the root query.

Closes #12520

# Impact
- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

**Details:** `User.checkouts` field now accepts two new arguments:
- `sortBy: CheckoutSortingInput` — sort checkouts by field and direction
- `filter: CheckoutFilterInput` — filter checkouts by channel and other criteria

The resolver was also updated to convert the dataloader result from a list to a queryset before applying `filter_connection_queryset`, using the correct replica database connection via `get_database_connection_name`.

This is a backward-compatible change. Existing queries without these arguments are unaffected.

# Docs
The `User.checkouts` field in the API reference will need to be updated to reflect the new `sortBy` and `filter` arguments:
https://docs.saleor.io/docs/3.x/api-reference/users/objects/user

- [ ] Link to documentation: *(to be added — docs PR not yet created)*

# Pull Request Checklist
- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [x] All migrations have proper dependencies
- [x] All indexes are added concurrently in migrations
- [x] All RunSql and RunPython migrations have revert option defined