### PR TITLE
Make OrderBulkCreateInput.status a required field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable, unreleased changes to this project will be documented in this file.
   To safely upgrade, ensure that all installed apps do not have this permission.
 - Bulk delete mutations now limit the number of `ids` per call (default 100, configurable via the `BULK_DELETE_LIMIT` env var). Exceeding the limit returns an `INVALID` error. This applies to all bulk delete mutations, including `productBulkDelete`, `productVariantBulkDelete`, `categoryBulkDelete`, `collectionBulkDelete`, `productTypeBulkDelete`, `productMediaBulkDelete`, `attributeBulkDelete`, `attributeValueBulkDelete`, `customerBulkDelete`, `staffBulkDelete`, `pageBulkDelete`, `pageTypeBulkDelete`, `menuBulkDelete`, `menuItemBulkDelete`, `giftCardBulkDelete`, `saleBulkDelete`, `voucherBulkDelete`, `promotionBulkDelete`, `shippingPriceBulkDelete`, `shippingZoneBulkDelete`, `draftOrderBulkDelete`, and `draftOrderLinesBulkDelete`.
 - Removed the deprecated `checkoutId` input argument from the `checkoutShippingAddressUpdate` and `checkoutBillingAddressUpdate` mutations. Use the `id` argument instead.
+- The OrderBulkCreateInput.status input field in the orderBulkCreate is now a required field. - #19434 by @ayesha-waris
 
 ### GraphQL API
 

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -571,7 +571,7 @@ class OrderBulkCreateInput(BaseInputObjectType):
         required=True,
         description="The date, when the order was inserted to Saleor database.",
     )
-    status = OrderStatusEnum(description="Status of the order.")
+    status = OrderStatusEnum(description="Status of the order.", required=True)
     user = graphene.Field(
         OrderBulkCreateUserInput,
         required=True,

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -35,7 +35,11 @@ from .....warehouse.models import Stock
 from ....core.enums import ErrorPolicyEnum
 from ....discount.enums import DiscountValueTypeEnum, OrderDiscountTypeEnum
 from ....payment.enums import TransactionActionEnum
-from ....tests.utils import assert_no_permission, get_graphql_content
+from ....tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 from ...bulk_mutations.order_bulk_create import MAX_NOTE_LENGTH, MINUTES_DIFF
 from ...enums import OrderStatusEnum, StockUpdatePolicyEnum
 
@@ -967,6 +971,41 @@ def test_order_bulk_create(
 
     customer_user.refresh_from_db()
     assert customer_user.number_of_orders == user_orders_count + 1
+
+
+def test_order_bulk_create_missing_status(
+    staff_api_client,
+    permission_manage_orders,
+    permission_manage_orders_import,
+    permission_manage_users,
+    order_bulk_input,
+):
+    # given
+    orders_count = Order.objects.count()
+    staff_api_client.user.user_permissions.add(
+        permission_manage_orders_import,
+        permission_manage_orders,
+        permission_manage_users,
+    )
+    order = order_bulk_input
+    del order["status"]
+    variables = {
+        "orders": [order],
+        "stockUpdatePolicy": StockUpdatePolicyEnum.SKIP.name,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_BULK_CREATE, variables)
+
+    # then - the required `status` field is rejected at the GraphQL schema level
+    assert response.status_code == 400
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert (
+        'In field "status": Expected "OrderStatus!", found null.'
+        in content["errors"][0]["message"]
+    )
+    assert Order.objects.count() == orders_count
 
 
 def test_order_bulk_create_multiple_orders(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -28374,7 +28374,7 @@ input OrderBulkCreateInput @doc(category: "Orders") {
   createdAt: DateTime!
 
   """Status of the order."""
-  status: OrderStatus
+  status: OrderStatus!
 
   """Customer associated with the order."""
   user: OrderBulkCreateUserInput!


### PR DESCRIPTION
### What does this PR do?

Makes the `status` field on `OrderBulkCreateInput` a required field in the `orderBulkCreate` mutation.

Currently, omitting `status` from the input raises a `KeyError: 'status'` deep in the mutation, surfacing as an unhandled HTTP 500 instead of a clean validation error. By marking the field required at the schema level, GraphQL rejects such requests up front with a proper validation error (HTTP 400) and the mutation no longer crashes.

```graphql
input OrderBulkCreateInput {
  ...
  status: OrderStatus!   # was: status: OrderStatus
}
```

**Closes #14506.**

### Why is this a breaking change, and why is it acceptable?

This is an intentional, schema-level breaking change. It is acceptable because `orderBulkCreate` is still a **preview feature**, as confirmed on the issue. The CHANGELOG entry is filed under Breaking changes.

### Context / prior attempts

This supersedes the closed PR #19362 (and the earlier abandoned #14760). It addresses the two review points from #19362:

- **Test for the missing-`status` scenario (@wcislo-saleor):** added `test_order_bulk_create_missing_status`, which omits `status` and asserts Saleor returns HTTP 400 with a GraphQL validation error — this test crashes without the fix.
- **CHANGELOG wording (@wcislo-saleor):** uses the maintainer's prescribed phrasing.

### Testing

- Added `test_order_bulk_create_missing_status` (missing `status` → HTTP 400, no order created).
- Full `test_order_bulk_create.py` suite passes (87 passed), plus the benchmark and subscription-webhook order-bulk-create tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)