### PR TITLE
fix(announcements): set default resolver in tests

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15326,7 +15326,7 @@ type Announcement {
   messageHtml: String!
 
   """
-  Determine the how critical the announcement is. UNSET if no severity level was defined for this announcement. When value is `UNSET`, it should be considered as low importance or informational.
+  Determine the how critical the announcement is. UNSET if no severity level was defined for this announcement.
   """
   importance: AnnouncementImportanceEnum!
 

--- a/saleor/graphql/shop/tests/queries/test_shop_announcements.py
+++ b/saleor/graphql/shop/tests/queries/test_shop_announcements.py
@@ -2,6 +2,8 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from datetime import datetime
 
+import pytest
+
 from .....site.apps import SiteAppConfig
 from ....tests.utils import (
     assert_no_permission,
@@ -110,6 +112,22 @@ def use_dummy_announcements(
     finally:
         settings.SHOP_ANNOUNCEMENT_RESOLVER_IMPORT = None
         SiteAppConfig.announcements_resolver = None
+
+
+@pytest.fixture(autouse=True)
+def default_settings(settings):
+    """Set the resolver to None, then reverts the changes during tear-down."""
+    old_resolver = SiteAppConfig.announcements_resolver
+
+    # Overrides the default resolver as it may potentially
+    # be set by users thus causing our tests to fail because we
+    # expect the value to be `None`
+    settings.SHOP_ANNOUNCEMENT_RESOLVER_IMPORT = None
+    SiteAppConfig.announcements_resolver = None
+
+    yield
+
+    SiteAppConfig.announcements_resolver = old_resolver
 
 
 def test_cannot_get_announcements_when_not_staff(user_api_client):

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -202,8 +202,7 @@ class Announcement(graphene.ObjectType):
         required=True,
         description=(
             "Determine the how critical the announcement is. UNSET if no "
-            "severity level was defined for this announcement. When value is `UNSET`, "
-            "it should be considered as low importance or informational."
+            "severity level was defined for this announcement."
         ),
     )
 


### PR DESCRIPTION
This sets the default resolver in settings instead of assuming `settings.SHOP_ANNOUNCEMENT_RESOLVER_IMPORT` is always `None` as this can cause tests to fail with:

```python
@contextmanager
    def use_dummy_announcements(
        settings,
        resolver_func: Callable[[], list[Announcement]] = resolve_dummy_announcements,
    ):
        # [...]
>       assert SiteAppConfig.announcements_resolver is None
E       assert <function resolve_announcements at 0xffd0add33740> is None
E        +  where <function resolve_announcements at 0xffd0add33740> = SiteAppConfig.announcements_resolver
```

This also resolves the comment around `UNSET`[^1] where one planned implementation is to dynamically set the importance level on the client-side based on the announcement's type and based on the metadata (`extra`).

[^1]: https://github.com/saleor/saleor/pull/19353#discussion_r3452456261

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
