### PR TITLE
build: add note about usage of `pytest-memray`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dev = [
     "pytest-cov>=6.0.0,<7",
     "pytest-django==4.11.1",
     "pytest-django-queries>=1.2,<1.3",
-    "pytest-memray>=1.5.0,<2",
+    "pytest-memray>=1.5.0,<2", # Used via @pytest.mark.limit_memory
     "pytest-mock>=3.6.1,<4",
     "pytest-recording>=0.13.0,<0.14",
     "pytest-socket>=0.8.0,<1",


### PR DESCRIPTION
`memray` and `pytest-memray` looked like unused dependencies which thus required git-blame to verify (https://github.com/saleor/saleor/commit/9f127a3cb5f057a19ae31df8ff9b14fa506edc1f) - this adds a note about how the `pytest-memray` dependency is being used which allows to quickly whether it's still used (thus reducing the risk of someone thinking it's unused, or worst: deleting the dependency which cause the CI/CD to pass as pytest will only warning about `limit_memory` marker being unknown rather than failing)



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
