### PR TITLE
fix: require status field in orderBulkCreate input (#14506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### GraphQL API
 
 - Added `stockAvailability` and `stocks` filters to the `productVariants` query `where` input, allowing variants to be filtered by their stock status and stock quantity for a given channel - #17689 by @ayesha-waris
-- Fix field validation of the `orderBulkCreate` mutation that requires the status field. - #14506 by @shivansh-dutta
+- Fix field validation of the `orderBulkCreate` mutation that requires the status field. - #19391 by @shivansh-dutta
 
 ### Webhooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Breaking changes
 
+- [Preview feature] The `OrderBulkCreateInput.status` input field in the `orderBulkCreate` mutation is now a required field.
 - Removed the deprecated Authorize.Net payment gateway plugin (`mirumee.payments.authorize_net`).
 - Apps will be no longer to be granted with `MANAGE_APPS` permission. In certain cases, this permission was able to be assigned by the authorized user.
   App with such permission was not able to *act* like an admin app, but permission technically was granted.
@@ -18,6 +19,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### GraphQL API
 
 - Added `stockAvailability` and `stocks` filters to the `productVariants` query `where` input, allowing variants to be filtered by their stock status and stock quantity for a given channel - #17689 by @ayesha-waris
+- Fix field validation of the `orderBulkCreate` mutation that requires the status field. - #14506 by @shivansh-dutta
 
 ### Webhooks
 

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -571,7 +571,7 @@ class OrderBulkCreateInput(BaseInputObjectType):
         required=True,
         description="The date, when the order was inserted to Saleor database.",
     )
-    status = OrderStatusEnum(description="Status of the order.")
+    status = OrderStatusEnum(required=True, description="Status of the order.")
     user = graphene.Field(
         OrderBulkCreateUserInput,
         required=True,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -28374,7 +28374,7 @@ input OrderBulkCreateInput @doc(category: "Orders") {
   createdAt: DateTime!
 
   """Status of the order."""
-  status: OrderStatus
+  status: OrderStatus!
 
   """Customer associated with the order."""
   user: OrderBulkCreateUserInput!


### PR DESCRIPTION
I want to merge this change because the `orderBulkCreate` mutation currently crashes      
  with an unhandled `KeyError: 'status'` (surfaced as an Internal Server Error) when the    
  `status` field is omitted from an order, instead of returning a clean validation error.   

  The `status` field on `OrderBulkCreateInput` was optional in the schema, but the Python   
  handler (`create_single_order`) reads `order_input["status"]` as a hard dict key. This    
  change marks the field `required=True` so GraphQL rejects the request with a descriptive  
  validation error before it reaches the Python layer. The committed `schema.graphql`       
  snapshot is regenerated accordingly (`status: OrderStatus` -> `OrderStatus!`).

  This follows the maintainer guidance on the earlier attempt (#14760): I used the exact    
  CHANGELOG wording suggested there, and — per @maarcingebala's note that these changes are 
  guaranteed by the GraphQL schema and don't need a dedicated test — I did not add a test.  

  Closes #14506

  # Impact

  - [ ] New migrations
  - [x] New/Updated API fields or mutations
  - [ ] Deprecated API fields or mutations
  - [ ] Removed API types, fields, or mutations

  # Docs

  No documentation changes required — this promotes an existing Preview-feature input field 
  to required; behavior is now the standard GraphQL required-field validation.

  - [ ] Link to documentation:

  # Pull Request Checklist

  - [x] Privileged queries and mutations are either absent or guarded by proper permission  
  checks
  Closes #14506

  # Impact

  - [ ] New migrations
  - [x] New/Updated API fields or mutations
  - [ ] Deprecated API fields or mutations
  - [ ] Removed API types, fields, or mutations

  # Docs

  No documentation changes required — this promotes an existing Preview-feature input field 
  to required; behavior is now the standard GraphQL required-field validation.

  - [ ] Link to documentation:

  # Pull Request Checklist

  - [x] Privileged queries and mutations are either absent or guarded by proper permission  
  checks
  - [x] Database queries are optimized and the number of queries is constant
  - [x] Database migrations are either absent or optimized for zero downtime
  - [x] The changes are covered by test cases <!-- covered by GraphQL schema required-field 
  validation; no dedicated test per prior maintainer guidance -->
  - [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`,
  `PREVIEW_FEATURE`, etc.)
  - [x] All migrations have proper dependencies
  - [x] All indexes are added concurrently in migrations
  - [x] All RunSql and RunPython migrations have revert option defined