### PR TITLE
feat: raise logger.error when sync webhook is called inside db transa…

### DIFF
--- a/saleor/webhook/transport/synchronous/tests/test_transport.py
+++ b/saleor/webhook/transport/synchronous/tests/test_transport.py
@@ -269,3 +269,26 @@ def test_send_webhook_request_sync_record_external_request_with_unknown_webhook_
     assert external_request_content_length.attributes == attributes
     assert external_request_content_length.count == 1
     assert external_request_content_length.sum == payload_size
+
+
+def test_send_webhook_request_sync_logs_error_inside_transaction(
+    event_delivery_payload_in_database,
+):
+    from django.db import transaction
+    from unittest.mock import patch
+    from ..transport import send_webhook_request_sync
+
+    with patch(
+        "saleor.webhook.transport.synchronous.transport._send_webhook_request_sync"
+    ) as mock_send, patch(
+        "saleor.webhook.transport.synchronous.transport.logger"
+    ) as mock_logger:
+        mock_send.return_value = (
+            type("R", (), {"status": "success"})(),
+            {},
+        )
+        with transaction.atomic():
+            send_webhook_request_sync(event_delivery_payload_in_database)
+
+        mock_logger.error.assert_called_once()
+        assert "transaction" in mock_logger.error.call_args[0][0]

--- a/saleor/webhook/transport/synchronous/tests/test_transport.py
+++ b/saleor/webhook/transport/synchronous/tests/test_transport.py
@@ -290,5 +290,5 @@ def test_send_webhook_request_sync_logs_error_inside_transaction(
         with transaction.atomic():
             send_webhook_request_sync(event_delivery_payload_in_database)
 
-        mock_logger.error.assert_called_once()
-        assert "transaction" in mock_logger.error.call_args[0][0]
+        mock_logger.warning.assert_called_once()
+        assert "transaction" in mock_logger.warning.call_args[0][0]

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db import transaction
+from django.db import connection, transaction
 from opentelemetry.trace import StatusCode
 from promise import Promise
 
@@ -195,6 +195,13 @@ def _send_webhook_request_sync(
 def send_webhook_request_sync(
     delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
 ) -> dict[Any, Any] | None:
+    if connection.in_atomic_block:
+        logger.error(
+            "Sync webhook called inside a database transaction. "
+            "Event: %s. This may cause data inconsistency if the "
+            "transaction is rolled back.",
+            delivery.event_type,
+        )
     response, response_data = _send_webhook_request_sync(delivery, timeout)
     return response_data if response.status == EventDeliveryStatus.SUCCESS else None
 

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -196,11 +196,12 @@ def send_webhook_request_sync(
     delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
 ) -> dict[Any, Any] | None:
     if connection.in_atomic_block:
-        logger.error(
+        logger.warning(
             "Sync webhook called inside a database transaction. "
             "Event: %s. This may cause data inconsistency if the "
             "transaction is rolled back.",
             delivery.event_type,
+            stack_info=True,
         )
     response, response_data = _send_webhook_request_sync(delivery, timeout)
     return response_data if response.status == EventDeliveryStatus.SUCCESS else None


### PR DESCRIPTION
I want to merge this change because sync webhooks should never be called inside a database transaction — if the transaction rolls back, the external app has already acted on data that never committed.

Closes #15138

## What does this PR do?
Adds a `logger.error` call inside `send_webhook_request_sync` that fires whenever the function is called within an active Django database transaction, using Django's `connection.in_atomic_block`. This makes it easy to detect all places in the codebase where sync webhooks are accidentally called inside transactions.

## Impact
- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

## Docs
No documentation changes required for this fix.

- [ ] Link to documentation: N/A

## Pull Request Checklist
- [x] Tests added for new behavior (`test_send_webhook_request_sync_logs_error_inside_transaction`)
- [x] All tests passing (7 passed)
- [x] Follows project style guide
- [x] No breaking changes introduced