### PR TITLE
Release 3.22.54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.53",
+  "version": "3.22.54",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.53",
+      "version": "3.22.54",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.53",
+  "version": "3.22.54",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.22.53"
+version = "3.22.54"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.53"
+__version__ = "3.22.54"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ supported-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-26T07:45:12.804338Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3W"
 
 [options.exclude-newer-package]
@@ -2558,7 +2558,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.22.53"
+version = "3.22.54"
 source = { virtual = "." }
 dependencies = [
     { name = "adyen", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
Diffs for `3.22.53...release-3.22.54`:

- 8f9a4a86ec335b9575057609857ee3df5cb87096  Mikail Kocak: release: v3.22.54
- bbd1e6ad998af75d377a776b4f60bd20a05bf009  Marcin Wcisło: Refresh order to guarantee correct order payment status calculcation (#19323) (#19357)
- 2e22cf501b365d584ec2f06db3bbbc8a376b18b5  Mikail: feat(shop): add Announcements API (#19353) (#19367)
- c3ed5a4e1d1b1ba9511d7711299f4e8481816807  Tomasz Magulski: ci: pin changelog-enforcer action to v3.7.0 (#19335)
- 3785f3611fadad8434717513b650353cffa04b82  Lukasz Ostrowski: ci: upgrade graphql-inspector action to v5.0.21 for Node 24 (#19330)
- b4525a787cf48a688bdae2699d983fdfe30dd708  Lukasz Ostrowski: Add translation field on AssignedSwatchAttributeValue (#19328)