### PR TITLE
Add possibility of running multiple development supporting containers (database, cache, container for running tests) in parallel primarily for use with Git worktrees (#19247)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[cod]
 .*
 !.devcontainer
+!.worktree-container
 !.dockerignore
 !.github
 !.gitignore

--- a/.worktree-container/README.md
+++ b/.worktree-container/README.md
@@ -1,0 +1,36 @@
+# Worktree-safe dev container
+
+A drop-in alternative to `.devcontainer/` for running **multiple git worktrees of this
+repo at the same time** without the stacks colliding.
+
+It differs from `.devcontainer/` in two ways:
+
+1. **Ephemeral host ports.** Services publish only their container port, so Docker assigns a
+   random free host port to each stack. Two stacks never fight over `5432`/`6379`/etc.
+2. **Per-worktree Compose project name.** The `compose.sh` wrapper derives the project name
+   from the worktree's root directory, so containers, networks, and volumes are namespaced per
+   worktree automatically — each worktree gets its own isolated data with no setup.
+
+It reuses `.devcontainer/`'s `Dockerfile`, `common.env`, and `backend.env` (referenced by
+relative path from `docker-compose.yml`) rather than copying them, so `.devcontainer/` must
+remain present.
+
+## Using it with the Compose CLI
+
+Use the `compose.sh` wrapper instead of `docker compose` — it sets a per-worktree project name
+for you, so there is nothing to configure per worktree:
+
+```sh
+.worktree-container/compose.sh up -d
+.worktree-container/compose.sh ps
+.worktree-container/compose.sh down      # add -v to also drop the volumes
+```
+
+Because host ports are ephemeral, look up the assigned host port when connecting from host machine:
+
+```sh
+.worktree-container/compose.sh port db 5432       # -> 127.0.0.1:<random>
+.worktree-container/compose.sh port cache 6379
+.worktree-container/compose.sh port mailpit 8025
+.worktree-container/compose.sh port dashboard 80
+```

--- a/.worktree-container/compose.sh
+++ b/.worktree-container/compose.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+# Wrapper around `docker compose` that gives each git worktree its own isolated
+# stack automatically — no per-worktree setup.
+#
+# The Compose project name is derived from the worktree's root directory, so
+# containers, networks, and volumes are namespaced per worktree. Run this instead
+# of `docker compose`, e.g.:
+#
+#   .worktree-container/compose.sh up -d
+#   .worktree-container/compose.sh port db 5432
+#   .worktree-container/compose.sh down
+set -eu
+
+dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+root="$(git -C "$dir" rev-parse --show-toplevel)"
+
+# Sanitize the worktree dir name into a valid Compose project name
+# (lowercase; anything outside [a-z0-9_-] becomes "-").
+name="$(printf '%s' "$(basename "$root")" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_-' '-')"
+
+exec docker compose -p "saleor-${name}" -f "${dir}/docker-compose.yml" "$@"

--- a/.worktree-container/docker-compose.yml
+++ b/.worktree-container/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  saleor:
+    image: saleor
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    command: sleep infinity
+    env_file:
+      - ../.devcontainer/common.env
+      - ../.devcontainer/backend.env
+    depends_on:
+      - db
+      - cache
+    volumes:
+      - ..:/app
+      - saleor-pre-commit-cache:/root/.cache/pre-commit/
+
+  dashboard:
+    image: ghcr.io/saleor/saleor-dashboard:3.22
+    restart: unless-stopped
+    ports:
+      - "80"
+
+  db:
+    image: docker.io/library/postgres:15-alpine
+    ports:
+      - "5432"
+    restart: unless-stopped
+    volumes:
+      - saleor-db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=saleor
+      - POSTGRES_PASSWORD=saleor
+
+  cache:
+    image: docker.io/valkey/valkey:8.1-alpine
+    restart: unless-stopped
+    volumes:
+      - saleor-cache:/data
+    ports:
+      - "6379"
+
+  mailpit:
+    image: docker.io/axllent/mailpit
+    ports:
+      - "1025" # SMTP Server
+      - "8025" # Mailpit UI
+    restart: unless-stopped
+
+volumes:
+  saleor-db:
+    driver: local
+  saleor-cache:
+    driver: local
+  saleor-pre-commit-cache:
+    driver: local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,12 +12,29 @@
 
 # Testing
 
+## Running in a git worktree
+
+When Saleor is checked out in a git worktree, prefer running operations (tests, management
+commands, etc.) inside that worktree's containers rather than on the host machine. The host's
+services may belong to a different worktree, so running directly on the host can hit the wrong
+database/cache or collide with another worktree's stack.
+
+- Use the `.worktree-container/compose.sh` wrapper, which targets the current worktree's
+  isolated stack. Run commands inside the `saleor` service, e.g.:
+  ```sh
+  .worktree-container/compose.sh up -d                       # start this worktree's stack
+  .worktree-container/compose.sh exec saleor pytest --reuse-db saleor/path/to/test_file.py
+  .worktree-container/compose.sh exec saleor python manage.py migrate
+  ```
+- Do not run these operations directly on the host machine when working in a worktree.
+
 ## Running tests
 
 - Run tests using `pytest`
 - Attach `--reuse-db` argument to speed up tests by reusing the test database
 - Select tests to run by passing test file path as an argument
-- Enter virtual environment before executing tests
+- Inside the dev container, dependencies are installed system-wide, so run `pytest` directly — no virtual environment to activate
+- On the host (outside the container), enter the virtual environment before executing tests
 
 ## Writing tests
 


### PR DESCRIPTION
Backport of https://github.com/saleor/saleor/pull/19247.