### PR TITLE
Release 3.23.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.23.15",
+  "version": "3.23.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.23.15",
+      "version": "3.23.16",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.23.15",
+  "version": "3.23.16",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.23.15"
+version = "3.23.16"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,7 +1,7 @@
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.23.15"
+__version__ = "3.23.16"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2505,7 +2505,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.23.15"
+version = "3.23.16"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
* Release 3.23.16 (acc03513ac)
* Ensure attempts sending messages to AWS SQS and Google PubSub time out (#19401) (#19422) (bc90883c6f)
* Add possibility of running multiple development supporting containers (database, cache, container for running tests) in parallel primarily for use with Git worktrees (#19247) (#19388) (2567c28128)
