### PR TITLE
Make amount optional for cancel events in transactionEventReport

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -37,7 +37,7 @@ from .....permission.enums import PaymentPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_322
+from ....core.descriptions import ADDED_IN_322, ADDED_IN_323
 from ....core.doc_category import DOC_CATEGORY_PAYMENTS
 from ....core.enums import TransactionEventReportErrorCode
 from ....core.mutations import DeprecatedModelMutation
@@ -105,6 +105,13 @@ class TransactionEventReport(DeprecatedModelMutation):
                 "the amount will be calculated based on the previous events with "
                 "the same pspReference. "
                 "If not possible to calculate, the mutation will return an error."
+                "\n\n`CANCEL_REQUEST` and `CANCEL_SUCCESS` events are an exception - "
+                "when the amount is not provided it is deduced automatically. "
+                "`CANCEL_REQUEST` defaults to the transaction's current authorized "
+                "(remaining cancelable) amount. `CANCEL_SUCCESS` defaults to the amount "
+                "of the matching `CANCEL_REQUEST` (same pspReference), or to the current "
+                "authorized amount when there is no matching request. If the amount "
+                "cannot be deduced, the mutation will return an error." + ADDED_IN_323
             ),
             required=False,
         )
@@ -270,7 +277,11 @@ class TransactionEventReport(DeprecatedModelMutation):
 
     @classmethod
     def clean_amount_value(
-        cls, amount: float | None, event_type: str, psp_reference: str, currency: str
+        cls,
+        amount: float | None,
+        event_type: str,
+        psp_reference: str,
+        transaction: payment_models.TransactionItem,
     ):
         if amount is None:
             if event_type not in OPTIONAL_AMOUNT_EVENTS:
@@ -283,7 +294,9 @@ class TransactionEventReport(DeprecatedModelMutation):
                     }
                 )
             try:
-                amount = get_transaction_event_amount(event_type, psp_reference)
+                amount = get_transaction_event_amount(
+                    event_type, psp_reference, transaction
+                )
             except ValueError as e:
                 raise ValidationError(
                     {
@@ -293,7 +306,7 @@ class TransactionEventReport(DeprecatedModelMutation):
                         )
                     },
                 ) from e
-        return quantize_price(amount, currency)
+        return quantize_price(amount, transaction.currency)
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
@@ -331,9 +344,7 @@ class TransactionEventReport(DeprecatedModelMutation):
                 ]
             )
 
