### PR TITLE
Clean up  ADDED_IN annotations for versions below 3.22 (EOLs)

### DIFF
--- a/saleor/graphql/account/mutations/account/account_address_create.py
+++ b/saleor/graphql/account/mutations/account/account_address_create.py
@@ -10,7 +10,6 @@ from .....core.tracing import traced_atomic_transaction
 from .....permission.auth_filters import AuthorizationFilters
 from .....webhook.event_types import WebhookEventAsyncType
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_319
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import DeprecatedModelMutation
 from ....core.types import AccountError
@@ -47,7 +46,6 @@ class AccountAddressCreate(
                 "ID of customer the application is impersonating. "
                 "The field can be used and is required by apps only. "
                 "Requires IMPERSONATE_USER and AUTHENTICATED_APP permission."
-                + ADDED_IN_319
             ),
         )
 

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -9,7 +9,6 @@ from .....permission.auth_filters import AuthorizationFilters
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.mixins import AddressMetadataMixin
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_319
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.types import AccountError, NonNullList
 from ....core.utils import WebhookEventInfo
@@ -56,7 +55,6 @@ class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate, AppImpersonateMixi
                 "ID of customer the application is impersonating. "
                 "The field can be used and is required by apps only. "
                 "Requires IMPERSONATE_USER and AUTHENTICATED_APP permission."
-                + ADDED_IN_319
             ),
         )
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -35,7 +35,7 @@ from ..core.connection import (
     filter_connection_queryset,
 )
 from ..core.context import SyncWebhookControlContext, get_database_connection_name
-from ..core.descriptions import ADDED_IN_319, ADDED_IN_322, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_322, PREVIEW_FEATURE
 from ..core.doc_category import DOC_CATEGORY_USERS
 from ..core.enums import LanguageCodeEnum
 from ..core.federation import federated_entity, resolve_federation_references
@@ -107,7 +107,6 @@ class AddressInput(BaseInputObjectType):
             "library. Some mutations may require additional permissions to use the "
             "the field. More info about permissions can be found in relevant mutation."
         )
-        + ADDED_IN_319
         + PREVIEW_FEATURE,
         default_value=False,
         required=False,

--- a/saleor/graphql/app/mutations/app_create.py
+++ b/saleor/graphql/app/mutations/app_create.py
@@ -3,7 +3,6 @@ import graphene
 from ....app import models
 from ....permission.enums import AppPermission, get_permissions
 from ....webhook.event_types import WebhookEventAsyncType
-from ...core.descriptions import ADDED_IN_319
 from ...core.doc_category import DOC_CATEGORY_APPS
 from ...core.enums import PermissionEnum
 from ...core.mutations import DeprecatedModelMutation
@@ -21,7 +20,7 @@ class AppInput(BaseInputObjectType):
     identifier = graphene.String(
         description=(
             "Canonical app ID. If not provided, "
-            "the identifier will be generated based on app.id." + ADDED_IN_319
+            "the identifier will be generated based on app.id."
         )
     )
     permissions = NonNullList(

--- a/saleor/graphql/app/mutations/app_reenable_sync_webhooks.py
+++ b/saleor/graphql/app/mutations/app_reenable_sync_webhooks.py
@@ -9,7 +9,6 @@ from ....app import models as app_models
 from ....app.error_codes import AppErrorCode
 from ....graphql.app.enums import CircuitBreakerState
 from ....graphql.app.types import App
-from ....graphql.core.descriptions import ADDED_IN_321
 from ....permission.enums import AppPermission
 from ....webhook.circuit_breaker.breaker_board import (
     initialize_breaker_board,
@@ -40,7 +39,7 @@ class AppReenableSyncWebhooks(BaseMutation):
         description = (
             "Re-enable sync webhooks for provided app. "
             "Can be used to manually re-enable sync webhooks for the app before "
-            "the cooldown period ends." + ADDED_IN_321
+            "the cooldown period ends."
         )
         doc_category = DOC_CATEGORY_APPS
         permissions = (AppPermission.MANAGE_APPS,)

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -32,7 +32,7 @@ from ..core import ResolveInfo, SaleorContext
 from ..core.connection import CountableConnection
 from ..core.context import get_database_connection_name
 from ..core.dataloaders import DataLoader
-from ..core.descriptions import ADDED_IN_319, ADDED_IN_321, ADDED_IN_322
+from ..core.descriptions import ADDED_IN_322
 from ..core.doc_category import DOC_CATEGORY_APPS
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import PermissionsField
@@ -645,7 +645,7 @@ class AppProblem(ModelObjectType[models.AppProblem]):
 class App(ModelObjectType[models.App]):
     id = graphene.GlobalID(required=True, description="The ID of the app.")
     identifier = graphene.String(
-        required=False, description="Canonical app ID from the manifest" + ADDED_IN_319
+        required=False, description="Canonical app ID from the manifest"
     )
     permissions = NonNullList(Permission, description="List of the app's permissions.")
     created = DateTime(description="The date and time when the app was created.")
@@ -716,12 +716,11 @@ class App(ModelObjectType[models.App]):
     )
     brand = graphene.Field(AppBrand, description="App's brand data.")
     breaker_state = CircuitBreakerStateEnum(
-        description="Circuit breaker state, if open, sync webhooks operation is disrupted."
-        + ADDED_IN_321,
+        description="Circuit breaker state, if open, sync webhooks operation is disrupted.",
         required=True,
     )
     breaker_last_state_change = DateTime(
-        description="Circuit breaker last state change date." + ADDED_IN_321,
+        description="Circuit breaker last state change date.",
         required=False,
     )
 

--- a/saleor/graphql/channel/mutations/channel_create.py
+++ b/saleor/graphql/channel/mutations/channel_create.py
@@ -10,9 +10,6 @@ from ....webhook.event_types import WebhookEventAsyncType
 from ...account.enums import CountryCodeEnum
 from ...core import ResolveInfo
 from ...core.descriptions import (
-    ADDED_IN_318,
-    ADDED_IN_320,
-    ADDED_IN_321,
     ADDED_IN_322,
     ADDED_IN_323,
     DEPRECATED_IN_3X_INPUT,
@@ -120,7 +117,6 @@ class CheckoutSettingsInput(BaseInputObjectType):
             "checkout `authorize_status` reaches `FULL`. This occurs when the total sum "
             "of charged and authorized transaction amounts equals or exceeds the "
             "checkout's total amount."
-            + ADDED_IN_320
             + DEPRECATED_IN_3X_INPUT
             + " Use `automatic_completion` instead."
         )
@@ -193,9 +189,7 @@ class OrderSettingsInput(BaseInputObjectType):
             "Specify whether a coupon applied to draft orders will count toward "
             "voucher usage."
             "\n\nWarning:  when switching this setting from `false` to `true`, "
-            "the vouchers will be disconnected from all draft orders."
-            + ADDED_IN_318
-            + PREVIEW_FEATURE
+            "the vouchers will be disconnected from all draft orders." + PREVIEW_FEATURE
         ),
     )
     draft_order_line_price_freeze_period = Hour(
@@ -203,7 +197,7 @@ class OrderSettingsInput(BaseInputObjectType):
         description=(
             "Time in hours after which the draft order line price will be refreshed. "
             "Default value is 24 hours. "
-            "Enter 0 or null to disable." + ADDED_IN_321 + PREVIEW_FEATURE
+            "Enter 0 or null to disable." + PREVIEW_FEATURE
         ),
     )
 
@@ -223,7 +217,7 @@ class OrderSettingsInput(BaseInputObjectType):
             "returned in the `OrderLine.discounts` field. In this case, "
             "percentage-based vouchers retain their original type."
             "\nIn future releases, `OrderLineDiscount` will become the default "
-            "behavior, and this flag will be deprecated and removed." + ADDED_IN_321
+            "behavior, and this flag will be deprecated and removed."
         ),
     )
 
@@ -244,14 +238,12 @@ class PaymentSettingsInput(BaseInputObjectType):
         required=False,
         description=(
             "Determine if the funds for expired checkouts should be released automatically."
-            + ADDED_IN_320
         ),
     )
     checkout_ttl_before_releasing_funds = Hour(
         required=False,
         description=(
             "The time in hours after which funds for expired checkouts will be released."
-            + ADDED_IN_320
         ),
     )
     checkout_release_funds_cut_off_date = DateTime(
@@ -260,7 +252,7 @@ class PaymentSettingsInput(BaseInputObjectType):
             "Specifies the earliest date on which funds for expired checkouts can begin "
             "to be released. Expired checkouts dated before this cut-off will not have their "
             "funds released. Additionally, no funds will be released for checkouts that are "
-            "more than one year old, regardless of the cut-off date." + ADDED_IN_320
+            "more than one year old, regardless of the cut-off date."
         ),
     )
 

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -18,9 +18,6 @@ from ...permission.enums import (
 from ..account.enums import CountryCodeEnum
 from ..core import ResolveInfo
 from ..core.descriptions import (
-    ADDED_IN_318,
-    ADDED_IN_320,
-    ADDED_IN_321,
     ADDED_IN_322,
     ADDED_IN_323,
     DEPRECATED_IN_3X_INPUT,
@@ -90,8 +87,7 @@ class CheckoutSettings(ObjectType):
             "checkout `charge_status` reaches `FULL`. This occurs when the total sum "
             "of charged and authorized transaction amounts equals or exceeds the "
             "checkout's total amount."
-        )
-        + ADDED_IN_320,
+        ),
     )
     automatic_completion_delay = Minute(
         required=False,
@@ -172,14 +168,13 @@ class OrderSettings(ObjectType):
         required=True,
         description=(
             "Determine if voucher applied on draft order should be count toward "
-            "voucher usage." + ADDED_IN_318 + PREVIEW_FEATURE
+            "voucher usage." + PREVIEW_FEATURE
         ),
     )
     draft_order_line_price_freeze_period = Hour(
         required=False,
         description=(
             "Time in hours after which the draft order line price will be refreshed."
-            + ADDED_IN_321
             + PREVIEW_FEATURE
         ),
     )
@@ -200,7 +195,7 @@ class OrderSettings(ObjectType):
             "returned in the `OrderLine.discounts` field. In this case, "
             "percentage-based vouchers retain their original type."
             "\nIn future releases, `OrderLineDiscount` will become the default "
-            "behavior, and this flag will be deprecated and removed." + ADDED_IN_321
+            "behavior, and this flag will be deprecated and removed."
         ),
     )
 
@@ -222,14 +217,12 @@ class PaymentSettings(ObjectType):
         required=False,
         description=(
             "Determine if the funds for expired checkouts should be released automatically."
-            + ADDED_IN_320
         ),
     )
     checkout_ttl_before_releasing_funds = Hour(
         required=False,
         description=(
             "The time in hours after which funds for expired checkouts will be released."
-            + ADDED_IN_320
         ),
     )
     checkout_release_funds_cut_off_date = DateTime(
@@ -238,7 +231,7 @@ class PaymentSettings(ObjectType):
             "Specifies the earliest date on which funds for expired checkouts can begin "
             "to be released. Expired checkouts dated before this cut-off will not have their "
             "funds released. Additionally, no funds will be released for checkouts that are "
-            "more than one year old, regardless of the cut-off date." + ADDED_IN_320
+            "more than one year old, regardless of the cut-off date."
         ),
     )
 
@@ -361,7 +354,7 @@ class Channel(ModelObjectType):
 
     tax_configuration = PermissionsField(
         "saleor.graphql.tax.types.TaxConfiguration",
-        description="Channel specific tax configuration." + ADDED_IN_320,
+        description="Channel specific tax configuration.",
         required=True,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_STAFF_USER,

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -9,7 +9,7 @@ from ....webhook.event_types import WebhookEventAsyncType
 from ...account.types import AddressInput
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
-from ...core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
@@ -43,8 +43,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
                 "Indicates whether the billing address should be saved "
                 "to the user’s address book upon checkout completion. "
                 "If not provided, the default behavior is to save the address."
-            )
-            + ADDED_IN_321,
+            ),
         )
         validation_rules = CheckoutAddressValidationRules(
             required=False,

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -22,7 +22,6 @@ from ...app.dataloaders import get_app_promise
 from ...channel.utils import clean_channel
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
-from ...core.descriptions import ADDED_IN_321
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import DeprecatedModelMutation
@@ -149,7 +148,6 @@ class CheckoutCreateInput(BaseInputObjectType):
             "Can only be set when a shipping address is provided. If not specified "
             "along with the address, the default behavior is to save the address."
         )
-        + ADDED_IN_321
     )
     shipping_address = AddressInput(
         description=(
@@ -166,7 +164,6 @@ class CheckoutCreateInput(BaseInputObjectType):
             "Can only be set when a billing address is provided. If not specified "
             "along with the address, the default behavior is to save the address."
         )
-        + ADDED_IN_321
     )
     billing_address = AddressInput(
         description=(
@@ -187,7 +184,6 @@ class CheckoutCreateInput(BaseInputObjectType):
         description=(
             f"Checkout public metadata. "
             f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}"
-            f"{ADDED_IN_321}"
         ),
         required=False,
     )
@@ -199,7 +195,6 @@ class CheckoutCreateInput(BaseInputObjectType):
             f"{CheckoutPermissions.MANAGE_CHECKOUTS.name}, "
             f"{CheckoutPermissions.HANDLE_CHECKOUTS.name} \n\n"
             f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}"
-            f"{ADDED_IN_321}"
         ),
         required=False,
     )

