### PR TITLE
Release 3.21.61

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.21.60",
+  "version": "3.21.61",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.21.60",
+      "version": "3.21.61",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.21.60",
+  "version": "3.21.61",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ help = "Run tests with db reuse to speed up testing time"
 
 [tool.poetry]
 name = "saleor"
-version = "3.21.60"
+version = "3.21.61"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.21.60"
+__version__ = "3.21.61"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.21.61 (332c5f1143)
* Make logic sending messages to AWS SQS and Google PubSub more tolerant to prevent task giving up without retries (#19384) (#19395) (28548477a5)
* ci: pin changelog-enforcer action to v3.7.0 (#19336) (7702f5f28f)