-        amount = cls.clean_amount_value(
-            amount, type, psp_reference, transaction.currency
-        )
+        amount = cls.clean_amount_value(amount, type, psp_reference, transaction)
         app_identifier = None
         if app and app.identifier:
             app_identifier = app.identifier

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -2597,7 +2597,14 @@ def test_transaction_event_report_missing_amount(
     [
         event_type
         for event_type in OPTIONAL_AMOUNT_EVENTS
-        if event_type != TransactionEventType.INFO
+        if event_type
+        not in (
+            TransactionEventType.INFO,
+            # Cancel events deduce the amount from the transaction's authorized
+            # value, which is non-zero here, so they don't raise.
+            TransactionEventType.CANCEL_REQUEST,
+            TransactionEventType.CANCEL_SUCCESS,
+        )
     ],
 )
 def test_transaction_event_report_missing_amount_not_deduced_error_raised(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report_no_amount.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report_no_amount.py
@@ -1,0 +1,246 @@
+from decimal import Decimal
+
+import graphene
+import pytest
+
+from .....payment import TransactionEventType
+from .....payment.models import TransactionEvent
+from .....payment.transaction_item_calculations import recalculate_transaction_amounts
+from ....core.enums import TransactionEventReportErrorCode
+from ....tests.utils import get_graphql_content
+from ...enums import TransactionEventTypeEnum
+from .test_transaction_event_report import MUTATION_DATA_FRAGMENT
+
+MUTATION_REPORT_NO_AMOUNT = (
+    MUTATION_DATA_FRAGMENT
+    + """
+mutation TransactionEventReport(
+    $id: ID
+    $type: TransactionEventTypeEnum!
+    $pspReference: String!
+) {
+    transactionEventReport(
+        id: $id
+        type: $type
+        pspReference: $pspReference
+    ) {
+        ...TransactionEventData
+    }
+}
+"""
+)
+
+
+def test_cancel_request_deduces_authorized(
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    authorized_value = Decimal(100)
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=authorized_value
+    )
+    psp_reference = "111-abc"
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CANCEL_REQUEST.name,
+        "pspReference": psp_reference,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_REPORT_NO_AMOUNT,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["errors"]
+
+    event = TransactionEvent.objects.get(
+        psp_reference=psp_reference, type=TransactionEventType.CANCEL_REQUEST
+    )
+    assert event.amount_value == authorized_value
+
+
+def test_cancel_success_deduces_request(
+    transaction_item_generator,
+    transaction_events_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    authorized_value = Decimal(100)
+    requested_amount = Decimal(30)
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=authorized_value
+    )
+    psp_reference = "111-abc"
+    transaction_events_generator(
+        transaction=transaction,
+        psp_references=[psp_reference],
+        types=[TransactionEventType.CANCEL_REQUEST],
+        amounts=[requested_amount],
+    )
+    # The pending cancel request reduces the authorized balance, so the success
+    # amount must be taken from the request, not from `authorized_value`.
+    recalculate_transaction_amounts(transaction)
+    assert transaction.authorized_value == authorized_value - requested_amount
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CANCEL_SUCCESS.name,
+        "pspReference": psp_reference,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_REPORT_NO_AMOUNT,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["errors"]
+
+    event = TransactionEvent.objects.get(
+        psp_reference=psp_reference, type=TransactionEventType.CANCEL_SUCCESS
+    )
+    assert event.amount_value == requested_amount
+
+
+def test_cancel_success_matches_psp_reference(
+    transaction_item_generator,
+    transaction_events_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    authorized_value = Decimal(100)
+    matching_request_amount = Decimal(25)
+    other_request_amount = Decimal(40)
+    matching_psp_reference = "psp-A"
+    other_psp_reference = "psp-B"
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=authorized_value
+    )
+    transaction_events_generator(
+        transaction=transaction,
+        psp_references=[matching_psp_reference, other_psp_reference],
+        types=[
+            TransactionEventType.CANCEL_REQUEST,
+            TransactionEventType.CANCEL_REQUEST,
+        ],
+        amounts=[matching_request_amount, other_request_amount],
+    )
+    recalculate_transaction_amounts(transaction)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CANCEL_SUCCESS.name,
+        "pspReference": matching_psp_reference,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_REPORT_NO_AMOUNT,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["errors"]
+
+    event = TransactionEvent.objects.get(
+        psp_reference=matching_psp_reference,
+        type=TransactionEventType.CANCEL_SUCCESS,
+    )
+    assert event.amount_value == matching_request_amount
+
+
+def test_cancel_success_without_request(
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    authorized_value = Decimal(50)
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=authorized_value
+    )
+    psp_reference = "111-abc"
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CANCEL_SUCCESS.name,
+        "pspReference": psp_reference,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_REPORT_NO_AMOUNT,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["errors"]
+
+    event = TransactionEvent.objects.get(
+        psp_reference=psp_reference, type=TransactionEventType.CANCEL_SUCCESS
+    )
+    assert event.amount_value == authorized_value
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        TransactionEventTypeEnum.CANCEL_REQUEST.name,
+        TransactionEventTypeEnum.CANCEL_SUCCESS.name,
+    ],
+)
+def test_cancel_nothing_to_cancel_error(
+    event_type,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        app=app_api_client.app, authorized_value=Decimal(0)
+    )
+    psp_reference = "111-abc"
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": event_type,
+        "pspReference": psp_reference,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_REPORT_NO_AMOUNT,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    assert not transaction_report_data["transactionEvent"]
+    errors = transaction_report_data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "amount"
+    assert errors[0]["code"] == TransactionEventReportErrorCode.REQUIRED.name

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19045,6 +19045,10 @@ type Mutation {
     The amount of the event to report. 
     
     Required for all `REQUEST`, `SUCCESS`, `ACTION_REQUIRED`, and `ADJUSTMENT` events. For other events, the amount will be calculated based on the previous events with the same pspReference. If not possible to calculate, the mutation will return an error.
+    
+    `CANCEL_REQUEST` and `CANCEL_SUCCESS` events are an exception - when the amount is not provided it is deduced automatically. `CANCEL_REQUEST` defaults to the transaction's current authorized (remaining cancelable) amount. `CANCEL_SUCCESS` defaults to the amount of the matching `CANCEL_REQUEST` (same pspReference), or to the current authorized amount when there is no matching request. If the amount cannot be deduced, the mutation will return an error.
+    
+    Added in Saleor 3.23.
     """
     amount: PositiveDecimal
 

--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -268,6 +268,8 @@ OPTIONAL_AMOUNT_EVENTS = [
     TransactionEventType.REFUND_REVERSE,
     TransactionEventType.CHARGE_BACK,
     TransactionEventType.INFO,
+    TransactionEventType.CANCEL_REQUEST,
+    TransactionEventType.CANCEL_SUCCESS,
 ]
 
 

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -2023,17 +2023,26 @@ def invalidate_cache_for_stored_payment_methods_if_needed(
         )
 
 
-def get_transaction_event_amount(event_type: str, psp_reference: str):
+def get_transaction_event_amount(
+    event_type: str,
+    psp_reference: str,
+    transaction: TransactionItem | None = None,
+):
     """Deduce the transaction event amount if possible.
 
     - In case of missing amount for event INFO, use 0
     - In case of missing amount for *_FAILURE the amount is taken from *_SUCCESS or
     *_REQUEST event with the same pspReference.
+    - In case of CANCEL_REQUEST, the amount is taken from the transaction's current
+    `authorized_value` - the remaining cancelable balance.
+    - In case of CANCEL_SUCCESS, the amount is taken from the CANCEL_REQUEST event with
+    the same pspReference (the requested cancel). When there is no such request, the
+    transaction's current `authorized_value` is used.
     - In case of REFUND_REVERSE, the amount is taken from REFUND_SUCCESS with the same
     pspReference.
     - In case of CHARGEBACK the amount is taken from CHARGE_SUCCESS with the same
     pspReference.
-    - If the specific event for the pspReference doesn't exist, the exception is raised.
+    - If the amount cannot be deduced, the exception is raised.
     """
     if event_type == TransactionEventType.INFO:
         return Decimal(0)
@@ -2052,6 +2061,9 @@ def get_transaction_event_amount(event_type: str, psp_reference: str):
             TransactionEventType.CHARGE_SUCCESS,
             TransactionEventType.CHARGE_REQUEST,
             TransactionEventType.CHARGE_FAILURE,
+        ],
+        TransactionEventType.CANCEL_SUCCESS: [
+            TransactionEventType.CANCEL_REQUEST,
         ],
         TransactionEventType.CANCEL_FAILURE: [
             TransactionEventType.CANCEL_SUCCESS,
@@ -2075,6 +2087,18 @@ def get_transaction_event_amount(event_type: str, psp_reference: str):
         .order_by("-created_at")
         .first()
     )
-    if matched_event is None:
-        raise ValueError(f"Unable to deduce the amount for {event_type} event.")
-    return matched_event.amount_value
+    if matched_event is not None:
+        return matched_event.amount_value
+
+    cancel_events = (
+        TransactionEventType.CANCEL_REQUEST,
+        TransactionEventType.CANCEL_SUCCESS,
+    )
+    if (
+        event_type in cancel_events
+        and transaction is not None
+        and transaction.authorized_value > Decimal(0)
+    ):
+        return transaction.authorized_value
+
+    raise ValueError(f"Unable to deduce the amount for {event_type} event.")


### PR DESCRIPTION
`CANCEL_REQUEST` and `CANCEL_SUCCESS` no longer require an explicit `amount`. When omitted, the amount is deduced automatically:

- `CANCEL_REQUEST` defaults to the transaction's current `authorized_value` (the remaining cancelable balance).
- `CANCEL_SUCCESS` defaults to the matching `CANCEL_REQUEST` event amount (same pspReference), falling back to `authorized_value` when there is no prior request. Reading the request event rather than the `cancel_pending_value` aggregate keeps the amount correct under concurrent cancels across multiple pspReferences, and avoids the zeroed-out `authorized_value` once a cancel request is pending.
- When the amount cannot be deduced (no authorized balance and no matching request) the existing REQUIRED error is raised; apps can still pass an explicit amount.

`CANCEL_FAILURE` was already optional and is unchanged.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