--- a/saleor/graphql/checkout/mutations/checkout_customer_note_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_note_update.py
@@ -4,7 +4,6 @@ from ....checkout.actions import call_checkout_event
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
-from ...core.descriptions import ADDED_IN_321
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.types import CheckoutError
@@ -26,9 +25,7 @@ class CheckoutCustomerNoteUpdate(BaseMutation):
         )
 
     class Meta:
-        description = (
-            "Updates customer note in the existing checkout object." + ADDED_IN_321
-        )
+        description = "Updates customer note in the existing checkout object."
         doc_category = DOC_CATEGORY_CHECKOUT
         error_type_class = CheckoutError
         error_type_field = "checkout_errors"

--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -9,7 +9,7 @@ from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...checkout.types import CheckoutLine
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.scalars import UUID, PositiveDecimal
 from ...core.types import BaseInputObjectType, CheckoutError, NonNullList
@@ -59,7 +59,7 @@ class CheckoutLineUpdateInput(BaseInputObjectType):
     metadata = NonNullList(
         MetadataInput,
         description=(
-            f"Checkout line public metadata. Will add and update keys. To delete keys use deleteMetadata mutation. {ADDED_IN_321} "
+            f"Checkout line public metadata. Will add and update keys. To delete keys use deleteMetadata mutation. "
             f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}"
         ),
         required=False,

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -22,7 +22,7 @@ from ....webhook.event_types import WebhookEventAsyncType
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
 from ...core.context import SyncWebhookControlContext
-from ...core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -66,8 +66,7 @@ class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixi
                 "Indicates whether the shipping address should be saved "
                 "to the user’s address book upon checkout completion. "
                 "If not provided, the default behavior is to save the address."
-            )
-            + ADDED_IN_321,
+            ),
         )
         validation_rules = CheckoutAddressValidationRules(
             required=False,

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -45,9 +45,6 @@ from ..core import ResolveInfo
 from ..core.connection import CountableConnection
 from ..core.context import ChannelContext
 from ..core.descriptions import (
-    ADDED_IN_318,
-    ADDED_IN_319,
-    ADDED_IN_321,
     ADDED_IN_323,
     PREVIEW_FEATURE,
 )
@@ -302,8 +299,7 @@ class CheckoutLine(SyncWebhookControlContextModelObjectType[models.CheckoutLine]
     )
     prior_unit_price = graphene.Field(
         Money,
-        description="The unit price of the checkout line prior to promotion."
-        + ADDED_IN_321,
+        description="The unit price of the checkout line prior to promotion.",
     )
     total_price = BaseField(
         TaxedMoney,
@@ -323,8 +319,7 @@ class CheckoutLine(SyncWebhookControlContextModelObjectType[models.CheckoutLine]
     )
     prior_total_price = graphene.Field(
         Money,
-        description="The sum of the checkout line price prior to promotion."
-        + ADDED_IN_321,
+        description="The sum of the checkout line price prior to promotion.",
     )
     requires_shipping = graphene.Boolean(
         description="Indicates whether the item need to be delivered.",
@@ -334,7 +329,7 @@ class CheckoutLine(SyncWebhookControlContextModelObjectType[models.CheckoutLine]
         CheckoutLineProblem, description="List of problems with the checkout line."
     )
     is_gift = graphene.Boolean(
-        description="Determine if the line is a gift." + ADDED_IN_319 + PREVIEW_FEATURE,
+        description="Determine if the line is a gift." + PREVIEW_FEATURE,
     )
 
     class Meta:
@@ -609,7 +604,7 @@ class Checkout(SyncWebhookControlContextModelObjectType[models.Checkout]):
         description="The shipping address of the checkout.",
     )
     customer_note = graphene.String(
-        required=True, description=f"The customer note for the checkout. {ADDED_IN_321}"
+        required=True, description="The customer note for the checkout. "
     )
     note = graphene.String(
         required=True,
@@ -636,7 +631,7 @@ class Checkout(SyncWebhookControlContextModelObjectType[models.Checkout]):
     )
     voucher = PermissionsField(
         "saleor.graphql.discount.types.vouchers.Voucher",
-        description="The voucher assigned to the checkout." + ADDED_IN_318,
+        description="The voucher assigned to the checkout.",
         permissions=[DiscountPermissions.MANAGE_DISCOUNTS],
     )
     voucher_code = graphene.String(

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -10,10 +10,6 @@ DEPRECATED_IN_3X_TYPE = "\n\nDEPRECATED: this type will be removed."
 
 DEPRECATED_IN_3X_EVENT = "\n\nDEPRECATED: this event will be removed."
 
-ADDED_IN_318 = "\n\nAdded in Saleor 3.18."
-ADDED_IN_319 = "\n\nAdded in Saleor 3.19."
-ADDED_IN_320 = "\n\nAdded in Saleor 3.20."
-ADDED_IN_321 = "\n\nAdded in Saleor 3.21."
 ADDED_IN_322 = "\n\nAdded in Saleor 3.22."
 ADDED_IN_323 = "\n\nAdded in Saleor 3.23."
 ADDED_IN_324 = "\n\nAdded in Saleor 3.24."

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -26,7 +26,6 @@ from ...core.doc_category import (
     DOC_CATEGORY_WEBHOOKS,
 )
 from ...core.scalars import DateTime, Decimal
-from ..descriptions import ADDED_IN_318
 from ..enums import (
     AccountErrorCode,
     AppErrorCode,
@@ -304,7 +303,7 @@ class DiscountError(ProductWithoutVariantError):
     )
     voucher_codes = NonNullList(
         graphene.String,
-        description="List of voucher codes which causes the error." + ADDED_IN_318,
+        description="List of voucher codes which causes the error.",
         required=False,
     )
 

--- a/saleor/graphql/csv/mutations/export_voucher_codes.py
+++ b/saleor/graphql/csv/mutations/export_voucher_codes.py
@@ -9,9 +9,6 @@ from ....permission.enums import DiscountPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import (
-    ADDED_IN_318,
-)
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.types import BaseInputObjectType, ExportError, NonNullList
 from ...core.utils import WebhookEventInfo, raise_validation_error
@@ -46,7 +43,7 @@ class ExportVoucherCodes(BaseExportMutation):
         )
 
     class Meta:
-        description = "Export voucher codes to csv/xlsx file." + ADDED_IN_318
+        description = "Export voucher codes to csv/xlsx file."
         doc_category = DOC_CATEGORY_DISCOUNTS
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
         error_type_class = ExportError

--- a/saleor/graphql/discount/inputs.py
+++ b/saleor/graphql/discount/inputs.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ..core.descriptions import ADDED_IN_319, PREVIEW_FEATURE
+from ..core.descriptions import PREVIEW_FEATURE
 from ..core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ..core.scalars import JSON, PositiveDecimal
 from ..core.types import BaseInputObjectType, NonNullList
@@ -86,7 +86,7 @@ class PromotionRuleBaseInput(BaseInputObjectType):
         OrderPredicateInput,
         description=(
             "Defines the conditions on the checkout/draft order level that must be met "
-            "for the reward to be applied." + ADDED_IN_319 + PREVIEW_FEATURE
+            "for the reward to be applied." + PREVIEW_FEATURE
         ),
     )
     reward_value_type = RewardValueTypeEnum(
@@ -101,7 +101,5 @@ class PromotionRuleBaseInput(BaseInputObjectType):
         ),
     )
     reward_type = RewardTypeEnum(
-        description="Defines the reward type of the promotion rule."
-        + ADDED_IN_319
-        + PREVIEW_FEATURE
+        description="Defines the reward type of the promotion rule." + PREVIEW_FEATURE
     )

--- a/saleor/graphql/discount/mutations/promotion/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_create.py
@@ -16,7 +16,7 @@ from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....channel.types import Channel
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_319, PREVIEW_FEATURE
+from ....core.descriptions import PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import DeprecatedModelMutation
 from ....core.scalars import JSON, DateTime
@@ -59,7 +59,6 @@ class PromotionRuleInput(PromotionRuleBaseInput):
     gifts = NonNullList(
         graphene.ID,
         description="Product variant IDs available as a gift to choose."
-        + ADDED_IN_319
         + PREVIEW_FEATURE,
     )
 
@@ -81,7 +80,7 @@ class PromotionCreateInput(PromotionInput):
         description=(
             "Defines the promotion type. Implicate the required promotion rules "
             "predicate type and whether the promotion rules will give the catalogue "
-            "or order discount. " + ADDED_IN_319
+            "or order discount. "
         ),
         required=True,
     )

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
@@ -11,7 +11,7 @@ from .....product.utils.product import mark_products_in_channels_as_dirty
 from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_319, PREVIEW_FEATURE
+from ....core.descriptions import PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import DeprecatedModelMutation
 from ....core.types import Error, NonNullList
@@ -53,17 +53,13 @@ class PromotionRuleUpdateInput(PromotionRuleBaseInput):
     add_gifts = NonNullList(
         graphene.ID,
         description=(
-            "List of variant IDs available as a gift to add."
-            + ADDED_IN_319
-            + PREVIEW_FEATURE
+            "List of variant IDs available as a gift to add." + PREVIEW_FEATURE
         ),
     )
     remove_gifts = NonNullList(
         graphene.ID,
         description=(
-            "List of variant IDs available as a gift to remove."
-            + ADDED_IN_319
-            + PREVIEW_FEATURE
+            "List of variant IDs available as a gift to remove." + PREVIEW_FEATURE
         ),
     )
 

--- a/saleor/graphql/discount/mutations/voucher/voucher_code_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_code_bulk_delete.py
@@ -4,7 +4,6 @@ from .....core.tracing import traced_atomic_transaction
 from .....discount import models
 from .....permission.enums import DiscountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
-from ....core.descriptions import ADDED_IN_318
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.enums import VoucherCodeBulkDeleteErrorCode
 from ....core.mutations import BaseMutation
@@ -27,7 +26,7 @@ class VoucherCodeBulkDelete(BaseMutation):
         )
 
     class Meta:
-        description = "Deletes voucher codes." + ADDED_IN_318
+        description = "Deletes voucher codes."
         model = models.VoucherCode
         object_type = VoucherCode
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/voucher/voucher_create.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_create.py
@@ -10,7 +10,6 @@ from .....webhook.event_types import WebhookEventAsyncType
 from ....core import ResolveInfo
 from ....core.context import ChannelContext
 from ....core.descriptions import (
-    ADDED_IN_318,
     DEPRECATED_IN_3X_INPUT,
     PREVIEW_FEATURE,
 )
@@ -43,7 +42,7 @@ class VoucherInput(BaseInputObjectType):
     add_codes = NonNullList(
         graphene.String,
         required=False,
-        description="List of codes to add." + ADDED_IN_318 + PREVIEW_FEATURE,
+        description="List of codes to add." + PREVIEW_FEATURE,
     )
     start_date = DateTime(description="Start date of the voucher in ISO 8601 format.")
     end_date = DateTime(description="End date of the voucher in ISO 8601 format.")
@@ -89,7 +88,7 @@ class VoucherInput(BaseInputObjectType):
             "When set to 'True', each voucher code can be used only once; "
             "otherwise, codes can be used multiple times depending on `usageLimit`."
             "\n\nThe option can only be changed if none of the voucher codes "
