### PR TITLE
Validate checkout line input limits

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -40,6 +40,7 @@ from .utils import (
     check_permissions_for_custom_prices,
     get_variants_and_total_quantities,
     group_lines_input_on_add,
+    validate_checkout_line_input_list_size,
     validate_variants_are_published,
     validate_variants_available_for_purchase,
 )
@@ -137,7 +138,7 @@ class CheckoutCreateInput(BaseInputObjectType):
         CheckoutLineInput,
         description=(
             "A list of checkout lines, each containing information about "
-            "an item in the checkout."
+            "an item in the checkout. Maximum 100 items."
         ),
         required=True,
     )
@@ -442,6 +443,7 @@ class CheckoutCreate(DeprecatedModelMutation, I18nMixin):
         )
         lines = data.pop("lines", None)
         if lines:
+            validate_checkout_line_input_list_size(lines, "lines")
             (
                 cleaned_input["variants"],
                 cleaned_input["lines_data"],

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -35,6 +35,7 @@ from .utils import (
     get_variants_and_total_quantities,
     group_lines_input_on_add,
     mark_checkout_deliveries_as_stale_if_needed,
+    validate_checkout_line_input_list_size,
     validate_variants_are_published,
     validate_variants_available_for_purchase,
 )
@@ -63,7 +64,7 @@ class CheckoutLinesAdd(BaseMutation):
             required=True,
             description=(
                 "A list of checkout lines, each containing information about "
-                "an item in the checkout."
+                "an item in the checkout. Maximum 100 items."
             ),
         )
 
@@ -219,6 +220,7 @@ class CheckoutLinesAdd(BaseMutation):
         token=None,
         id=None,
     ):
+        validate_checkout_line_input_list_size(lines, "lines")
         app = get_app_promise(info.context).get()
         check_permissions_for_custom_prices(app, lines)
 

--- a/saleor/graphql/checkout/mutations/checkout_lines_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_delete.py
@@ -17,7 +17,11 @@ from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils import resolve_global_ids_to_primary_keys
 from ..types import Checkout
-from .utils import get_checkout, mark_checkout_deliveries_as_stale_if_needed
+from .utils import (
+    get_checkout,
+    mark_checkout_deliveries_as_stale_if_needed,
+    validate_checkout_line_input_list_size,
+)
 
 
 class CheckoutLinesDelete(BaseMutation):
@@ -35,7 +39,7 @@ class CheckoutLinesDelete(BaseMutation):
         lines_ids = NonNullList(
             graphene.ID,
             required=True,
-            description="A list of checkout lines.",
+            description="A list of checkout lines. Maximum 100 items.",
         )
 
     class Meta:
@@ -88,6 +92,7 @@ class CheckoutLinesDelete(BaseMutation):
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, id=None, lines_ids, token=None
     ):
+        validate_checkout_line_input_list_size(lines_ids, "lines_ids")
         checkout = get_checkout(cls, info, checkout_id=None, token=token, id=id)
 
         _, lines_to_delete = resolve_global_ids_to_primary_keys(

--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -26,6 +26,7 @@ from .utils import (
     check_lines_quantity,
     get_variants_and_total_quantities,
     group_lines_input_data_on_update,
+    validate_checkout_line_input_list_size,
 )
 
 
@@ -92,7 +93,7 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
             required=True,
             description=(
                 "A list of checkout lines, each containing information about "
-                "an item in the checkout."
+                "an item in the checkout. Maximum 100 items."
             ),
         )
 
@@ -216,6 +217,7 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
     def perform_mutation(  # type: ignore[override]
         cls, root, info: ResolveInfo, /, *, lines, checkout_id=None, token=None, id=None
     ):
