### PR TITLE
fix(tests): remove --run-slow argument for pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -50,32 +50,6 @@ pytest_plugins = [
 ]
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--run-slow",
-        action="store_true",
-        default=False,
-        help="Run tests marked as slow.",
-    )
-
-
-def pytest_configure(config):
-    config.addinivalue_line("markers", "slow: mark test as slow")
-
-
-def pytest_collection_modifyitems(config, items):
-    if config.getoption("--run-slow"):
-        return
-
-    skip_slow = pytest.mark.skip(
-        reason="test is marked as slow and --run-slow is not passed"
-    )
-
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
-
-
 if os.environ.get("PYTEST_DB_URL"):
 
     @pytest.fixture(scope="session")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ filterwarnings = [
 markers = [
     "integration",
     "e2e",
+    "slow",
 ]
 
 [tool.poe.tasks]


### PR DESCRIPTION
The `--run-slow` argument is unnecessary because it is only used for 1 slow test which takes ~7.5 seconds. While the test is slow, it is only 1 test thus does not directly have a major impact over our CIs. However, if one still wishes to not run the slow test locally, then they can run `pytest -m "not slow"`

The `--run-slow` argument was risky as CI/CD was never running that test which thus would require developers to actively be running the test with `--run-slow` which is unrealistic.

Example run:

```
$ uv run pytest -q -n0 --reuse-db -m slow saleor/product/tests/test_tasks.py
Bytecode compiled 12210 files in 487ms
.                                                                                                                                                                                                                                                                                           [100%]
[… unrelated warnings …]
1 passed, 45 deselected, 2 warnings in 6.91s
```

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
