### PR TITLE
Add common deadline for sending webhooks in threads

### DIFF
--- a/saleor/webhook/transport/asynchronous/tests/test_send_webhooks_async_for_app.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_send_webhooks_async_for_app.py
@@ -1,4 +1,5 @@
-from threading import Event
+import logging
+from threading import Event, Thread
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,6 +15,7 @@ from ..transport import (
     MAX_WEBHOOK_RETRIES,
     WebhookResponse,
     execute_webhook_requests,
+    join_threads_with_deadline,
     send_webhooks_async_for_app,
 )
 
@@ -385,6 +387,47 @@ def test_execute_webhook_requests_stops_mid_batch_on_soft_timeout(
     assert http_requests.qsize() == 2
 
 
+@patch("saleor.webhook.transport.utils.send_prepared_webhook_request_using_http")
+def test_execute_webhook_requests_stops_mid_batch_when_deadline_event_set(
+    mock_send_prepared_webhook_request_using_http,
+    app,
+    event_deliveries,
+):
+    # given
+    deadline_exceeded_event = Event()
+
+    def succeed_then_set_event(*args, **kwargs):
+        # set the deadline event after the first request, so the next loop guard
+        # breaks the loop
+        deadline_exceeded_event.set()
+        return WebhookResponse(content="", status=EventDeliveryStatus.SUCCESS)
+
+    mock_send_prepared_webhook_request_using_http.side_effect = succeed_then_set_event
+
+    http_requests, _ = get_pending_delivery_requests(
+        domain="example.com",
+        app_id=app.id,
+        session=MagicMock(),
+        batch_size=10,
+    )
+    assert http_requests.qsize() == 3
+    results: list = []
+
+    # when
+    execute_webhook_requests(
+        thread_id=0,
+        queue=http_requests,
+        results=results,
+        deadline_exceeded_event=deadline_exceeded_event,
+        telemetry_context=MagicMock(),
+    )
+
+    # then
+    assert mock_send_prepared_webhook_request_using_http.call_count == 1
+    assert len(results) == 1
+    assert http_requests.qsize() == 2
+
+
 @override_settings(WEBHOOK_ASYNC_MAX_CONCURRENCY=1)
 @patch("saleor.webhook.transport.utils.send_prepared_webhook_request_using_http")
 def test_execute_webhook_requests_stops_on_failure_when_concurrency_is_one(
@@ -457,6 +500,103 @@ def test_execute_webhook_requests_continues_on_failure_when_concurrency_above_on
     assert mock_send_prepared_webhook_request_using_http.call_count == 3
     assert len(results) == 3
     assert http_requests.empty()
+
+
+def test_join_threads_with_deadline_sets_event_and_joins_finished_threads(caplog, app):
+    # given
+    caplog.set_level(logging.WARNING)
+    deadline_exceeded_event = Event()
+
+    # Workers that return immediately, so they finish well within the deadline.
+    threads = [Thread(target=lambda: None, name=f"worker-{i}") for i in range(3)]
+    for thread in threads:
+        thread.start()
+
+    # when
+    join_threads_with_deadline(threads, deadline_exceeded_event, app_id=app.id)
+
+    # then
+    assert deadline_exceeded_event.is_set() is True
+    assert all(thread.is_alive() is False for thread in threads)
+    warnings = [
+        record
+        for record in caplog.records
+        if record.message == "Webhook worker did not finish before the deadline."
+    ]
+    assert len(warnings) == 0
+
+
+@override_settings(
+    WEBHOOK_ASYNC_BATCH_TIMEOUT=0,
+    REQUESTS_CONN_EST_TIMEOUT=0,
+    WEBHOOK_WAITING_FOR_RESPONSE_TIMEOUT=0,
+)
+def test_join_threads_with_deadline_warns_for_unfinished_thread(caplog, app):
+    # given
+    caplog.set_level(logging.WARNING)
+
+    # A worker that blocks until the test releases it, so it stays alive past the
+    # deadlines. Imitates a thread sending webhooks past both deadlines.
+    release_event = Event()
+    thread = Thread(target=release_event.wait, name="unfinished-worker")
+    thread.start()
+    deadline_exceeded_event = Event()
+
+    try:
+        # when
+        join_threads_with_deadline([thread], deadline_exceeded_event, app_id=app.id)
+
+        # then
+        assert thread.is_alive() is True
+        assert deadline_exceeded_event.is_set() is True
+        warnings = [
+            record
+            for record in caplog.records
+            if record.message == "Webhook worker did not finish before the deadline."
+        ]
+        assert len(warnings) == 1
+        assert warnings[0].app_id == app.id
+        assert warnings[0].thread_name == thread.name
+    finally:
+        # release the blocked worker so it does not leak into other tests
+        release_event.set()
+        thread.join()
+
+
+@override_settings(
+    WEBHOOK_ASYNC_BATCH_TIMEOUT=0,
+    REQUESTS_CONN_EST_TIMEOUT=2,
+    WEBHOOK_WAITING_FOR_RESPONSE_TIMEOUT=18,
+)
+def test_join_threads_with_deadline_grace_period_lets_lingering_thread_finish(
+    caplog, app
+):
+    # given
+    caplog.set_level(logging.WARNING)
+
+    # A worker that blocks until deadline exceeded event is set, so it stays alive past
+    # the first deadline. Imitates a thread sending webhooks past first deadline but
+    # finished before the second one.
+    deadline_exceeded_event = Event()
+    thread = Thread(target=deadline_exceeded_event.wait, name="lingering-worker")
+    thread.start()
+
+    try:
+        # when
+        join_threads_with_deadline([thread], deadline_exceeded_event, app_id=app.id)
+
+        # then
+        assert thread.is_alive() is False
+        assert deadline_exceeded_event.is_set() is True
+        warnings = [
+            record
+            for record in caplog.records
+            if record.message == "Webhook worker did not finish before the deadline."
+        ]
+        assert len(warnings) == 0
+    finally:
+        deadline_exceeded_event.set()
+        thread.join()
 
 
 @pytest.fixture

--- a/saleor/webhook/transport/asynchronous/tests/test_send_webhooks_async_for_app.py
+++ b/saleor/webhook/transport/asynchronous/tests/test_send_webhooks_async_for_app.py
@@ -1,3 +1,4 @@
+from threading import Event
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -372,6 +373,7 @@ def test_execute_webhook_requests_stops_mid_batch_on_soft_timeout(
             thread_id=0,
             queue=http_requests,
             results=results,
+            deadline_exceeded_event=Event(),
             telemetry_context=MagicMock(),
         )
 
@@ -408,6 +410,7 @@ def test_execute_webhook_requests_stops_on_failure_when_concurrency_is_one(
         thread_id=0,
         queue=http_requests,
         results=results,
+        deadline_exceeded_event=Event(),
         telemetry_context=MagicMock(),
     )
 
@@ -444,6 +447,7 @@ def test_execute_webhook_requests_continues_on_failure_when_concurrency_above_on
         thread_id=0,
         queue=http_requests,
         results=results,
+        deadline_exceeded_event=Event(),
         telemetry_context=MagicMock(),
     )
 

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -897,7 +897,7 @@ def join_threads_with_deadline(
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             break
-        thread.join(remaining)
+        thread.join(timeout=remaining)
 
     deadline_exceeded_event.set()
 
@@ -907,12 +907,13 @@ def join_threads_with_deadline(
     grace_period_deadline = time.monotonic() + (
         settings.REQUESTS_CONN_EST_TIMEOUT
         + settings.WEBHOOK_WAITING_FOR_RESPONSE_TIMEOUT
+        + 2  # arbitrary leeway
     )
     for thread in threads:
         remaining = grace_period_deadline - time.monotonic()
         if remaining <= 0:
             break
-        thread.join(remaining)
+        thread.join(timeout=remaining)
 
     unfinished_threads = [thread for thread in threads if thread.is_alive()]
     for thread in unfinished_threads:

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -1,12 +1,12 @@
 import datetime
 import json
 import logging
+import time
 from collections import defaultdict
 from collections.abc import Callable, Hashable, Sequence
 from dataclasses import asdict, dataclass
-from datetime import timedelta
 from queue import Empty as QueueEmpty
-from threading import Thread
+from threading import Event, Thread
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -17,7 +17,6 @@ from django.apps import apps
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Exists, OuterRef
-from django.utils import timezone
 from opentelemetry.trace import StatusCode
 from promise import Promise
 
@@ -887,6 +886,45 @@ def trigger_send_webhooks_async_for_apps():
             )
 
 
+def join_threads_with_deadline(
+    threads: list[Thread], deadline_exceeded_event: Event, app_id: int
+) -> None:
+    """Join all threads in two phases bounded by shared deadlines."""
+
+    # This is the time budget for sending webhooks.
+    deadline = time.monotonic() + settings.WEBHOOK_ASYNC_BATCH_TIMEOUT
+    for thread in threads:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        thread.join(remaining)
+
+    deadline_exceeded_event.set()
+
+    # This is grace period for webhooks being sent to finish before results are
+    # processed.
+    # Logic sending the webhooks must respect predictable timeout.
+    grace_period_deadline = time.monotonic() + (
+        settings.REQUESTS_CONN_EST_TIMEOUT
+        + settings.WEBHOOK_WAITING_FOR_RESPONSE_TIMEOUT
+    )
+    for thread in threads:
+        remaining = grace_period_deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        thread.join(remaining)
+
+    unfinished_threads = [thread for thread in threads if thread.is_alive()]
+    for thread in unfinished_threads:
+        logger.warning(
+            "Webhook worker did not finish before the deadline.",
+            extra={
+                "app_id": app_id,
+                "thread_name": thread.name,
+            },
+        )
+
+
 @app.task(
     queue=settings.WEBHOOK_CELERY_QUEUE_NAME,
     bind=True,
@@ -896,7 +934,7 @@ def trigger_send_webhooks_async_for_apps():
 @task_with_telemetry_context
 def send_webhooks_async_for_app(
     self,
-    app_id,
+    app_id: int,
     *,
     session: "HTTPSession",
     telemetry_context: TelemetryTaskContext,
@@ -933,12 +971,17 @@ def send_webhooks_async_for_app(
             app_id,
             max_workers,
         )
+
+        # Shared across all workers. It's set once the deadline is reached to signal
+        # workers to stop pulling new deliveries from the queue.
+        deadline_exceeded_event = Event()
         threads = []
         for thread_id in range(max_workers):
             thread = Thread(
                 target=execute_webhook_requests,
-                args=(thread_id, http_requests, results),
+                args=(thread_id, http_requests, results, deadline_exceeded_event),
                 kwargs={"telemetry_context": telemetry_context.to_dict()},
+                name=f"send_webhooks_async_for_app-worker-{app_id}-{thread_id}",
             )
             thread.start()
             threads.append(thread)
@@ -949,16 +992,34 @@ def send_webhooks_async_for_app(
             thread_id = max_workers
             thread = Thread(
                 target=execute_webhook_requests,
-                args=(thread_id, other_requests, results),
+                args=(thread_id, other_requests, results, deadline_exceeded_event),
                 kwargs={"telemetry_context": telemetry_context.to_dict()},
+                name=f"send_webhooks_async_for_app-worker-{app_id}-{thread_id}",
             )
             thread.start()
             threads.append(thread)
 
-        for thread in threads:
-            thread.join()
+        join_threads_with_deadline(threads, deadline_exceeded_event, app_id)
 
-        process_executed_delivery_requests(results)
+        # There might be threads still processing requests even after the generous
+        # deadline. Copy the results to protect against appending to the list during
+        # iteration over it.
+        results_to_process = list(results)
+
+        process_executed_delivery_requests(results_to_process)
+
+        # Detect the situation when webhook could have been processed but would not be
+        # recorded as executed. It's not fool-proof because thread in theory could still
+        # be processing webhook and result is not yet appended to the list.
+        if len(results) != len(results_to_process):
+            logger.warning(
+                "Webhook result(s) were not processed (persisted: %d, not persisted: %d)",
+                len(results_to_process),
+                len(results) - len(results_to_process),
+                extra={
+                    "app_id": app_id,
+                },
+            )
 
 
 @allow_writer()
@@ -997,13 +1058,14 @@ def execute_webhook_requests(
     thread_id: int,
     queue: "Queue[EventDeliveryRequest]",
     results: list[EventDeliveryRequest],
+    deadline_exceeded_event: Event,
     *,
     telemetry_context: TelemetryTaskContext,
 ):
-    stop_after = timezone.now() + timedelta(
-        seconds=settings.WEBHOOK_ASYNC_BATCH_TIMEOUT
-    )
-    while timezone.now() < stop_after:
+    # This deadline is kept here in case the deadline exceeded event for whatever reason is not set.
+    deadline = time.monotonic() + settings.WEBHOOK_ASYNC_BATCH_TIMEOUT
+
+    while time.monotonic() < deadline and not deadline_exceeded_event.is_set():
         try:
             request = queue.get(block=False)
         except QueueEmpty:
@@ -1084,9 +1146,8 @@ def execute_webhook_requests(
             # so we need to break the loop and start next iteration from retrying last failed delivery.
             # In case of higher concurrency we can continue processing next deliveries,
             # as they are processed in parallel and not necessarily in chronological order.
-            if settings.WEBHOOK_ASYNC_MAX_CONCURRENCY > 1:
-                continue
-            break
+            if settings.WEBHOOK_ASYNC_MAX_CONCURRENCY <= 1:
+                break
 
 
 def send_observability_events(webhooks: list[WebhookData], events: list[bytes]):

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -1013,7 +1013,7 @@ def send_webhooks_async_for_app(
         # be processing webhook and result is not yet appended to the list.
         if len(results) != len(results_to_process):
             logger.warning(
-                "Webhook result(s) were not processed (persisted: %d, not persisted: %d)",
+                "Some webhook result(s) were not persisted (persisted: %d, not persisted: %d)",
                 len(results_to_process),
                 len(results) - len(results_to_process),
                 extra={


### PR DESCRIPTION
Why these changes are needed? Task can hang indefinitely when invoking `thread.join()`.