+        validate_checkout_line_input_list_size(lines, "lines")
         for line in lines:
             validate_one_of_args_is_in_mutation(
                 "line_id",

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -32,7 +32,10 @@ from ....product import models as product_models
 from ....product.models import ProductChannelListing, ProductVariant
 from ....warehouse.availability import check_stock_and_preorder_quantity_bulk
 from ...core import ResolveInfo
-from ...core.validators import validate_one_of_args_is_in_mutation
+from ...core.validators import (
+    validate_limit_of_list_input,
+    validate_one_of_args_is_in_mutation,
+)
 from ..types import Checkout
 
 if TYPE_CHECKING:
@@ -44,6 +47,17 @@ ERROR_CC_ADDRESS_CHANGE_FORBIDDEN = (
     "Can't change shipping address manually. "
     "For click and collect delivery, address is set to a warehouse address."
 )
+CHECKOUT_LINE_INPUT_LIST_LIMIT = 100
+
+
+def validate_checkout_line_input_list_size(input_list: list, field_name: str):
+    try:
+        validate_limit_of_list_input(
+            input_list, CHECKOUT_LINE_INPUT_LIST_LIMIT, field_name
+        )
+    except ValidationError as error:
+        error.code = CheckoutErrorCode.INVALID.value
+        raise ValidationError({field_name: error}) from error
 
 
 @dataclass

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -103,6 +103,30 @@ def test_checkout_create_triggers_async_webhooks(
     assert mocked_webhook_trigger.called
 
 
+def test_checkout_create_rejects_too_many_lines(api_client, stock, channel_USD):
+    # given
+    variant = stock.product_variant
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    lines = [{"quantity": 1, "variantId": variant_id}] * 101
+    variables = {
+        "checkoutInput": {
+            "channel": channel_USD.slug,
+            "lines": lines,
+        }
+    }
+
+    # when
+    response = api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
+    content = get_graphql_content(response)
+
+    # then
+    errors = content["data"]["checkoutCreate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "lines"
+    assert errors[0]["message"] == "The maximum number of items in lines is 100."
+    assert errors[0]["code"] == CheckoutErrorCode.INVALID.name
+
+
 def test_checkout_create_with_default_channel(
     api_client, stock, graphql_address_data, channel_USD
 ):

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -149,6 +149,30 @@ def test_checkout_lines_add(
     assert checkout.search_index_dirty is True
 
 
+def test_checkout_lines_add_rejects_too_many_lines(
+    user_api_client, checkout_with_item, stock
+):
+    # given
+    checkout = checkout_with_item
+    previous_last_change = checkout.last_change
+    variant = stock.product_variant
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    lines = [{"variantId": variant_id, "quantity": 1}] * 101
+    variables = {"id": to_global_id_or_none(checkout), "lines": lines}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
+    content = get_graphql_content(response)
+
+    # then
+    errors = content["data"]["checkoutLinesAdd"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "lines"
+    assert errors[0]["message"] == "The maximum number of items in lines is 100."
+    assert errors[0]["code"] == CheckoutErrorCode.INVALID.name
+    assert checkout.last_change == previous_last_change
+
+
 @pytest.mark.parametrize(
     ("channel_listing_model", "listing_filter_field"),
     [

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -92,6 +92,32 @@ def test_checkout_lines_delete(
     assert checkout.search_index_dirty is True
 
 
+def test_checkout_lines_delete_rejects_too_many_lines_ids(
+    user_api_client, checkout_with_items
+):
+    # given
+    checkout = checkout_with_items
+    previous_last_change = checkout.last_change
+    line = checkout.lines.first()
+    line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "linesIds": [line_id] * 101,
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_DELETE, variables)
+    content = get_graphql_content(response)
+
+    # then
+    errors = content["data"]["checkoutLinesDelete"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "linesIds"
+    assert errors[0]["message"] == "The maximum number of items in lines_ids is 100."
+    assert errors[0]["code"] == CheckoutErrorCode.INVALID.name
+    assert checkout.last_change == previous_last_change
+
+
 @pytest.mark.parametrize(
     ("channel_listing_model", "listing_filter_field"),
     [

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -139,6 +139,30 @@ def test_checkout_lines_update(
     assert checkout.search_index_dirty is False
 
 
+def test_checkout_lines_update_rejects_too_many_lines(
+    user_api_client, checkout_with_item
+):
+    # given
+    checkout = checkout_with_item
+    previous_last_change = checkout.last_change
+    line = checkout.lines.first()
+    line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
+    lines = [{"lineId": line_id, "quantity": 1}] * 101
+    variables = {"id": to_global_id_or_none(checkout), "lines": lines}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+    content = get_graphql_content(response)
+
+    # then
+    errors = content["data"]["checkoutLinesUpdate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "lines"
+    assert errors[0]["message"] == "The maximum number of items in lines is 100."
+    assert errors[0]["code"] == CheckoutErrorCode.INVALID.name
+    assert checkout.last_change == previous_last_change
+
+
 @pytest.mark.parametrize(
     ("channel_listing_model", "listing_filter_field"),
     [

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -21032,7 +21032,7 @@ type Mutation {
     """The checkout's ID."""
     id: ID
 
-    """A list of checkout lines."""
+    """A list of checkout lines. Maximum 100 items."""
     linesIds: [ID!]!
 
     """Checkout token."""
@@ -21053,7 +21053,7 @@ type Mutation {
     id: ID
 
     """
-    A list of checkout lines, each containing information about an item in the checkout.
+    A list of checkout lines, each containing information about an item in the checkout. Maximum 100 items.
     """
     lines: [CheckoutLineInput!]!
 
@@ -21075,7 +21075,7 @@ type Mutation {
     id: ID
 
     """
-    A list of checkout lines, each containing information about an item in the checkout.
+    A list of checkout lines, each containing information about an item in the checkout. Maximum 100 items.
     """
     lines: [CheckoutLineUpdateInput!]!
 
@@ -30939,7 +30939,7 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   channel: String
 
   """
-  A list of checkout lines, each containing information about an item in the checkout.
+  A list of checkout lines, each containing information about an item in the checkout. Maximum 100 items.
   """
   lines: [CheckoutLineInput!]!
 


### PR DESCRIPTION
## Summary
- enforce Saleor's documented 100-item limit for checkout line list inputs
- reject oversized checkoutCreate, checkoutLinesAdd, checkoutLinesUpdate, and checkoutLinesDelete payloads before heavier processing
- document the limit in the generated GraphQL schema and add regression coverage

Closes #19209

## Tests
- UV_CACHE_DIR=.uv-cache uv run ruff check saleor/graphql/checkout/mutations/utils.py saleor/graphql/checkout/mutations/checkout_create.py saleor/graphql/checkout/mutations/checkout_lines_add.py saleor/graphql/checkout/mutations/checkout_lines_update.py saleor/graphql/checkout/mutations/checkout_lines_delete.py saleor/graphql/checkout/tests/mutations/test_checkout_create.py saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
- UV_CACHE_DIR=.uv-cache uv run python -m py_compile saleor/graphql/checkout/mutations/utils.py saleor/graphql/checkout/mutations/checkout_create.py saleor/graphql/checkout/mutations/checkout_lines_add.py saleor/graphql/checkout/mutations/checkout_lines_update.py saleor/graphql/checkout/mutations/checkout_lines_delete.py
- git diff --check
- direct validator smoke test: passed

Database-backed pytest command was attempted, but local PostgreSQL is not configured with Saleor's expected saleor/saleor credentials.