### PR TITLE
Add tests for logic that hasn't been covered yet

### DIFF
--- a/saleor/app/tests/test_acquire_webhook_lock.py
+++ b/saleor/app/tests/test_acquire_webhook_lock.py
@@ -1,0 +1,69 @@
+import threading
+
+import pytest
+from django.db import transaction
+
+from ..models import AppWebhookMutex
+from ..utils import acquire_webhook_lock
+
+
+def test_acquires_lock_when_mutex_row_exists(app):
+    # given
+    AppWebhookMutex.objects.create(app=app)
+
+    # when
+    with acquire_webhook_lock(app.id) as acquired:
+        # then
+        assert acquired is True
+
+
+def test_creates_mutex_row_and_acquires_when_missing(app):
+    # given
+    assert not AppWebhookMutex.objects.filter(app_id=app.id).exists()
+
+    # when
+    with acquire_webhook_lock(app.id) as acquired:
+        # then
+        assert acquired is True
+
+    assert AppWebhookMutex.objects.filter(app_id=app.id).count() == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_does_not_acquire_when_lock_held_by_concurrent_transaction(
+    app, django_db_blocker
+):
+    """Acquire the lock in a second thread, then assert the main thread is refused.
+
+    `nowait=True` makes Postgres raise OperationalError immediately instead of
+    blocking, which `acquire_webhook_lock` translates into `acquired = False`.
+    """
+    # given
+    AppWebhookMutex.objects.create(app=app)
+
+    lock_held = threading.Event()
+    release_lock = threading.Event()
+
+    def hold_lock():
+        with django_db_blocker.unblock():
+            with transaction.atomic():
+                AppWebhookMutex.objects.select_for_update(
+                    nowait=True, of=("self",)
+                ).get(app_id=app.id)
+                lock_held.set()
+                # keep the row locked until the main thread has tried to acquire
+                release_lock.wait(timeout=5)
+
+    # opens database transaction and keeps it held until `release_lock` is set
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert lock_held.wait(timeout=5), "background thread failed to acquire the lock"
+
+    try:
+        # when
+        with acquire_webhook_lock(app.id) as acquired:
+            # then
+            assert acquired is False
+    finally:
+        release_lock.set()
+        holder.join(timeout=5)

--- a/saleor/core/tests/test_schedules.py
+++ b/saleor/core/tests/test_schedules.py
@@ -716,10 +716,29 @@ def test_async_webhooks_schedule_are_dirty(event_delivery):
     schedule = async_webhooks_schedule()
     assert event_delivery.status == EventDeliveryStatus.PENDING
     assert event_delivery.payload is not None
+    assert event_delivery.webhook.is_active is True
+    assert event_delivery.webhook.app.is_active is True
 
     # when
     is_due, next_run = schedule.is_due(timezone.now() - datetime.timedelta(seconds=2))
 
     # then
     assert is_due is True
+    assert next_run == schedule.initial_timedelta.total_seconds()
+
+
+@override_settings(WEBHOOK_ASYNC_LEGACY_MODE=True)
+def test_async_webhooks_schedule_not_dirty_when_legacy_mode_enabled(event_delivery):
+    # given
+    schedule = async_webhooks_schedule()
+    assert event_delivery.status == EventDeliveryStatus.PENDING
+    assert event_delivery.payload is not None
+    assert event_delivery.webhook.is_active is True
+    assert event_delivery.webhook.app.is_active is True
+
+    # when
+    is_due, next_run = schedule.is_due(timezone.now() - datetime.timedelta(seconds=2))
+
+    # then
+    assert is_due is False
     assert next_run == schedule.initial_timedelta.total_seconds()

