### PR TITLE
Release 3.21.63

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.21.62",
+  "version": "3.21.63",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.21.62",
+      "version": "3.21.63",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.21.62",
+  "version": "3.21.63",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ help = "Run tests with db reuse to speed up testing time"
 
 [tool.poetry]
 name = "saleor"
-version = "3.21.62"
+version = "3.21.63"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.21.62"
+__version__ = "3.21.63"
 
 
 class PatchedSubscriberExecutionContext:


### PR DESCRIPTION
* Release 3.21.63 (17fe005358)
* Ensure attempts sending messages to AWS SQS and Google PubSub time out (#19401) (#19420) (02910d58a2)
* Add possibility of running multiple development supporting containers (database, cache, container for running tests) in parallel primarily for use with Git worktrees (#19247) (#19386) (4d56959317)
