### PR TITLE
Log warning when sync webhook is triggered inside a db transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other changes
 
+- Log a warning when a synchronous webhook is triggered inside an open database transaction, making it easier to find call sites that need to be moved outside the transaction - #19425 by @ayesha-waris
+
 #### Search improvements
 
 ### Deprecations

--- a/saleor/webhook/transport/synchronous/tests/test_transport.py
+++ b/saleor/webhook/transport/synchronous/tests/test_transport.py
@@ -12,7 +12,7 @@ from ...metrics import (
     METRIC_EXTERNAL_REQUEST_DURATION,
 )
 from ...utils import WebhookResponse
-from ..transport import _send_webhook_request_sync
+from ..transport import _send_webhook_request_sync, send_webhook_request_sync
 
 
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_using_http")
@@ -269,3 +269,63 @@ def test_send_webhook_request_sync_record_external_request_with_unknown_webhook_
     assert external_request_content_length.attributes == attributes
     assert external_request_content_length.count == 1
     assert external_request_content_length.sum == payload_size
+
+
+@patch("saleor.webhook.transport.synchronous.transport._send_webhook_request_sync")
+@patch("saleor.webhook.transport.synchronous.transport.transaction.get_connection")
+def test_send_webhook_request_sync_logs_warning_when_called_inside_transaction(
+    mock_get_connection,
+    mock_send_webhook_request_sync,
+    event_delivery_payload_in_database,
+    caplog,
+):
+    # given
+    mock_get_connection.return_value.in_atomic_block = True
+    response = MagicMock(spec=WebhookResponse)
+    response.status = EventDeliveryStatus.SUCCESS
+    response_data = {"key": "value"}
+    mock_send_webhook_request_sync.return_value = (response, response_data)
+    delivery = event_delivery_payload_in_database
+
+    # when
+    result = send_webhook_request_sync(delivery)
+
+    # then
+    mock_send_webhook_request_sync.assert_called_once()
+    assert result == response_data
+    warning_records = [
+        record for record in caplog.records if record.levelname == "WARNING"
+    ]
+    assert len(warning_records) == 1
+    assert warning_records[0].message == (
+        f"Sync webhook was triggered inside a database transaction: "
+        f"{delivery.event_type}"
+    )
+
+
+@patch("saleor.webhook.transport.synchronous.transport._send_webhook_request_sync")
+@patch("saleor.webhook.transport.synchronous.transport.transaction.get_connection")
+def test_send_webhook_request_sync_no_warning_when_called_outside_transaction(
+    mock_get_connection,
+    mock_send_webhook_request_sync,
+    event_delivery_payload_in_database,
+    caplog,
+):
+    # given
+    mock_get_connection.return_value.in_atomic_block = False
+    response = MagicMock(spec=WebhookResponse)
+    response.status = EventDeliveryStatus.SUCCESS
+    response_data = {"key": "value"}
+    mock_send_webhook_request_sync.return_value = (response, response_data)
+    delivery = event_delivery_payload_in_database
+
+    # when
+    result = send_webhook_request_sync(delivery)
+
+    # then
+    mock_send_webhook_request_sync.assert_called_once()
+    assert result == response_data
+    warning_records = [
+        record for record in caplog.records if record.levelname == "WARNING"
+    ]
+    assert len(warning_records) == 0

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -195,6 +195,18 @@ def _send_webhook_request_sync(
 def send_webhook_request_sync(
     delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
 ) -> dict[Any, Any] | None:
+    if transaction.get_connection().in_atomic_block:
+        # Sync webhooks should be triggered outside of any database transaction.
+        # Running them inside one keeps the DB connection open for the duration of an
+        # external HTTP request, which can exhaust the connection pool and lead to
+        # deadlocks. This mirrors the async transport, which warns in the same case.
+        # The stack trace pinpoints the call site so the offending caller can be moved
+        # out of the transaction.
+        logger.warning(
+            "Sync webhook was triggered inside a database transaction: %s",
+            delivery.event_type,
+            stack_info=True,
+        )
     response, response_data = _send_webhook_request_sync(delivery, timeout)
     return response_data if response.status == EventDeliveryStatus.SUCCESS else None
 


### PR DESCRIPTION
## What

Adds a `logger.warning` that fires when a synchronous webhook is triggered inside an open database transaction.

Closes #15138.

## Why

Sync webhooks must be triggered **outside** of any database transaction. Running them inside one holds the DB connection open for the duration of an external HTTP request, which can exhaust the connection pool and lead to deadlocks. Today there is no signal when this happens, so problematic call sites are hard to find.

This mirrors the existing check in the async transport (`saleor/webhook/transport/asynchronous/transport.py`), which already warns when async webhooks are triggered inside a transaction.

## Log level: `warning`, not `error`

The issue title says "error", but this PR deliberately logs at **`warning`** level, following the maintainer consensus on the earlier attempt (#19354):

> "The issue specifically mentions logging an error but I think that could be excessive. Async transport in the similar situation logs a warning which I find more fitting here." — @wcislo-saleor
>
> "+1, warning will allow us to set up dashboard/monitoring, without triggering error-related incidents." — @lkostrowski

An `error`-level log would trip incident alerting for what is really a monitoring signal; `warning` supports dashboards/monitoring without raising incidents, and matches how the async transport already handles the same situation.

## How

- The check lives in `send_webhook_request_sync`, the single generic entry point all sync webhook sends funnel through, so it covers existing and future sync webhooks without per-event wiring.
- It passes `stack_info=True` so the log pinpoints the offending call site, which is what's actually needed to locate and fix callers.

## Tests

Added two tests in `saleor/webhook/transport/synchronous/tests/test_transport.py`:
- logs the warning (once) when called inside a transaction, and still performs the send;
- logs nothing when called outside a transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)