-            "have been used." + ADDED_IN_318 + PREVIEW_FEATURE
+            "have been used." + PREVIEW_FEATURE
         )
     )
     usage_limit = graphene.Int(

--- a/saleor/graphql/discount/sorters.py
+++ b/saleor/graphql/discount/sorters.py
@@ -3,7 +3,6 @@ from django.db.models import F, Min, OuterRef, Q, QuerySet, Subquery
 
 from ...discount.models import VoucherCode
 from ..core.descriptions import (
-    ADDED_IN_318,
     CHANNEL_REQUIRED,
     DEFAULT_DEPRECATION_REASON,
 )
@@ -77,7 +76,6 @@ class VoucherSortField(graphene.Enum):
         descrption_extras = {
             VoucherSortField.VALUE.name: [CHANNEL_REQUIRED],  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
             VoucherSortField.MINIMUM_SPENT_AMOUNT.name: [CHANNEL_REQUIRED],  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
-            VoucherSortField.NAME.name: [ADDED_IN_318],  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
         }
         if self.name in VoucherSortField.__enum__._member_names_:
             sort_name = self.name.lower().replace("_", " ")

--- a/saleor/graphql/discount/types/discounts.py
+++ b/saleor/graphql/discount/types/discounts.py
@@ -8,7 +8,6 @@ from ....core.prices import quantize_price
 from ....discount import models
 from ....permission.enums import OrderPermissions
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_321
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.fields import PermissionsField
 from ...core.scalars import PositiveDecimal
@@ -62,7 +61,7 @@ class OrderDiscount(BaseOrderDiscount[models.OrderDiscount]):
     total = graphene.Field(
         Money,
         required=True,
-        description="The amount of discount applied to the order." + ADDED_IN_321,
+        description="The amount of discount applied to the order.",
     )
 
     class Meta:

--- a/saleor/graphql/discount/types/promotions.py
+++ b/saleor/graphql/discount/types/promotions.py
@@ -6,7 +6,7 @@ from ....permission.auth_filters import AuthorizationFilters
 from ...channel.types import Channel
 from ...core import ResolveInfo
 from ...core.connection import CountableConnection
-from ...core.descriptions import ADDED_IN_319, PREVIEW_FEATURE
+from ...core.descriptions import PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import PermissionsField
 from ...core.scalars import JSON, DateTime, PositiveDecimal
@@ -31,7 +31,7 @@ class Promotion(ModelObjectType[models.Promotion]):
     type = PromotionTypeEnum(
         description=(
             "The type of the promotion. Implicate if the discount is applied on "
-            "catalogue or order level." + ADDED_IN_319 + PREVIEW_FEATURE
+            "catalogue or order level." + PREVIEW_FEATURE
         )
     )
     description = JSON(description="Description of the promotion.")
@@ -86,7 +86,7 @@ class PromotionRule(ModelObjectType[models.PromotionRule]):
     reward_value = PositiveDecimal(
         description=(
             "The reward value of the promotion rule. Defines the discount value "
-            "applied when the rule conditions are met." + ADDED_IN_319 + PREVIEW_FEATURE
+            "applied when the rule conditions are met." + PREVIEW_FEATURE
         )
     )
     reward_value_type = RewardValueTypeEnum(
@@ -95,7 +95,6 @@ class PromotionRule(ModelObjectType[models.PromotionRule]):
     predicate_type = PromotionTypeEnum(
         description=(
             "The type of the predicate that must be met to apply the reward."
-            + ADDED_IN_319
             + PREVIEW_FEATURE
         )
     )
@@ -107,26 +106,21 @@ class PromotionRule(ModelObjectType[models.PromotionRule]):
     order_predicate = JSON(
         description=(
             "The checkout/order predicate that must be met to apply the rule reward."
-            + ADDED_IN_319
             + PREVIEW_FEATURE
         ),
     )
     reward_type = RewardTypeEnum(
-        description="The reward type of the promotion rule."
-        + ADDED_IN_319
-        + PREVIEW_FEATURE
+        description="The reward type of the promotion rule." + PREVIEW_FEATURE
     )
     translation = TranslationField(PromotionRuleTranslation, type_name="promotion rule")
     gift_ids = NonNullList(
         graphene.ID,
         description="Product variant IDs available as a gift to choose."
-        + ADDED_IN_319
         + PREVIEW_FEATURE,
     )
     gifts_limit = graphene.Int(
         default_value=1,
         description="Defines the maximum number of gifts to choose from the gifts list."
-        + ADDED_IN_319
         + PREVIEW_FEATURE,
     )
 

--- a/saleor/graphql/discount/types/vouchers.py
+++ b/saleor/graphql/discount/types/vouchers.py
@@ -12,7 +12,7 @@ from ...core.context import (
     ChannelQsContext,
     get_database_connection_name,
 )
-from ...core.descriptions import ADDED_IN_318, DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import ConnectionField, PermissionsField
 from ...core.scalars import DateTime
@@ -71,7 +71,7 @@ class VoucherCode(ModelObjectType[models.VoucherCode]):
     created_at = DateTime(required=True, description="Date time of code creation.")
 
     class Meta:
-        description = "Represents voucher code." + ADDED_IN_318 + PREVIEW_FEATURE
+        description = "Represents voucher code." + PREVIEW_FEATURE
         model = models.VoucherCode
 
 
@@ -86,7 +86,7 @@ class Voucher(ChannelContextType[models.Voucher]):
     name = graphene.String(description="The name of the voucher.")
     codes = ConnectionField(
         VoucherCodeCountableConnection,
-        description="List of codes available for this voucher." + ADDED_IN_318,
+        description="List of codes available for this voucher.",
     )
     code = graphene.String(
         description="The code of the voucher." + DEPRECATED_IN_3X_INPUT
@@ -115,7 +115,6 @@ class Voucher(ChannelContextType[models.Voucher]):
         required=True,
         description=(
             "Determine if the voucher codes can be used once or multiple times."
-            + ADDED_IN_318
             + PREVIEW_FEATURE
         ),
     )

--- a/saleor/graphql/giftcard/mutations/gift_card_create.py
+++ b/saleor/graphql/giftcard/mutations/gift_card_create.py
@@ -15,7 +15,7 @@ from ....permission.enums import GiftcardPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ...core.mutations import DeprecatedModelMutation
 from ...core.scalars import Date
@@ -37,14 +37,14 @@ class GiftCardInput(BaseInputObjectType):
     metadata = NonNullList(
         MetadataInput,
         description=(
-            f"Gift Card public metadata. {ADDED_IN_321} "
+            f"Gift Card public metadata. "
             f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}"
         ),
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description=f"Gift Card private metadata. {ADDED_IN_321} "
+        description=f"Gift Card private metadata. "
         f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -58,7 +58,6 @@ from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
-from ...core.descriptions import ADDED_IN_318, ADDED_IN_319
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.enums import ErrorPolicy, ErrorPolicyEnum, LanguageCodeEnum
 from ...core.mutations import BaseMutation
@@ -489,7 +488,7 @@ class OrderBulkCreateOrderLineInput(BaseInputObjectType):
     product_name = graphene.String(description="The name of the product.")
     product_sku = graphene.String(
         required=False,
-        description="The SKU of the product." + ADDED_IN_318,
+        description="The SKU of the product.",
     )
     translated_variant_name = graphene.String(
         description="Translation of the product variant name."
@@ -518,16 +517,15 @@ class OrderBulkCreateOrderLineInput(BaseInputObjectType):
     )
     unit_discount_reason = graphene.String(
         required=False,
-        description="Reason of the discount on order line." + ADDED_IN_319,
+        description="Reason of the discount on order line.",
     )
     unit_discount_type = graphene.Field(
         DiscountValueTypeEnum,
         required=False,
-        description="Type of the discount: fixed or percent" + ADDED_IN_319,
+        description="Type of the discount: fixed or percent",
     )
     unit_discount_value = PositiveDecimal(
-        description="Value of the discount. Can store fixed value or percent value"
-        + ADDED_IN_319,
+        description="Value of the discount. Can store fixed value or percent value",
         required=False,
     )
     warehouse = graphene.ID(
@@ -622,7 +620,7 @@ class OrderBulkCreateInput(BaseInputObjectType):
         description="List of gift card codes associated with the order.",
     )
     voucher_code = graphene.String(
-        description="Code of a voucher associated with the order." + ADDED_IN_318
+        description="Code of a voucher associated with the order."
     )
     discounts = NonNullList(OrderDiscountCommonInput, description="List of discounts.")
     fulfillments = NonNullList(

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -30,7 +30,7 @@ from ...account.types import AddressInput
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
-from ...core.descriptions import ADDED_IN_318, ADDED_IN_321, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import ModelWithRestrictedChannelAccessMutation
@@ -95,7 +95,6 @@ class DraftOrderInput(BaseInputObjectType):
             "Can only be set when a billing address is provided. If not specified "
             "along with the address, the default behavior is to not save the address."
         )
-        + ADDED_IN_321
     )
     user = graphene.ID(
         description="Customer associated with the draft order.", name="user"
@@ -116,7 +115,6 @@ class DraftOrderInput(BaseInputObjectType):
             "Can only be set when a shipping address is provided. If not specified "
             "along with the address, the default behavior is to not save the address."
         )
-        + ADDED_IN_321
     )
     shipping_method = graphene.ID(
         description="ID of a selected shipping method.", name="shippingMethod"
@@ -128,7 +126,7 @@ class DraftOrderInput(BaseInputObjectType):
         deprecation_reason="Use `voucherCode` instead.",
     )
     voucher_code = graphene.String(
-        description="A code of the voucher associated with the order." + ADDED_IN_318,
+        description="A code of the voucher associated with the order.",
         name="voucherCode",
     )
     customer_note = graphene.String(
@@ -147,13 +145,13 @@ class DraftOrderInput(BaseInputObjectType):
     )
     metadata = NonNullList(
         MetadataInput,
-        description=f"Order public metadata. {ADDED_IN_321} "
+        description=f"Order public metadata. "
         f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}",
         required=False,
     )
     private_metadata = NonNullList(
         MetadataInput,
-        description=f"Order private metadata. {ADDED_IN_321} "
+        description=f"Order private metadata. "
         f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}",
         required=False,
     )
@@ -161,7 +159,7 @@ class DraftOrderInput(BaseInputObjectType):
     language_code = graphene.Argument(
         LanguageCodeEnum,
         required=False,
-        description=(f"Order language code.{ADDED_IN_321}"),
+        description=("Order language code."),
     )
 
     class Meta:

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -12,7 +12,6 @@ from ....permission.enums import OrderPermissions
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import (
-    ADDED_IN_320,
     ADDED_IN_322,
     ADDED_IN_323,
     PREVIEW_FEATURE,
@@ -100,7 +99,7 @@ class OrderGrantRefundCreateInput(BaseInputObjectType):
             "If `amount` is not provided in the input and calculated automatically by "
             "Saleor, the `min(calculatedAmount, transaction.chargedAmount)` will be "
             "used. "
-            "Field required starting from Saleor 3.21." + ADDED_IN_320 + PREVIEW_FEATURE
+            "Field required starting from Saleor 3.21." + PREVIEW_FEATURE
         ),
         required=True,
     )

--- a/saleor/graphql/order/mutations/order_grant_refund_update.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_update.py
@@ -12,7 +12,6 @@ from ....permission.enums import OrderPermissions
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
 from ...core.descriptions import (
-    ADDED_IN_320,
     ADDED_IN_322,
     ADDED_IN_323,
     PREVIEW_FEATURE,
@@ -112,9 +111,7 @@ class OrderGrantRefundUpdateInput(BaseInputObjectType):
             "If `amount` is not provided in the input and calculated automatically by "
             "Saleor, the `min(calculatedAmount, transaction.chargedAmount)` will be "
             "used."
-            "Field will be required starting from Saleor 3.21."
-            + ADDED_IN_320
-            + PREVIEW_FEATURE
+            "Field will be required starting from Saleor 3.21." + PREVIEW_FEATURE
         ),
         required=False,
     )

--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -21,7 +21,6 @@ from ...account.mutations.account.utils import ADDRESS_UPDATE_FIELDS
 from ...account.types import AddressInput
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
-from ...core.descriptions import ADDED_IN_321
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import ModelWithExtRefMutation
@@ -43,8 +42,7 @@ class OrderUpdateInput(BaseInputObjectType):
     metadata = NonNullList(
         MetadataInput,
         description=(
-            f"Order public metadata. {ADDED_IN_321}"
-            f"{MetadataInputDescription.PUBLIC_METADATA_INPUT}"
+            f"Order public metadata. {MetadataInputDescription.PUBLIC_METADATA_INPUT}"
         ),
         required=False,
     )
@@ -52,8 +50,7 @@ class OrderUpdateInput(BaseInputObjectType):
     private_metadata = NonNullList(
         MetadataInput,
         description=(
-            f"Order private metadata. {ADDED_IN_321}"
-            f"{MetadataInputDescription.PRIVATE_METADATA_INPUT}"
+            f"Order private metadata. {MetadataInputDescription.PRIVATE_METADATA_INPUT}"
         ),
         required=False,
     )