--- a/saleor/webhook/transport/asynchronous/tests/test_maybe_send_webhooks_async.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_maybe_send_webhooks_async.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import override_settings
+
+from ..transport import get_queue_name_for_webhook, maybe_send_webhooks_async
+
+SEND_WEBHOOK_REQUEST_ASYNC_PATH = "saleor.webhook.transport.asynchronous.transport.send_webhook_request_async.apply_async"
+
+
+@override_settings(WEBHOOK_ASYNC_LEGACY_MODE=True)
+@patch(SEND_WEBHOOK_REQUEST_ASYNC_PATH)
+def test_dispatches_delivery_when_legacy_mode_enabled(
+    mock_apply_async,
+    event_delivery,
+):
+    # given
+    domain = "example.com"
+
+    # when
+    maybe_send_webhooks_async([event_delivery], domain=domain)
+
+    # then
+    mock_apply_async.assert_called_once()
+    call = mock_apply_async.call_args
+    assert call.kwargs["kwargs"]["event_delivery_id"] == event_delivery.pk
+    assert call.kwargs["queue"] == get_queue_name_for_webhook(
+        event_delivery.webhook,
+        default_queue=settings.WEBHOOK_CELERY_QUEUE_NAME,
+    )
+
+
+@override_settings(WEBHOOK_ASYNC_LEGACY_MODE=False)
+@patch(SEND_WEBHOOK_REQUEST_ASYNC_PATH)
+def test_does_not_dispatch_delivery_when_legacy_mode_disabled(
+    mock_apply_async,
+    event_delivery,
+):
+    # given
+    domain = "example.com"
+
+    # when
+    maybe_send_webhooks_async([event_delivery], domain=domain)
+
+    # then
+    mock_apply_async.assert_not_called()

--- a/saleor/webhook/transport/asynchronous/tests/test_send_webhooks_async_for_app.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_send_webhooks_async_for_app.py
@@ -1,12 +1,18 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.test import override_settings
+from freezegun import freeze_time
 
 from .....app.models import AppWebhookMutex
 from .....core.models import EventDelivery, EventDeliveryAttempt, EventDeliveryStatus
+from .....webhook.event_types import WebhookEventAsyncType
+from .....webhook.models import Webhook
+from ...utils import get_pending_delivery_requests
 from ..transport import (
     MAX_WEBHOOK_RETRIES,
     WebhookResponse,
+    execute_webhook_requests,
     send_webhooks_async_for_app,
 )
 
@@ -330,3 +336,172 @@ def test_send_webhooks_async_for_app_last_retry_succeeds(
 
     assert not EventDelivery.objects.exists()
     assert not EventDeliveryAttempt.objects.exists()
+
+
+@override_settings(WEBHOOK_ASYNC_BATCH_TIMEOUT=10)
+@patch("saleor.webhook.transport.utils.send_prepared_webhook_request_using_http")
+def test_execute_webhook_requests_stops_mid_batch_on_soft_timeout(
+    mock_send_prepared_webhook_request_using_http,
+    app,
+    event_deliveries,
+):
+    # given
+    with freeze_time("2024-01-01 12:00:00", tick=False) as frozen_time:
+
+        def succeed_then_advance_past_timeout(*args, **kwargs):
+            # advance past WEBHOOK_ASYNC_BATCH_TIMEOUT after the first request,
+            # so the next loop guard breaks the loop
+            frozen_time.tick(delta=11)
+            return WebhookResponse(content="", status=EventDeliveryStatus.SUCCESS)
+
+        mock_send_prepared_webhook_request_using_http.side_effect = (
+            succeed_then_advance_past_timeout
+        )
+
+        http_requests, _ = get_pending_delivery_requests(
+            domain="example.com",
+            app_id=app.id,
+            session=MagicMock(),
+            batch_size=10,
+        )
+        assert http_requests.qsize() == 3
+        results: list = []
+
+        # when
+        execute_webhook_requests(
+            thread_id=0,
+            queue=http_requests,
+            results=results,
+            telemetry_context=MagicMock(),
+        )
+
+    # then
+    # exactly one delivery was processed before the timeout broke the loop
+    assert mock_send_prepared_webhook_request_using_http.call_count == 1
+    assert len(results) == 1
+    # the remaining deliveries stay queued for a later batch
+    assert http_requests.qsize() == 2
+
+
+@override_settings(WEBHOOK_ASYNC_MAX_CONCURRENCY=1)
+@patch("saleor.webhook.transport.utils.send_prepared_webhook_request_using_http")
+def test_execute_webhook_requests_stops_on_failure_when_concurrency_is_one(
+    mock_send_prepared_webhook_request_using_http,
+    app,
+    event_deliveries,
+):
+    # given
+    mock_send_prepared_webhook_request_using_http.return_value = WebhookResponse(
+        content="", status=EventDeliveryStatus.FAILED
+    )
+    http_requests, _ = get_pending_delivery_requests(
+        domain="example.com",
+        app_id=app.id,
+        session=MagicMock(),
+        batch_size=10,
+    )
+    assert http_requests.qsize() == 3
+    results: list = []
+
+    # when
+    execute_webhook_requests(
+        thread_id=0,
+        queue=http_requests,
+        results=results,
+        telemetry_context=MagicMock(),
+    )
+
+    # then
+    # with concurrency 1 deliveries are processed in chronological order, so a
+    # failure must stop the thread to preserve ordering on the next batch
+    assert mock_send_prepared_webhook_request_using_http.call_count == 1
+    assert len(results) == 1
+    assert http_requests.qsize() == 2
+
+
+@override_settings(WEBHOOK_ASYNC_MAX_CONCURRENCY=2)
+@patch("saleor.webhook.transport.utils.send_prepared_webhook_request_using_http")
+def test_execute_webhook_requests_continues_on_failure_when_concurrency_above_one(
+    mock_send_prepared_webhook_request_using_http,
+    app,
+    event_deliveries,
+):
+    # given
+    mock_send_prepared_webhook_request_using_http.return_value = WebhookResponse(
+        content="", status=EventDeliveryStatus.FAILED
+    )
+    http_requests, _ = get_pending_delivery_requests(
+        domain="example.com",
+        app_id=app.id,
+        session=MagicMock(),
+        batch_size=10,
+    )
+    assert http_requests.qsize() == 3
+    results: list = []
+
+    # when
+    execute_webhook_requests(
+        thread_id=0,
+        queue=http_requests,
+        results=results,
+        telemetry_context=MagicMock(),
+    )
+
+    # then
+    # with concurrency greater than 1 ordering is not guaranteed, so a failed delivery must
+    # not stop the thread - it keeps draining the queue
+    assert mock_send_prepared_webhook_request_using_http.call_count == 3
+    assert len(results) == 3
+    assert http_requests.empty()
+
+
+@pytest.fixture
+def sqs_webhook(app):
+    return Webhook.objects.create(
+        name="SQS webhook",
+        app=app,
+        target_url=(
+            "awssqs://access_key:secret@sqs.us-east-1.amazonaws.com/account_id/queue"
+        ),
+    )
+
+
+@pytest.fixture
+def sqs_event_delivery(event_payload, sqs_webhook):
+    return EventDelivery.objects.create(
+        event_type=WebhookEventAsyncType.ANY,
+        payload=event_payload,
+        webhook=sqs_webhook,
+    )
+
+
+@override_settings(WEBHOOK_ASYNC_MAX_CONCURRENCY=2)
+@patch("saleor.webhook.transport.utils.boto3.client")
+@patch("saleor.webhook.transport.utils.send_prepared_webhook_request_using_http")
+def test_send_webhooks_async_for_app_processes_http_and_non_http(
+    mock_send_prepared_webhook_request_using_http,
+    mock_boto3_client,
+    app,
+    app_webhook_mutex,
+    event_delivery,
+    sqs_event_delivery,
+):
+    # given
+    assert EventDelivery.objects.filter(status=EventDeliveryStatus.PENDING).count() == 2
+
+    mock_send_prepared_webhook_request_using_http.return_value = WebhookResponse(
+        content="", status=EventDeliveryStatus.SUCCESS
+    )
+    mock_sqs = MagicMock()
+    mock_sqs.send_message.return_value = {"MessageId": "1"}
+    mock_boto3_client.return_value = mock_sqs
+
+    # when
+    send_webhooks_async_for_app(
+        app_id=app.id, telemetry_context=MagicMock(), concurrency=1
+    )
+
+    # then
+    mock_send_prepared_webhook_request_using_http.assert_called_once()
+    mock_sqs.send_message.assert_called_once()
+    assert not EventDelivery.objects.exists()


### PR DESCRIPTION
Add tests for the following logic:
- `maybe_send_webhooks_async` dispatches in legacy mode, no-ops when disabled
- `async_webhooks_schedule` stays not-dirty in legacy mode
- `acquire_webhook_lock`: acquire, auto-create mutex, refuse on concurrent lock
- `execute_webhook_requests`: soft-timeout break, and break vs. continue on failure by concurrency
- `send_webhooks_async_for_app` processes HTTP and non-HTTP deliveries