@@ -61,7 +58,7 @@ class OrderUpdateInput(BaseInputObjectType):
     language_code = graphene.Argument(
         LanguageCodeEnum,
         required=False,
-        description=(f"Order language code.{ADDED_IN_321}"),
+        description=("Order language code."),
     )
 
     class Meta:

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -75,10 +75,6 @@ from ..checkout.utils import prevent_sync_event_circular_query
 from ..core.connection import CountableConnection
 from ..core.context import ChannelContext
 from ..core.descriptions import (
-    ADDED_IN_318,
-    ADDED_IN_319,
-    ADDED_IN_320,
-    ADDED_IN_321,
     ADDED_IN_322,
     ADDED_IN_323,
     DEPRECATED_IN_3X_INPUT,
@@ -355,19 +351,17 @@ class OrderGrantedRefund(
         required=True,
         description=(
             "Status of the granted refund calculated based on transactionItem assigned "
-            "to granted refund." + ADDED_IN_320
+            "to granted refund."
         ),
     )
     transaction_events = NonNullList(
         TransactionEvent,
-        description=(
-            "List of refund events associated with the granted refund." + ADDED_IN_320
-        ),
+        description=("List of refund events associated with the granted refund."),
     )
 
     transaction = graphene.Field(
         TransactionItem,
-        description="The transaction assigned to the granted refund." + ADDED_IN_320,
+        description="The transaction assigned to the granted refund.",
     )
 
     class Meta:
@@ -1248,11 +1242,11 @@ class OrderLine(
         required=False, description="Voucher code that was used for this order line."
     )
     is_gift = graphene.Boolean(
-        description="Determine if the line is a gift." + ADDED_IN_319 + PREVIEW_FEATURE,
+        description="Determine if the line is a gift." + PREVIEW_FEATURE,
     )
     discounts = NonNullList(
         "saleor.graphql.discount.types.discounts.OrderLineDiscount",
-        description="List of applied discounts" + ADDED_IN_321,
+        description="List of applied discounts",
     )
 
     class Meta:
@@ -1741,7 +1735,7 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
     )
     undiscounted_shipping_price = graphene.Field(
         Money,
-        description="Undiscounted total price of shipping." + ADDED_IN_319,
+        description="Undiscounted total price of shipping.",
         required=True,
     )
     shipping_price = graphene.Field(
@@ -1788,7 +1782,7 @@ class Order(SyncWebhookControlContextModelObjectType[ModelObjectType[models.Orde
     voucher = graphene.Field(Voucher, description="Voucher linked to the order.")
     voucher_code = graphene.String(
         required=False,
-        description="Voucher code that was used for Order." + ADDED_IN_318,
+        description="Voucher code that was used for Order.",
     )
     gift_cards = NonNullList(
         GiftCard, description="List of user gift cards.", required=True

--- a/saleor/graphql/page/schema.py
+++ b/saleor/graphql/page/schema.py
@@ -5,7 +5,7 @@ from ..channel.dataloaders.by_self import ChannelBySlugLoader
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.context import ChannelContext, ChannelQsContext
-from ..core.descriptions import ADDED_IN_321, ADDED_IN_322, DEPRECATED_IN_3X_INPUT
+from ..core.descriptions import ADDED_IN_322, DEPRECATED_IN_3X_INPUT
 from ..core.doc_category import DOC_CATEGORY_PAGES
 from ..core.enums import LanguageCodeEnum
 from ..core.fields import BaseField, FilterConnectionField
@@ -42,8 +42,7 @@ class PageQueries(graphene.ObjectType):
         slug=graphene.String(description="The slug of the page."),
         slug_language_code=graphene.Argument(
             LanguageCodeEnum,
-            description="Language code of the page slug, omit to use primary slug."
-            + ADDED_IN_321,
+            description="Language code of the page slug, omit to use primary slug.",
         ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -22,7 +22,7 @@ from ...channel.mutations import BaseChannelListingMutation
 from ...channel.types import Channel
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
-from ...core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.mutations import BaseMutation
 from ...core.scalars import Date, DateTime, PositiveDecimal
@@ -391,7 +391,7 @@ class ProductVariantChannelListingAddInput(BaseInputObjectType):
     prior_price = PositiveDecimal(
         description="Previous price of the variant in channel. Useful for providing "
         "promotion information required by customer protection laws such as EU Omnibus "
-        "directive." + ADDED_IN_321
+        "directive."
     )
     preorder_threshold = graphene.Int(
         description="The threshold for preorder variant in channel."

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -13,7 +13,6 @@ from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.context import ChannelContext, ChannelQsContext
 from ..core.descriptions import (
-    ADDED_IN_321,
     ADDED_IN_322,
     DEFAULT_DEPRECATION_REASON,
     DEPRECATED_IN_3X_INPUT,
@@ -157,8 +156,7 @@ class ProductQueries(graphene.ObjectType):
         slug=graphene.Argument(graphene.String, description="Slug of the category"),
         slug_language_code=graphene.Argument(
             LanguageCodeEnum,
-            description="Language code of the category slug, omit to use primary slug."
-            + ADDED_IN_321,
+            description="Language code of the category slug, omit to use primary slug.",
         ),
         description="Look up a category by ID or slug.",
         doc_category=DOC_CATEGORY_PRODUCTS,
@@ -172,8 +170,7 @@ class ProductQueries(graphene.ObjectType):
         slug=graphene.Argument(graphene.String, description="Slug of the collection"),
         slug_language_code=graphene.Argument(
             LanguageCodeEnum,
-            description="Language code of the collection slug, omit to use primary slug."
-            + ADDED_IN_321,
+            description="Language code of the collection slug, omit to use primary slug.",
         ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
@@ -212,8 +209,7 @@ class ProductQueries(graphene.ObjectType):
         slug=graphene.Argument(graphene.String, description="Slug of the product."),
         slug_language_code=graphene.Argument(
             LanguageCodeEnum,
-            description="Language code of the product slug, omit to use primary slug."
-            + ADDED_IN_321,
+            description="Language code of the product slug, omit to use primary slug.",
         ),
         external_reference=graphene.Argument(
             graphene.String, description="External ID of the product."

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -21,7 +21,6 @@ from ....tax.utils import (
 from ...account import types as account_types
 from ...channel.dataloaders.by_self import ChannelByIdLoader
 from ...channel.types import Channel
-from ...core.descriptions import ADDED_IN_321
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.fields import PermissionsField
 from ...core.scalars import Date, DateTime
@@ -322,8 +321,7 @@ class ProductVariantChannelListing(
         Money,
         description="Previous price of the variant in channel. Useful for providing "
         "promotion information required by customer protection laws such as EU Omnibus "
-        "directive.\n\n Warning: This field is not updated automatically. Use Channel Listings mutation to update it manually."
-        + ADDED_IN_321,
+        "directive.\n\n Warning: This field is not updated automatically. Use Channel Listings mutation to update it manually.",
     )
     margin = PermissionsField(
         graphene.Int,

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -66,7 +66,6 @@ from ...core.context import (
     get_database_connection_name,
 )
 from ...core.descriptions import (
-    ADDED_IN_321,
     ADDED_IN_322,
     DEPRECATED_IN_3X_INPUT,
     RICH_CONTENT,
@@ -206,7 +205,6 @@ class BasePricingInfo(BaseObjectType):
         description=(
             "The discount amount compared to prior price. Null if product "
             "is not on sale or prior price was not provided in VariantChannelListing"
-            + ADDED_IN_321
         ),
     )
 
@@ -229,9 +227,7 @@ class VariantPricingInfo(BasePricingInfo):
     price_undiscounted = graphene.Field(
         TaxedMoney, description="The price without any discount."
     )
-    price_prior = graphene.Field(
-        TaxedMoney, description="The price prior to discount." + ADDED_IN_321
-    )
+    price_prior = graphene.Field(TaxedMoney, description="The price prior to discount.")
 
     # deprecated
     discount_local_currency = graphene.Field(
@@ -265,7 +261,7 @@ class ProductPricingInfo(BasePricingInfo):
     )
     price_range_prior = graphene.Field(
         TaxedMoneyRange,
-        description="The prior price range of the product variants." + ADDED_IN_321,
+        description="The prior price range of the product variants.",
     )
 
     # deprecated
@@ -1068,7 +1064,7 @@ class Product(ChannelContextType[models.Product]):
         description=(
             "List of variants for the product. Requires the following permissions to "
             "include the unpublished items: "
-            f"{', '.join([p.name for p in ALL_PRODUCTS_PERMISSIONS])}." + ADDED_IN_321
+            f"{', '.join([p.name for p in ALL_PRODUCTS_PERMISSIONS])}."
         ),
     )
     media = NonNullList(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -352,11 +352,7 @@ type Query {
     """Slug of the category"""
     slug: String
 
-    """
-    Language code of the category slug, omit to use primary slug.
-    
-    Added in Saleor 3.21.
-    """
+    """Language code of the category slug, omit to use primary slug."""
     slugLanguageCode: LanguageCodeEnum
   ): Category @doc(category: "Products")
 
@@ -370,11 +366,7 @@ type Query {
     """Slug of the collection"""
     slug: String
 
-    """
-    Language code of the collection slug, omit to use primary slug.
-    
-    Added in Saleor 3.21.
-    """
+    """Language code of the collection slug, omit to use primary slug."""
     slugLanguageCode: LanguageCodeEnum
 
     """Slug of a channel for which the data should be returned."""
@@ -424,11 +416,7 @@ type Query {
     """Slug of the product."""
     slug: String
 
-    """
-    Language code of the product slug, omit to use primary slug.
-    
-    Added in Saleor 3.21.
-    """
+    """Language code of the product slug, omit to use primary slug."""
     slugLanguageCode: LanguageCodeEnum
 
     """External ID of the product."""
@@ -690,11 +678,7 @@ type Query {
     """The slug of the page."""
     slug: String
 
-    """
-    Language code of the page slug, omit to use primary slug.
-    
-    Added in Saleor 3.21.
-    """
+    """Language code of the page slug, omit to use primary slug."""
     slugLanguageCode: LanguageCodeEnum
 
     """
@@ -2218,11 +2202,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   """A voucher metadata is updated."""
   VOUCHER_METADATA_UPDATED
 
-  """
-  A voucher code export is completed.
-  
-  Added in Saleor 3.18.
-  """
+  """A voucher code export is completed."""
   VOUCHER_CODE_EXPORT_COMPLETED
 
   """An observability event is created."""
@@ -2831,11 +2811,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   """A voucher metadata is updated."""
   VOUCHER_METADATA_UPDATED
 
-  """
-  A voucher code export is completed.
-  
-  Added in Saleor 3.18.
-  """
+  """A voucher code export is completed."""
   VOUCHER_CODE_EXPORT_COMPLETED
 
   """An observability event is created."""
@@ -2883,11 +2859,7 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
   """
   metafields(keys: [String!]): Metadata
 
-  """
-  Canonical app ID from the manifest
-  
-  Added in Saleor 3.19.
-  """
+  """Canonical app ID from the manifest"""
   identifier: String
 
   """List of the app's permissions."""
@@ -2970,18 +2942,10 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
   """App's brand data."""
   brand: AppBrand
 
-  """
-  Circuit breaker state, if open, sync webhooks operation is disrupted.
-  
-  Added in Saleor 3.21.
-  """
+  """Circuit breaker state, if open, sync webhooks operation is disrupted."""
   breakerState: CircuitBreakerStateEnum!
 
-  """
-  Circuit breaker last state change date.
-  
-  Added in Saleor 3.21.
-  """
+  """Circuit breaker last state change date."""
   breakerLastStateChange: DateTime
 }
 
@@ -3641,11 +3605,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   """The shipping address of the checkout."""
   shippingAddress: Address
 
-  """
-  The customer note for the checkout. 
-  
-  Added in Saleor 3.21.
-  """
+  """The customer note for the checkout."""
   customerNote: String!
 
   """The note for the checkout."""
@@ -3666,8 +3626,6 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
 
   """
   The voucher assigned to the checkout.
-  
-  Added in Saleor 3.18.
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
@@ -3946,8 +3904,6 @@ type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
   """
   Channel specific tax configuration.
   
-  Added in Saleor 3.20.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxConfiguration: TaxConfiguration!
@@ -4030,8 +3986,6 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
 
   """
   Stocks that belong to this warehouse.
-  
-  Added in Saleor 3.20.
   
   Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
   """
@@ -6956,8 +6910,6 @@ type Product implements Node & ObjectWithMetadata & ObjectWithAttributes @doc(ca
 
   """
   List of variants for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
-  
-  Added in Saleor 3.21.
   """
   productVariants(
     """Filtering options for product variant."""
@@ -8629,11 +8581,7 @@ type CategoryTranslation implements Node @doc(category: "Products") {
   """Translated SEO description."""
   seoDescription: String
 
-  """
-  Translated category slug.
-  
-  Added in Saleor 3.21.
-  """
+  """Translated category slug."""
   slug: String
 
   """Translated category name."""
@@ -8673,11 +8621,7 @@ type CategoryTranslatableContent implements Node @doc(category: "Products") {
   """SEO description to translate."""
   seoDescription: String
 
-  """
-  Slug to translate.
-  
-  Added in Saleor 3.21.
-  """
+  """Slug to translate."""
   slug: String
 
   """Name of the category translatable content."""
@@ -8900,8 +8844,6 @@ type ProductVariantChannelListing implements Node @doc(category: "Products") {
   Previous price of the variant in channel. Useful for providing promotion information required by customer protection laws such as EU Omnibus directive.
   
    Warning: This field is not updated automatically. Use Channel Listings mutation to update it manually.
-  
-  Added in Saleor 3.21.
   """
   priorPrice: Money
 
@@ -8935,8 +8877,6 @@ type VariantPricingInfo @doc(category: "Products") {
 
   """
   The discount amount compared to prior price. Null if product is not on sale or prior price was not provided in VariantChannelListing
-  
-  Added in Saleor 3.21.
   """
   discountPrior: TaxedMoney
 
@@ -8949,11 +8889,7 @@ type VariantPricingInfo @doc(category: "Products") {
   """The price without any discount."""
   priceUndiscounted: TaxedMoney
 
-  """
-  The price prior to discount.
-  
-  Added in Saleor 3.21.
-  """
+  """The price prior to discount."""
   pricePrior: TaxedMoney
 
   """The discounted price in the local currency."""
@@ -9024,8 +8960,6 @@ input AddressInput {
 
   """
   Determine if the address should be validated. By default, Saleor accepts only address inputs matching ruleset from [Google Address Data]{https://chromium-i18n.appspot.com/ssl-address), using [i18naddress](https://github.com/mirumee/google-i18n-address) library. Some mutations may require additional permissions to use the the field. More info about permissions can be found in relevant mutation.
-  
-  Added in Saleor 3.19.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -10014,8 +9948,6 @@ type ProductPricingInfo @doc(category: "Products") {
 
   """
   The discount amount compared to prior price. Null if product is not on sale or prior price was not provided in VariantChannelListing
-  
-  Added in Saleor 3.21.
   """
   discountPrior: TaxedMoney
 
@@ -10031,11 +9963,7 @@ type ProductPricingInfo @doc(category: "Products") {
   """The undiscounted price range of the product variants."""
   priceRangeUndiscounted: TaxedMoneyRange
 
-  """
-  The prior price range of the product variants.
-  
-  Added in Saleor 3.21.
-  """
+  """The prior price range of the product variants."""
   priceRangePrior: TaxedMoneyRange
 
   """
@@ -10354,11 +10282,7 @@ type CollectionTranslation implements Node @doc(category: "Products") {
   """Translated SEO description."""
   seoDescription: String
 
-  """
-  Translated collection slug.
-  
-  Added in Saleor 3.21.
-  """
+  """Translated collection slug."""
   slug: String
 
   """Translated collection name."""
@@ -10398,11 +10322,7 @@ type CollectionTranslatableContent implements Node @doc(category: "Products") {
   """SEO description to translate."""
   seoDescription: String
 
-  """
-  Slug to translate
-  
-  Added in Saleor 3.21.
-  """
+  """Slug to translate"""
   slug: String
 
   """Collection's name to translate."""
@@ -10462,11 +10382,7 @@ type ProductTranslation implements Node @doc(category: "Products") {
   """Translated SEO description."""
   seoDescription: String
 
-  """
-  Translated product slug.
-  
-  Added in Saleor 3.21.
-  """
+  """Translated product slug."""
   slug: String
 
   """Translated product name."""
@@ -10506,11 +10422,7 @@ type ProductTranslatableContent implements Node @doc(category: "Products") {
   """SEO description to translate."""
   seoDescription: String
 
-  """
-  Slug to translate.
-  
-  Added in Saleor 3.21.
-  """
+  """Slug to translate."""
   slug: String
 
   """Product's name to translate."""
@@ -10709,16 +10621,12 @@ type OrderSettings {
   """
   Determine if voucher applied on draft order should be count toward voucher usage.
   
-  Added in Saleor 3.18.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   includeDraftOrderInVoucherUsage: Boolean!
 
   """
   Time in hours after which the draft order line price will be refreshed.
-  
-  Added in Saleor 3.21.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -10729,8 +10637,6 @@ type OrderSettings {
   - When legacy propagation is enabled, discounts from these vouchers are represented as `OrderDiscount` objects, attached to the order and returned in the `Order.discounts` field. Additionally, percentage-based vouchers are converted to fixed-value discounts.
   - When legacy propagation is disabled, discounts are represented as `OrderLineDiscount` objects, attached to individual lines and returned in the `OrderLine.discounts` field. In this case, percentage-based vouchers retain their original type.
   In future releases, `OrderLineDiscount` will become the default behavior, and this flag will be deprecated and removed.
-  
-  Added in Saleor 3.21.
   """
   useLegacyLineDiscountPropagation: Boolean!
 }
@@ -10769,8 +10675,6 @@ type CheckoutSettings {
 
   """
   Default `false`. Determines if the paid checkouts should be automatically completed. This setting applies only to checkouts where payment was processed through transactions.When enabled, the checkout will be automatically completed once the checkout `charge_status` reaches `FULL`. This occurs when the total sum of charged and authorized transaction amounts equals or exceeds the checkout's total amount.
-  
-  Added in Saleor 3.20.
   """
   automaticallyCompleteFullyPaidCheckouts: Boolean!
 
@@ -10805,22 +10709,16 @@ type PaymentSettings {
 
   """
   Determine if the funds for expired checkouts should be released automatically.
-  
-  Added in Saleor 3.20.
   """
   releaseFundsForExpiredCheckouts: Boolean
 
   """
   The time in hours after which funds for expired checkouts will be released.
-  
-  Added in Saleor 3.20.
   """
   checkoutTtlBeforeReleasingFunds: Hour
 
   """
   Specifies the earliest date on which funds for expired checkouts can begin to be released. Expired checkouts dated before this cut-off will not have their funds released. Additionally, no funds will be released for checkouts that are more than one year old, regardless of the cut-off date.
-  
-  Added in Saleor 3.20.
   """
   checkoutReleaseFundsCutOffDate: DateTime
 }
@@ -10893,15 +10791,11 @@ type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes
 
   """
   The tax app `App.identifier` that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
-  
-  Added in Saleor 3.19.
   """
   taxAppId: String
 
   """
   Determines whether to use weighted tax for shipping. When set to true, the tax rate for shipping will be calculated based on the weighted average of tax rates from the order or checkout lines.
-  
-  Added in Saleor 3.21.
   """
   useWeightedTaxForShipping: Boolean
 }
@@ -10931,15 +10825,11 @@ type TaxConfigurationPerCountry @doc(category: "Taxes") {
 
   """
   The tax app `App.identifier` that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
-  
-  Added in Saleor 3.19.
   """
   taxAppId: String
 
   """
   Determines whether to use weighted tax for shipping. When set to true, the tax rate for shipping will be calculated based on the weighted average of tax rates from the order or checkout lines.
-  
-  Added in Saleor 3.21.
   """
   useWeightedTaxForShipping: Boolean
 }
@@ -10984,11 +10874,7 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
   """The name of the voucher."""
   name: String
 
-  """
-  List of codes available for this voucher.
-  
-  Added in Saleor 3.18.
-  """
+  """List of codes available for this voucher."""
   codes(
     """Return the elements in the list that come before the specified cursor."""
     before: String
@@ -11034,8 +10920,6 @@ type Voucher implements Node & ObjectWithMetadata @doc(category: "Discounts") {
 
   """
   Determine if the voucher codes can be used once or multiple times.
-  
-  Added in Saleor 3.18.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -11186,8 +11070,6 @@ type VoucherCodeCountableEdge @doc(category: "Discounts") {
 
 """
 Represents voucher code.
-
-Added in Saleor 3.18.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -11586,11 +11468,7 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
   """The unit price of the checkout line, without discounts."""
   undiscountedUnitPrice: Money!
 
-  """
-  The unit price of the checkout line prior to promotion.
-  
-  Added in Saleor 3.21.
-  """
+  """The unit price of the checkout line prior to promotion."""
   priorUnitPrice: Money
 
   """
@@ -11604,11 +11482,7 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
   """The sum of the checkout line price, without discounts."""
   undiscountedTotalPrice: Money!
 
-  """
-  The sum of the checkout line price prior to promotion.
-  
-  Added in Saleor 3.21.
-  """
+  """The sum of the checkout line price prior to promotion."""
   priorTotalPrice: Money
 
   """Indicates whether the item need to be delivered."""
@@ -11619,8 +11493,6 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
 
   """
   Determine if the line is a gift.
-  
-  Added in Saleor 3.19.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -11799,7 +11671,7 @@ Represents possible actions on payment transaction.
     The following actions are possible:
     CHARGE - Represents the charge action.
     REFUND - Represents a refund action.
-    CANCEL - Represents a cancel action. Added in Saleor 3.12.
+    CANCEL - Represents a cancel action.
 """
 enum TransactionActionEnum @doc(category: "Payments") {
   CHARGE
@@ -11949,11 +11821,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Shipping method for this order."""
   shippingMethod: ShippingMethod @deprecated(reason: "Use `deliveryMethod` instead.")
 
-  """
-  Undiscounted total price of shipping.
-  
-  Added in Saleor 3.19.
-  """
+  """Undiscounted total price of shipping."""
   undiscountedShippingPrice: Money!
 
   """Total price of shipping."""
@@ -11984,11 +11852,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Voucher linked to the order."""
   voucher: Voucher
 
-  """
-  Voucher code that was used for Order.
-  
-  Added in Saleor 3.18.
-  """
+  """Voucher code that was used for Order."""
   voucherCode: String
 
   """List of user gift cards."""
@@ -12412,17 +12276,11 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """
   Determine if the line is a gift.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   isGift: Boolean
 
-  """
-  List of applied discounts
-  
-  Added in Saleor 3.21.
-  """
+  """List of applied discounts"""
   discounts: [OrderLineDiscount!]
 }
 
@@ -12621,11 +12479,7 @@ type PageTranslation implements Node @doc(category: "Pages") {
   """Translated SEO description."""
   seoDescription: String
 
-  """
-  Translated page slug.
-  
-  Added in Saleor 3.21.
-  """
+  """Translated page slug."""
   slug: String
 
   """Translated page title."""
@@ -12665,11 +12519,7 @@ type PageTranslatableContent implements Node @doc(category: "Pages") {
   """SEO description to translate."""
   seoDescription: String
 
-  """
-  Slug to translate.
-  
-  Added in Saleor 3.21.
-  """
+  """Slug to translate."""
   slug: String
 
   """Page title to translate."""
@@ -13249,11 +13099,7 @@ type OrderDiscount implements Node @doc(category: "Discounts") {
   """Returns amount of discount."""
   amount: Money! @deprecated(reason: "Use `total` instead.")
 
-  """
-  The amount of discount applied to the order.
-  
-  Added in Saleor 3.21.
-  """
+  """The amount of discount applied to the order."""
   total: Money!
 }
 
@@ -13372,23 +13218,13 @@ type OrderGrantedRefund @doc(category: "Orders") {
 
   """
   Status of the granted refund calculated based on transactionItem assigned to granted refund.
-  
-  Added in Saleor 3.20.
   """
   status: OrderGrantedRefundStatusEnum!
 
-  """
-  List of refund events associated with the granted refund.
-  
-  Added in Saleor 3.20.
-  """
+  """List of refund events associated with the granted refund."""
   transactionEvents: [TransactionEvent!]
 
-  """
-  The transaction assigned to the granted refund.
-  
-  Added in Saleor 3.20.
-  """
+  """The transaction assigned to the granted refund."""
   transaction: TransactionItem
 }
 
@@ -13469,8 +13305,6 @@ type TransactionEvent implements Node @doc(category: "Payments") {
 
 """
 Represents possible event types.
-
-    Added in Saleor 3.12.
 
     The following types are possible:
     AUTHORIZATION_SUCCESS - represents success authorization.
@@ -15179,8 +15013,6 @@ type Shop implements ObjectWithMetadata {
   """
   List of tax apps that can be assigned to the channel. The list will be calculated by Saleor based on the apps that are subscribed to webhooks related to tax calculations: CHECKOUT_CALCULATE_TAXES
   
-  Added in Saleor 3.19.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, MANAGE_APPS.
   """
   availableTaxApps: [App!]!
@@ -16574,11 +16406,7 @@ enum VoucherSortField {
   """Sort vouchers by code."""
   CODE @deprecated
 
-  """
-  Sort vouchers by name.
-  
-  Added in Saleor 3.18.
-  """
+  """Sort vouchers by name."""
   NAME
 
   """Sort vouchers by start date."""
@@ -16650,8 +16478,6 @@ type Promotion implements Node & ObjectWithMetadata @doc(category: "Discounts") 
   """
   The type of the promotion. Implicate if the discount is applied on catalogue or order level.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   type: PromotionTypeEnum
@@ -16714,8 +16540,6 @@ type PromotionRule implements Node @doc(category: "Discounts") {
   """
   The reward value of the promotion rule. Defines the discount value applied when the rule conditions are met.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   rewardValue: PositiveDecimal
@@ -16725,8 +16549,6 @@ type PromotionRule implements Node @doc(category: "Discounts") {
 
   """
   The type of the predicate that must be met to apply the reward.
-  
-  Added in Saleor 3.19.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -16738,16 +16560,12 @@ type PromotionRule implements Node @doc(category: "Discounts") {
   """
   The checkout/order predicate that must be met to apply the rule reward.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderPredicate: JSON
 
   """
   The reward type of the promotion rule.
-  
-  Added in Saleor 3.19.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -16762,16 +16580,12 @@ type PromotionRule implements Node @doc(category: "Discounts") {
   """
   Product variant IDs available as a gift to choose.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   giftIds: [ID!]
 
   """
   Defines the maximum number of gifts to choose from the gifts list.
-  
-  Added in Saleor 3.19.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -20730,9 +20544,7 @@ type Mutation {
   ): VoucherChannelListingUpdate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_UPDATED], syncEvents: [])
 
   """
-  Deletes voucher codes.
-  
-  Added in Saleor 3.18. 
+  Deletes voucher codes. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   
@@ -20773,9 +20585,7 @@ type Mutation {
   ): ExportGiftCards @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, GIFT_CARD_EXPORT_COMPLETED], syncEvents: []) @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 
   """
-  Export voucher codes to csv/xlsx file.
-  
-  Added in Saleor 3.18. 
+  Export voucher codes to csv/xlsx file. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
   
@@ -20832,8 +20642,6 @@ type Mutation {
 
     """
     Indicates whether the billing address should be saved to the user’s address book upon checkout completion. If not provided, the default behavior is to save the address.
-    
-    Added in Saleor 3.21.
     """
     saveAddress: Boolean = true
 
@@ -20952,8 +20760,6 @@ type Mutation {
 
   """
   Updates customer note in the existing checkout object.
-  
-  Added in Saleor 3.21.
   
   Triggers the following webhook events:
   - CHECKOUT_UPDATED (async): A checkout was updated.
@@ -21133,8 +20939,6 @@ type Mutation {
 
     """
     Indicates whether the shipping address should be saved to the user’s address book upon checkout completion. If not provided, the default behavior is to save the address.
-    
-    Added in Saleor 3.21.
     """
     saveAddress: Boolean = true
 
@@ -21737,9 +21541,7 @@ type Mutation {
   ): AppProblemDismiss @doc(category: "Apps")
 
   """
-  Re-enable sync webhooks for provided app. Can be used to manually re-enable sync webhooks for the app before the cooldown period ends.
-  
-  Added in Saleor 3.21. 
+  Re-enable sync webhooks for provided app. Can be used to manually re-enable sync webhooks for the app before the cooldown period ends. 
   
   Requires one of the following permissions: MANAGE_APPS.
   """
@@ -21973,8 +21775,6 @@ type Mutation {
   accountAddressCreate(
     """
     ID of customer the application is impersonating. The field can be used and is required by apps only. Requires IMPERSONATE_USER and AUTHENTICATED_APP permission.
-    
-    Added in Saleor 3.19.
     """
     customerId: ID
 
@@ -22053,8 +21853,6 @@ type Mutation {
   accountUpdate(
     """
     ID of customer the application is impersonating. The field can be used and is required by apps only. Requires IMPERSONATE_USER and AUTHENTICATED_APP permission.
-    
-    Added in Saleor 3.19.
     """
     customerId: ID
 
@@ -22918,15 +22716,11 @@ input TaxConfigurationUpdateInput @doc(category: "Taxes") {
 
   """
   Determines whether to use weighted tax for shipping. When set to true, the tax rate for shipping will be calculated based on the weighted average of tax rates from the order or checkout lines. Default value is `False`.Can be used only with `taxCalculationStrategy` set to `FLAT_RATES`.
-  
-  Added in Saleor 3.21.
   """
   useWeightedTaxForShipping: Boolean
 
   """
   The tax app `App.identifier` that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. It's possible to set plugin by using prefix `plugin:` with `PLUGIN_ID` e.g. with Avalara `plugin:mirumee.taxes.avalara`.Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
-  
-  Added in Saleor 3.19.
   """
   taxAppId: String
 }
@@ -22950,15 +22744,11 @@ input TaxConfigurationPerCountryInput @doc(category: "Taxes") {
 
   """
   The tax app `App.identifier` that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
-  
-  Added in Saleor 3.19.
   """
   taxAppId: String
 
   """
   Determines whether to use weighted tax for shipping. When set to true, the tax rate for shipping will be calculated based on the weighted average of tax rates from the order or checkout lines. Default value is `False`.Can be used only with `taxCalculationStrategy` set to `FLAT_RATES`.
-  
-  Added in Saleor 3.21.
   """
   useWeightedTaxForShipping: Boolean
 }
@@ -24963,8 +24753,6 @@ input ProductVariantChannelListingAddInput @doc(category: "Products") {
 
   """
   Previous price of the variant in channel. Useful for providing promotion information required by customer protection laws such as EU Omnibus directive.
-  
-  Added in Saleor 3.21.
   """
   priorPrice: PositiveDecimal
 
@@ -27210,8 +26998,6 @@ input DraftOrderCreateInput @doc(category: "Orders") {
 
   """
   Indicates whether the billing address should be saved to the user’s address book upon draft order completion. Can only be set when a billing address is provided. If not specified along with the address, the default behavior is to not save the address.
-  
-  Added in Saleor 3.21.
   """
   saveBillingAddress: Boolean
 
@@ -27229,8 +27015,6 @@ input DraftOrderCreateInput @doc(category: "Orders") {
 
   """
   Indicates whether the shipping address should be saved to the user’s address book upon draft order completion.Can only be set when a shipping address is provided. If not specified along with the address, the default behavior is to not save the address.
-  
-  Added in Saleor 3.21.
   """
   saveShippingAddress: Boolean
 
@@ -27240,11 +27024,7 @@ input DraftOrderCreateInput @doc(category: "Orders") {
   """ID of the voucher associated with the order."""
   voucher: ID @deprecated(reason: "Use `voucherCode` instead.")
 
-  """
-  A code of the voucher associated with the order.
-  
-  Added in Saleor 3.18.
-  """
+  """A code of the voucher associated with the order."""
   voucherCode: String
 
   """A note from a customer. Visible by customers in the order summary."""
@@ -27262,28 +27042,20 @@ input DraftOrderCreateInput @doc(category: "Orders") {
   externalReference: String
 
   """
-  Order public metadata. 
-  
-  Added in Saleor 3.21. Can be read by any API client authorized to read the object it's attached to.
+  Order public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Order private metadata. 
-  
-  Added in Saleor 3.21. Requires permissions to modify and to read the metadata of the object it's attached to.
+  Order private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
 
-  """
-  Order language code.
-  
-  Added in Saleor 3.21.
-  """
+  """Order language code."""
   languageCode: LanguageCodeEnum
 
   """Variant line input consisting of variant ID and quantity of products."""
@@ -27360,8 +27132,6 @@ input DraftOrderInput @doc(category: "Orders") {
 
   """
   Indicates whether the billing address should be saved to the user’s address book upon draft order completion. Can only be set when a billing address is provided. If not specified along with the address, the default behavior is to not save the address.
-  
-  Added in Saleor 3.21.
   """
   saveBillingAddress: Boolean
 
@@ -27379,8 +27149,6 @@ input DraftOrderInput @doc(category: "Orders") {
 
   """
   Indicates whether the shipping address should be saved to the user’s address book upon draft order completion.Can only be set when a shipping address is provided. If not specified along with the address, the default behavior is to not save the address.
-  
-  Added in Saleor 3.21.
   """
   saveShippingAddress: Boolean
 
@@ -27390,11 +27158,7 @@ input DraftOrderInput @doc(category: "Orders") {
   """ID of the voucher associated with the order."""
   voucher: ID @deprecated(reason: "Use `voucherCode` instead.")
 
-  """
-  A code of the voucher associated with the order.
-  
-  Added in Saleor 3.18.
-  """
+  """A code of the voucher associated with the order."""
   voucherCode: String
 
   """A note from a customer. Visible by customers in the order summary."""
@@ -27412,28 +27176,20 @@ input DraftOrderInput @doc(category: "Orders") {
   externalReference: String
 
   """
-  Order public metadata. 
-  
-  Added in Saleor 3.21. Can be read by any API client authorized to read the object it's attached to.
+  Order public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Order private metadata. 
-  
-  Added in Saleor 3.21. Requires permissions to modify and to read the metadata of the object it's attached to.
+  Order private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
 
-  """
-  Order language code.
-  
-  Added in Saleor 3.21.
-  """
+  """Order language code."""
   languageCode: LanguageCodeEnum
 }
 
@@ -27850,8 +27606,6 @@ input OrderGrantRefundCreateInput @doc(category: "Orders") {
   """
   The ID of the transaction item related to the granted refund. If `amount` provided in the input, the transaction.chargedAmount needs to be equal or greater than provided `amount`.If `amount` is not provided in the input and calculated automatically by Saleor, the `min(calculatedAmount, transaction.chargedAmount)` will be used. Field required starting from Saleor 3.21.
   
-  Added in Saleor 3.20.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactionId: ID!
@@ -27969,8 +27723,6 @@ input OrderGrantRefundUpdateInput @doc(category: "Orders") {
 
   """
   The ID of the transaction item related to the granted refund. If `amount` provided in the input, the transaction.chargedAmount needs to be equal or greater than provided `amount`.If `amount` is not provided in the input and calculated automatically by Saleor, the `min(calculatedAmount, transaction.chargedAmount)` will be used.Field will be required starting from Saleor 3.21.
-  
-  Added in Saleor 3.20.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -28239,28 +27991,20 @@ input OrderUpdateInput @doc(category: "Orders") {
   externalReference: String
 
   """
-  Order public metadata. 
-  
-  Added in Saleor 3.21.Can be read by any API client authorized to read the object it's attached to.
+  Order public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Order private metadata. 
-  
-  Added in Saleor 3.21.Requires permissions to modify and to read the metadata of the object it's attached to.
+  Order private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   privateMetadata: [MetadataInput!]
 
-  """
-  Order language code.
-  
-  Added in Saleor 3.21.
-  """
+  """Order language code."""
   languageCode: LanguageCodeEnum
 }
 
@@ -28431,11 +28175,7 @@ input OrderBulkCreateInput @doc(category: "Orders") {
   """List of gift card codes associated with the order."""
   giftCards: [String!]
 
-  """
-  Code of a voucher associated with the order.
-  
-  Added in Saleor 3.18.
-  """
+  """Code of a voucher associated with the order."""
   voucherCode: String
 
   """List of discounts."""
@@ -28498,11 +28238,7 @@ input OrderBulkCreateOrderLineInput @doc(category: "Orders") {
   """The name of the product."""
   productName: String
 
-  """
-  The SKU of the product.
-  
-  Added in Saleor 3.18.
-  """
+  """The SKU of the product."""
   productSku: String
 
   """Translation of the product variant name."""
@@ -28529,25 +28265,13 @@ input OrderBulkCreateOrderLineInput @doc(category: "Orders") {
   """Price of the order line excluding applied discount."""
   undiscountedTotalPrice: TaxedMoneyInput!
 
-  """
-  Reason of the discount on order line.
-  
-  Added in Saleor 3.19.
-  """
+  """Reason of the discount on order line."""
   unitDiscountReason: String
 
-  """
-  Type of the discount: fixed or percent
-  
-  Added in Saleor 3.19.
-  """
+  """Type of the discount: fixed or percent"""
   unitDiscountType: DiscountValueTypeEnum
 
-  """
-  Value of the discount. Can store fixed value or percent value
-  
-  Added in Saleor 3.19.
-  """
+  """Value of the discount. Can store fixed value or percent value"""
   unitDiscountValue: PositiveDecimal
 
   """The ID of the warehouse, where the line will be allocated."""
@@ -29234,18 +28958,14 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
   expiryDate: Date
 
   """
-  Gift Card public metadata. 
-  
-  Added in Saleor 3.21. Can be read by any API client authorized to read the object it's attached to.
+  Gift Card public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Gift Card private metadata. 
-  
-  Added in Saleor 3.21. Requires permissions to modify and to read the metadata of the object it's attached to.
+  Gift Card private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -29335,18 +29055,14 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
   expiryDate: Date
 
   """
-  Gift Card public metadata. 
-  
-  Added in Saleor 3.21. Can be read by any API client authorized to read the object it's attached to.
+  Gift Card public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
   metadata: [MetadataInput!]
 
   """
-  Gift Card private metadata. 
-  
-  Added in Saleor 3.21. Requires permissions to modify and to read the metadata of the object it's attached to.
+  Gift Card private metadata. Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -29651,9 +29367,7 @@ input PromotionCreateInput @doc(category: "Discounts") {
   name: String!
 
   """
-  Defines the promotion type. Implicate the required promotion rules predicate type and whether the promotion rules will give the catalogue or order discount. 
-  
-  Added in Saleor 3.19.
+  Defines the promotion type. Implicate the required promotion rules predicate type and whether the promotion rules will give the catalogue or order discount.
   """
   type: PromotionTypeEnum!
 
@@ -29676,8 +29390,6 @@ input PromotionRuleInput @doc(category: "Discounts") {
   """
   Defines the conditions on the checkout/draft order level that must be met for the reward to be applied.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderPredicate: OrderPredicateInput
@@ -29695,8 +29407,6 @@ input PromotionRuleInput @doc(category: "Discounts") {
   """
   Defines the reward type of the promotion rule.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   rewardType: RewardTypeEnum
@@ -29706,8 +29416,6 @@ input PromotionRuleInput @doc(category: "Discounts") {
 
   """
   Product variant IDs available as a gift to choose.
-  
-  Added in Saleor 3.19.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -29905,8 +29613,6 @@ input PromotionRuleCreateInput {
   """
   Defines the conditions on the checkout/draft order level that must be met for the reward to be applied.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderPredicate: OrderPredicateInput
@@ -29924,8 +29630,6 @@ input PromotionRuleCreateInput {
   """
   Defines the reward type of the promotion rule.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   rewardType: RewardTypeEnum
@@ -29935,8 +29639,6 @@ input PromotionRuleCreateInput {
 
   """
   Product variant IDs available as a gift to choose.
-  
-  Added in Saleor 3.19.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -30009,8 +29711,6 @@ input PromotionRuleUpdateInput {
   """
   Defines the conditions on the checkout/draft order level that must be met for the reward to be applied.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderPredicate: OrderPredicateInput
@@ -30028,8 +29728,6 @@ input PromotionRuleUpdateInput {
   """
   Defines the reward type of the promotion rule.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   rewardType: RewardTypeEnum
@@ -30043,16 +29741,12 @@ input PromotionRuleUpdateInput {
   """
   List of variant IDs available as a gift to add.
   
-  Added in Saleor 3.19.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addGifts: [ID!]
 
   """
   List of variant IDs available as a gift to remove.
-  
-  Added in Saleor 3.19.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -30164,11 +29858,7 @@ type DiscountError @doc(category: "Discounts") {
   """List of channels IDs which causes the error."""
   channels: [ID!]
 
-  """
-  List of voucher codes which causes the error.
-  
-  Added in Saleor 3.18.
-  """
+  """List of voucher codes which causes the error."""
   voucherCodes: [String!]
 }
 
@@ -30380,8 +30070,6 @@ input VoucherInput @doc(category: "Discounts") {
   """
   List of codes to add.
   
-  Added in Saleor 3.18.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addCodes: [String!]
@@ -30426,8 +30114,6 @@ input VoucherInput @doc(category: "Discounts") {
   When set to 'True', each voucher code can be used only once; otherwise, codes can be used multiple times depending on `usageLimit`.
   
   The option can only be changed if none of the voucher codes have been used.
-  
-  Added in Saleor 3.18.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -30557,9 +30243,7 @@ input VoucherChannelListingAddInput @doc(category: "Discounts") {
 }
 
 """
-Deletes voucher codes.
-
-Added in Saleor 3.18. 
+Deletes voucher codes. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -30726,9 +30410,7 @@ input ExportGiftCardsInput @doc(category: "Gift cards") {
 }
 
 """
-Export voucher codes to csv/xlsx file.
-
-Added in Saleor 3.18. 
+Export voucher codes to csv/xlsx file. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
@@ -30948,8 +30630,6 @@ input CheckoutCreateInput @doc(category: "Checkout") {
 
   """
   Indicates whether the shipping address should be saved to the user’s address book upon checkout completion.Can only be set when a shipping address is provided. If not specified along with the address, the default behavior is to save the address.
-  
-  Added in Saleor 3.21.
   """
   saveShippingAddress: Boolean
 
@@ -30960,8 +30640,6 @@ input CheckoutCreateInput @doc(category: "Checkout") {
 
   """
   Indicates whether the billing address should be saved to the user’s address book upon checkout completion. Can only be set when a billing address is provided. If not specified along with the address, the default behavior is to save the address.
-  
-  Added in Saleor 3.21.
   """
   saveBillingAddress: Boolean
 
@@ -30980,8 +30658,6 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   Checkout public metadata. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
-  
-  Added in Saleor 3.21.
   """
   metadata: [MetadataInput!]
 
@@ -30991,8 +30667,6 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   Requires permissions to modify and to read the metadata of the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
-  
-  Added in Saleor 3.21.
   """
   privateMetadata: [MetadataInput!]
 }
@@ -31121,8 +30795,6 @@ type CheckoutCustomerDetach @doc(category: "Checkout") @webhookEventsInfo(asyncE
 """
 Updates customer note in the existing checkout object.
 
-Added in Saleor 3.21.
-
 Triggers the following webhook events:
 - CHECKOUT_UPDATED (async): A checkout was updated.
 """
@@ -31239,9 +30911,7 @@ input CheckoutLineUpdateInput @doc(category: "Checkout") {
   lineId: ID
 
   """
-  Checkout line public metadata. Will add and update keys. To delete keys use deleteMetadata mutation. 
-  
-  Added in Saleor 3.21. Can be read by any API client authorized to read the object it's attached to.
+  Checkout line public metadata. Will add and update keys. To delete keys use deleteMetadata mutation. Can be read by any API client authorized to read the object it's attached to.
   
   Warning: never store sensitive information, including financial data such as credit card details.
   """
@@ -31571,16 +31241,12 @@ input OrderSettingsInput @doc(category: "Orders") {
   
   Warning:  when switching this setting from `false` to `true`, the vouchers will be disconnected from all draft orders.
   
-  Added in Saleor 3.18.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   includeDraftOrderInVoucherUsage: Boolean
 
   """
   Time in hours after which the draft order line price will be refreshed. Default value is 24 hours. Enter 0 or null to disable.
-  
-  Added in Saleor 3.21.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -31591,8 +31257,6 @@ input OrderSettingsInput @doc(category: "Orders") {
   - When legacy propagation is enabled, discounts from these vouchers are represented as `OrderDiscount` objects, attached to the order and returned in the `Order.discounts` field. Additionally, percentage-based vouchers are converted to fixed-value discounts.
   - When legacy propagation is disabled, discounts are represented as `OrderLineDiscount` objects, attached to individual lines and returned in the `OrderLine.discounts` field. In this case, percentage-based vouchers retain their original type.
   In future releases, `OrderLineDiscount` will become the default behavior, and this flag will be deprecated and removed.
-  
-  Added in Saleor 3.21.
   """
   useLegacyLineDiscountPropagation: Boolean
 }
@@ -31605,8 +31269,6 @@ input CheckoutSettingsInput @doc(category: "Checkout") {
 
   """
   Default `false`. Determines if the paid checkouts should be automatically completed. This setting applies only to checkouts where payment was processed through transactions.When enabled, the checkout will be automatically completed once the checkout `authorize_status` reaches `FULL`. This occurs when the total sum of charged and authorized transaction amounts equals or exceeds the checkout's total amount.
-  
-  Added in Saleor 3.20.
   """
   automaticallyCompleteFullyPaidCheckouts: Boolean @deprecated(reason: "Use `automatic_completion` instead.")
 
@@ -31650,22 +31312,16 @@ input PaymentSettingsInput @doc(category: "Payments") {
 
   """
   Determine if the funds for expired checkouts should be released automatically.
-  
-  Added in Saleor 3.20.
   """
   releaseFundsForExpiredCheckouts: Boolean
 
   """
   The time in hours after which funds for expired checkouts will be released.
-  
-  Added in Saleor 3.20.
   """
   checkoutTtlBeforeReleasingFunds: Hour
 
   """
   Specifies the earliest date on which funds for expired checkouts can begin to be released. Expired checkouts dated before this cut-off will not have their funds released. Additionally, no funds will be released for checkouts that are more than one year old, regardless of the cut-off date.
-  
-  Added in Saleor 3.20.
   """
   checkoutReleaseFundsCutOffDate: DateTime
 }
@@ -32459,8 +32115,6 @@ input AppInput @doc(category: "Apps") {
 
   """
   Canonical app ID. If not provided, the identifier will be generated based on app.id.
-  
-  Added in Saleor 3.19.
   """
   identifier: String
 
@@ -32888,9 +32542,7 @@ input AppProblemDismissByStaffWithKeysInput @doc(category: "Apps") {
 }
 
 """
-Re-enable sync webhooks for provided app. Can be used to manually re-enable sync webhooks for the app before the cooldown period ends.
-
-Added in Saleor 3.21. 
+Re-enable sync webhooks for provided app. Can be used to manually re-enable sync webhooks for the app before the cooldown period ends. 
 
 Requires one of the following permissions: MANAGE_APPS.
 """
@@ -34000,8 +33652,6 @@ type Subscription @doc(category: "Miscellaneous") {
   """
   Event sent when new draft order is created.
   
-  Added in Saleor 3.20.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   draftOrderCreated(
@@ -34013,8 +33663,6 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when draft order is updated.
-  
-  Added in Saleor 3.20.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -34028,8 +33676,6 @@ type Subscription @doc(category: "Miscellaneous") {
   """
   Event sent when draft order is deleted.
   
-  Added in Saleor 3.20.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   draftOrderDeleted(
@@ -34041,8 +33687,6 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when new order is created.
-  
-  Added in Saleor 3.20.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -34056,8 +33700,6 @@ type Subscription @doc(category: "Miscellaneous") {
   """
   Event sent when order is updated.
   
-  Added in Saleor 3.20.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderUpdated(
@@ -34069,8 +33711,6 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order is confirmed.
-  
-  Added in Saleor 3.20.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -34084,8 +33724,6 @@ type Subscription @doc(category: "Miscellaneous") {
   """
   Payment has been made. The order may be partially or fully paid.
   
-  Added in Saleor 3.20.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderPaid(
@@ -34097,8 +33735,6 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order is fully paid.
-  
-  Added in Saleor 3.20.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -34112,8 +33748,6 @@ type Subscription @doc(category: "Miscellaneous") {
   """
   The order received a refund. The order may be partially or fully refunded.
   
-  Added in Saleor 3.20.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderRefunded(
@@ -34125,8 +33759,6 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   The order is fully refunded.
-  
-  Added in Saleor 3.20.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -34140,8 +33772,6 @@ type Subscription @doc(category: "Miscellaneous") {
   """
   Event sent when order is fulfilled.
   
-  Added in Saleor 3.20.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderFulfilled(
@@ -34153,8 +33783,6 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order is cancelled.
-  
-  Added in Saleor 3.20.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -34168,8 +33796,6 @@ type Subscription @doc(category: "Miscellaneous") {
   """
   Event sent when order becomes expired.
   
-  Added in Saleor 3.20.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderExpired(
@@ -34181,8 +33807,6 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when order metadata is updated.
-  
-  Added in Saleor 3.20.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -34196,8 +33820,6 @@ type Subscription @doc(category: "Miscellaneous") {
   """
   Event sent when orders are imported.
   
-  Added in Saleor 3.20.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderBulkCreated(
@@ -34209,8 +33831,6 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when new checkout is created.
-  
-  Added in Saleor 3.21.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -34224,8 +33844,6 @@ type Subscription @doc(category: "Miscellaneous") {
   """
   Event sent when checkout is updated.
   
-  Added in Saleor 3.21.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   checkoutUpdated(
@@ -34237,8 +33855,6 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when checkout is fully-paid.
-  
-  Added in Saleor 3.21.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -34252,8 +33868,6 @@ type Subscription @doc(category: "Miscellaneous") {
   """
   Event sent when checkout is fully authorized.
   
-  Added in Saleor 3.21.
-  
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   checkoutFullyAuthorized(
@@ -34265,8 +33879,6 @@ type Subscription @doc(category: "Miscellaneous") {
 
   """
   Event sent when checkout metadata is updated.
-  
-  Added in Saleor 3.21.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -37289,11 +36901,7 @@ type VoucherDeleted implements Event @doc(category: "Discounts") {
   ): Voucher
 }
 
-"""
-Event sent when new voucher codes were created.
-
-Added in Saleor 3.19.
-"""
+"""Event sent when new voucher codes were created."""
 type VoucherCodesCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -37311,11 +36919,7 @@ type VoucherCodesCreated implements Event {
   voucherCodes: [VoucherCode!]
 }
 
-"""
-Event sent when voucher codes were deleted.
-
-Added in Saleor 3.19.
-"""
+"""Event sent when voucher codes were deleted."""
 type VoucherCodesDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -37354,11 +36958,7 @@ type VoucherMetadataUpdated implements Event @doc(category: "Discounts") {
   ): Voucher
 }
 
-"""
-Event sent when voucher code export is completed.
-
-Added in Saleor 3.18.
-"""
+"""Event sent when voucher code export is completed."""
 type VoucherCodeExportCompleted implements Event @doc(category: "Discounts") {
   """Time of the event."""
   issuedAt: DateTime

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -19,7 +19,6 @@ from ..app.types import App
 from ..core import ResolveInfo
 from ..core.context import get_database_connection_name
 from ..core.descriptions import (
-    ADDED_IN_319,
     ADDED_IN_322,
     ADDED_IN_323,
     DEFAULT_DEPRECATION_REASON,
@@ -415,7 +414,7 @@ class Shop(graphene.ObjectType):
             "List of tax apps that can be assigned to the channel. "
             "The list will be calculated by Saleor based on the apps "
             "that are subscribed to webhooks related to tax calculations: "
-            "CHECKOUT_CALCULATE_TAXES" + ADDED_IN_319
+            "CHECKOUT_CALCULATE_TAXES"
         ),
         required=True,
         permissions=[

--- a/saleor/graphql/tax/mutations/tax_configuration_update.py
+++ b/saleor/graphql/tax/mutations/tax_configuration_update.py
@@ -9,7 +9,6 @@ from ....plugins import PLUGIN_IDENTIFIER_PREFIX
 from ....tax import error_codes, models
 from ...account.enums import CountryCodeEnum
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_319, ADDED_IN_321
 from ...core.doc_category import DOC_CATEGORY_TAXES
 from ...core.mutations import DeprecatedModelMutation
 from ...core.types import BaseInputObjectType, Error, NonNullList
@@ -51,7 +50,7 @@ class TaxConfigurationPerCountryInput(BaseInputObjectType):
         description=(
             "The tax app `App.identifier` that will be used to calculate the taxes for the "
             "given channel and country. If not provided, use the value from the channel's "
-            "tax configuration." + ADDED_IN_319
+            "tax configuration."
         ),
     )
     use_weighted_tax_for_shipping = graphene.Boolean(
@@ -60,7 +59,6 @@ class TaxConfigurationPerCountryInput(BaseInputObjectType):
             "the tax rate for shipping will be calculated based on the weighted average "
             "of tax rates from the order or checkout lines. Default value is `False`."
             "Can be used only with `taxCalculationStrategy` set to `FLAT_RATES`."
-            + ADDED_IN_321
         ),
     )
 
@@ -105,7 +103,6 @@ class TaxConfigurationUpdateInput(BaseInputObjectType):
             "the tax rate for shipping will be calculated based on the weighted average "
             "of tax rates from the order or checkout lines. Default value is `False`."
             "Can be used only with `taxCalculationStrategy` set to `FLAT_RATES`."
-            + ADDED_IN_321
         ),
     )
     tax_app_id = graphene.String(
@@ -117,7 +114,6 @@ class TaxConfigurationUpdateInput(BaseInputObjectType):
             "by using prefix `plugin:` with `PLUGIN_ID` "
             "e.g. with Avalara `plugin:mirumee.taxes.avalara`."
             "Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`."
-            + ADDED_IN_319
         ),
     )
 

--- a/saleor/graphql/tax/types.py
+++ b/saleor/graphql/tax/types.py
@@ -5,7 +5,6 @@ from ..channel.dataloaders.by_self import ChannelByIdLoader
 from ..channel.types import Channel
 from ..core import ResolveInfo
 from ..core.connection import CountableConnection
-from ..core.descriptions import ADDED_IN_319, ADDED_IN_321
 from ..core.doc_category import DOC_CATEGORY_TAXES
 from ..core.types import BaseObjectType, CountryDisplay, ModelObjectType, NonNullList
 from ..meta.types import ObjectWithMetadata
@@ -57,7 +56,6 @@ class TaxConfiguration(ModelObjectType[models.TaxConfiguration]):
             "iterate over all installed tax apps. If multiple tax apps exist with provided "
             "tax app id use the `App` with newest `created` date. "
             "Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`."
-            + ADDED_IN_319
         ),
         required=False,
     )
@@ -65,7 +63,7 @@ class TaxConfiguration(ModelObjectType[models.TaxConfiguration]):
         description=(
             "Determines whether to use weighted tax for shipping. When set to true, "
             "the tax rate for shipping will be calculated based on the weighted average "
-            "of tax rates from the order or checkout lines." + ADDED_IN_321
+            "of tax rates from the order or checkout lines."
         ),
     )
 
@@ -126,7 +124,6 @@ class TaxConfigurationPerCountry(ModelObjectType[models.TaxConfigurationPerCount
         description=(
             "The tax app `App.identifier` that will be used to calculate the taxes for the given channel "
             "and country. If not provided, use the value from the channel's tax configuration."
-            + ADDED_IN_319
         ),
         required=False,
     )
@@ -134,7 +131,7 @@ class TaxConfigurationPerCountry(ModelObjectType[models.TaxConfigurationPerCount
         description=(
             "Determines whether to use weighted tax for shipping. When set to true, "
             "the tax rate for shipping will be calculated based on the weighted average "
-            "of tax rates from the order or checkout lines." + ADDED_IN_321
+            "of tax rates from the order or checkout lines."
         ),
     )
 

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -35,7 +35,7 @@ from ..attribute.dataloaders.assigned_attributes import (
     AttributeValuesByVariantIdAndAttributeIdAndLimitLoader,
 )
 from ..core.context import ChannelContext, get_database_connection_name
-from ..core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_TYPE, RICH_CONTENT
+from ..core.descriptions import DEPRECATED_IN_3X_TYPE, RICH_CONTENT
 from ..core.enums import LanguageCodeEnum
 from ..core.fields import JSONString, PermissionsField
 from ..core.tracing import traced_resolver
@@ -342,7 +342,7 @@ class ProductTranslation(BaseTranslationType[product_models.ProductTranslation])
     )
     seo_title = graphene.String(description="Translated SEO title.")
     seo_description = graphene.String(description="Translated SEO description.")
-    slug = graphene.String(description="Translated product slug." + ADDED_IN_321)
+    slug = graphene.String(description="Translated product slug.")
     name = graphene.String(description="Translated product name.")
     description = JSONString(
         description="Translated description of the product." + RICH_CONTENT
@@ -381,7 +381,7 @@ class ProductTranslatableContent(ModelObjectType[product_models.Product]):
     )
     seo_title = graphene.String(description="SEO title to translate.")
     seo_description = graphene.String(description="SEO description to translate.")
-    slug = graphene.String(description="Slug to translate." + ADDED_IN_321)
+    slug = graphene.String(description="Slug to translate.")
     name = graphene.String(required=True, description="Product's name to translate.")
     description = JSONString(
         description="Product's description to translate." + RICH_CONTENT
@@ -459,7 +459,7 @@ class CollectionTranslation(BaseTranslationType[product_models.CollectionTransla
     )
     seo_title = graphene.String(description="Translated SEO title.")
     seo_description = graphene.String(description="Translated SEO description.")
-    slug = graphene.String(description="Translated collection slug." + ADDED_IN_321)
+    slug = graphene.String(description="Translated collection slug.")
     name = graphene.String(description="Translated collection name.")
     description = JSONString(
         description="Translated description of the collection." + RICH_CONTENT
@@ -497,7 +497,7 @@ class CollectionTranslatableContent(ModelObjectType[product_models.Collection]):
     )
     seo_title = graphene.String(description="SEO title to translate.")
     seo_description = graphene.String(description="SEO description to translate.")
-    slug = graphene.String(description="Slug to translate" + ADDED_IN_321)
+    slug = graphene.String(description="Slug to translate")
     name = graphene.String(required=True, description="Collection's name to translate.")
     description = JSONString(
         description="Collection's description to translate." + RICH_CONTENT
@@ -551,7 +551,7 @@ class CategoryTranslation(BaseTranslationType[product_models.CategoryTranslation
     )
     seo_title = graphene.String(description="Translated SEO title.")
     seo_description = graphene.String(description="Translated SEO description.")
-    slug = graphene.String(description="Translated category slug." + ADDED_IN_321)
+    slug = graphene.String(description="Translated category slug.")
     name = graphene.String(description="Translated category name.")
     description = JSONString(
         description="Translated description of the category." + RICH_CONTENT
@@ -590,7 +590,7 @@ class CategoryTranslatableContent(ModelObjectType[product_models.Category]):
     )
     seo_title = graphene.String(description="SEO title to translate.")
     seo_description = graphene.String(description="SEO description to translate.")
-    slug = graphene.String(description="Slug to translate." + ADDED_IN_321)
+    slug = graphene.String(description="Slug to translate.")
     name = graphene.String(
         required=True, description="Name of the category translatable content."
     )
@@ -633,7 +633,7 @@ class PageTranslation(BaseTranslationType[page_models.PageTranslation]):
     id = graphene.GlobalID(required=True, description="The ID of the page translation.")
     seo_title = graphene.String(description="Translated SEO title.")
     seo_description = graphene.String(description="Translated SEO description.")
-    slug = graphene.String(description="Translated page slug." + ADDED_IN_321)
+    slug = graphene.String(description="Translated page slug.")
     title = graphene.String(description="Translated page title.")
     content = JSONString(description="Translated content of the page." + RICH_CONTENT)
     content_json = JSONString(
@@ -667,7 +667,7 @@ class PageTranslatableContent(ModelObjectType[page_models.Page]):
     page_id = graphene.ID(required=True, description="The ID of the page to translate.")
     seo_title = graphene.String(description="SEO title to translate.")
     seo_description = graphene.String(description="SEO description to translate.")
-    slug = graphene.String(description="Slug to translate." + ADDED_IN_321)
+    slug = graphene.String(description="Slug to translate.")
     title = graphene.String(required=True, description="Page title to translate.")
     content = JSONString(description="Content of the page to translate." + RICH_CONTENT)
     content_json = JSONString(

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -11,7 +11,6 @@ from ..core import ResolveInfo
 from ..core.connection import CountableConnection, create_connection_slice
 from ..core.context import ChannelContext, get_database_connection_name
 from ..core.descriptions import (
-    ADDED_IN_320,
     DEPRECATED_IN_3X_INPUT,
 )
 from ..core.doc_category import DOC_CATEGORY_PRODUCTS
@@ -107,7 +106,7 @@ class Warehouse(ModelObjectType[models.Warehouse]):
     )
     stocks = ConnectionField(
         "saleor.graphql.warehouse.types.StockCountableConnection",
-        description="Stocks that belong to this warehouse." + ADDED_IN_320,
+        description="Stocks that belong to this warehouse.",
         permissions=[
             ProductPermissions.MANAGE_PRODUCTS,
             OrderPermissions.MANAGE_ORDERS,

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -2,7 +2,6 @@ import graphene
 
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..core.descriptions import (
-    ADDED_IN_318,
     DEFAULT_DEPRECATION_REASON,
 )
 from ..core.doc_category import DOC_CATEGORY_WEBHOOKS
@@ -233,7 +232,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.VOUCHER_DELETED: "A voucher is deleted.",
     WebhookEventAsyncType.VOUCHER_METADATA_UPDATED: "A voucher metadata is updated.",
     WebhookEventAsyncType.VOUCHER_CODE_EXPORT_COMPLETED: (
-        "A voucher code export is completed." + ADDED_IN_318
+        "A voucher code export is completed."
     ),
     WebhookEventAsyncType.ANY: "All the events.",
     WebhookEventAsyncType.OBSERVABILITY: "An observability event is created.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -50,10 +50,6 @@ from ..core.context import (
     get_database_connection_name,
 )
 from ..core.descriptions import (
-    ADDED_IN_318,
-    ADDED_IN_319,
-    ADDED_IN_320,
-    ADDED_IN_321,
     ADDED_IN_322,
     ADDED_IN_323,
     ADDED_IN_324,
@@ -2571,7 +2567,7 @@ class VoucherCodesCreated(SubscriptionObjectType, VoucherCodeBase):
         root_type = "VoucherCode"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when new voucher codes were created." + ADDED_IN_319
+        description = "Event sent when new voucher codes were created."
 
 
 class VoucherCodesDeleted(SubscriptionObjectType, VoucherCodeBase):
@@ -2579,7 +2575,7 @@ class VoucherCodesDeleted(SubscriptionObjectType, VoucherCodeBase):
         root_type = "VoucherCode"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when voucher codes were deleted." + ADDED_IN_319
+        description = "Event sent when voucher codes were deleted."
 
 
 class VoucherMetadataUpdated(SubscriptionObjectType, VoucherBase):
@@ -2600,7 +2596,7 @@ class VoucherCodeExportCompleted(SubscriptionObjectType):
         root_type = "ExportFile"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when voucher code export is completed." + ADDED_IN_318
+        description = "Event sent when voucher code export is completed."
         doc_category = DOC_CATEGORY_DISCOUNTS
 
     @staticmethod
@@ -2863,56 +2859,42 @@ class Subscription(SubscriptionObjectType):
     )
     draft_order_created = BaseField(
         DraftOrderCreated,
-        description=(
-            "Event sent when new draft order is created."
-            + ADDED_IN_320
-            + PREVIEW_FEATURE
-        ),
+        description=("Event sent when new draft order is created." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
     draft_order_updated = BaseField(
         DraftOrderUpdated,
-        description=(
-            "Event sent when draft order is updated." + ADDED_IN_320 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when draft order is updated." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
     draft_order_deleted = BaseField(
         DraftOrderDeleted,
-        description=(
-            "Event sent when draft order is deleted." + ADDED_IN_320 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when draft order is deleted." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
     order_created = BaseField(
         OrderCreated,
-        description=(
-            "Event sent when new order is created." + ADDED_IN_320 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when new order is created." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
     order_updated = BaseField(
         OrderUpdated,
-        description=(
-            "Event sent when order is updated." + ADDED_IN_320 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when order is updated." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
     order_confirmed = BaseField(
         OrderConfirmed,
-        description=(
-            "Event sent when order is confirmed." + ADDED_IN_320 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when order is confirmed." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
@@ -2921,7 +2903,6 @@ class Subscription(SubscriptionObjectType):
         OrderPaid,
         description=(
             "Payment has been made. The order may be partially or fully paid."
-            + ADDED_IN_320
             + PREVIEW_FEATURE
         ),
         resolver=default_channel_filterable_resolver,
@@ -2930,9 +2911,7 @@ class Subscription(SubscriptionObjectType):
     )
     order_fully_paid = BaseField(
         OrderFullyPaid,
-        description=(
-            "Event sent when order is fully paid." + ADDED_IN_320 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when order is fully paid." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
@@ -2941,7 +2920,7 @@ class Subscription(SubscriptionObjectType):
         OrderRefunded,
         description=(
             "The order received a refund. The order may be partially or fully "
-            "refunded." + ADDED_IN_320 + PREVIEW_FEATURE
+            "refunded." + PREVIEW_FEATURE
         ),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
@@ -2949,103 +2928,77 @@ class Subscription(SubscriptionObjectType):
     )
     order_fully_refunded = BaseField(
         OrderFullyRefunded,
-        description=("The order is fully refunded." + ADDED_IN_320 + PREVIEW_FEATURE),
+        description=("The order is fully refunded." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
     order_fulfilled = BaseField(
         OrderFulfilled,
-        description=(
-            "Event sent when order is fulfilled." + ADDED_IN_320 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when order is fulfilled." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
     order_cancelled = BaseField(
         OrderCancelled,
-        description=(
-            "Event sent when order is cancelled." + ADDED_IN_320 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when order is cancelled." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
     order_expired = BaseField(
         OrderExpired,
-        description=(
-            "Event sent when order becomes expired." + ADDED_IN_320 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when order becomes expired." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
     order_metadata_updated = BaseField(
         OrderMetadataUpdated,
-        description=(
-            "Event sent when order metadata is updated."
-            + ADDED_IN_320
-            + PREVIEW_FEATURE
-        ),
+        description=("Event sent when order metadata is updated." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
     order_bulk_created = BaseField(
         OrderBulkCreated,
-        description=(
-            "Event sent when orders are imported." + ADDED_IN_320 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when orders are imported." + PREVIEW_FEATURE),
         channels=channels_argument,
         doc_category=DOC_CATEGORY_ORDERS,
     )
 
     checkout_created = BaseField(
         CheckoutCreated,
-        description=(
-            "Event sent when new checkout is created." + ADDED_IN_321 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when new checkout is created." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_CHECKOUT,
     )
     checkout_updated = BaseField(
         CheckoutUpdated,
-        description=(
-            "Event sent when checkout is updated." + ADDED_IN_321 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when checkout is updated." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_CHECKOUT,
     )
     checkout_fully_paid = BaseField(
         CheckoutFullyPaid,
-        description=(
-            "Event sent when checkout is fully-paid." + ADDED_IN_321 + PREVIEW_FEATURE
-        ),
+        description=("Event sent when checkout is fully-paid." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_CHECKOUT,
     )
     checkout_fully_authorized = BaseField(
         CheckoutFullyAuthorized,
-        description=(
-            "Event sent when checkout is fully authorized."
-            + ADDED_IN_321
-            + PREVIEW_FEATURE
-        ),
+        description=("Event sent when checkout is fully authorized." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_CHECKOUT,
     )
     checkout_metadata_updated = BaseField(
         CheckoutMetadataUpdated,
-        description=(
-            "Event sent when checkout metadata is updated."
-            + ADDED_IN_321
-            + PREVIEW_FEATURE
-        ),
+        description=("Event sent when checkout metadata is updated." + PREVIEW_FEATURE),
         resolver=default_channel_filterable_resolver,
         channels=channels_argument,
         doc_category=DOC_CATEGORY_CHECKOUT,

--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -153,7 +153,7 @@ class TransactionAction:
     The following actions are possible:
     CHARGE - Represents the charge action.
     REFUND - Represents a refund action.
-    CANCEL - Represents a cancel action. Added in Saleor 3.12.
+    CANCEL - Represents a cancel action.
     """
 
     CHARGE = "charge"
@@ -169,8 +169,6 @@ class TransactionAction:
 
 class TransactionEventType:
     """Represents possible event types.
-
-    Added in Saleor 3.12.
 
     The following types are possible:
     AUTHORIZATION_SUCCESS - represents success authorization.


### PR DESCRIPTION
Drop all "Added in Saleor 3.x" changelog markers pointing to versions lower than 3.22 from the GraphQL types and the generated schema. These annotations are no longer relevant for the supported version range - 3.21 and lower are EOL

- Remove the ADDED_IN_318/319/320/321 constants from graphql/core/descriptions.py and strip every usage across the GraphQL layer (string concatenations, f-string placeholders, and sorter extras).
- Remove the "Added in Saleor 3.12." lines from the TransactionAction and TransactionEventType docstrings in payment/__init__.py, which were surfacing in the TransactionActionEnum/TransactionEventTypeEnum schema descriptions.
- Regenerate saleor/graphql/schema.graphql. Only description prose changed; all type/field/enum definitions are unchanged.
