### PR TITLE
app installation improvements - fetch_manifest can be retried up to two times

### DIFF
--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -203,13 +203,25 @@ def fetch_brand_data_async(
         )
 
 
-def fetch_manifest(manifest_url: str, timeout=settings.COMMON_REQUESTS_TIMEOUT):
+def fetch_manifest(manifest_url: str, timeout=settings.APP_MANIFEST_TIMEOUT):
     headers = {AppHeaders.SCHEMA_VERSION: schema_version}
-    response = HTTPClient.send_request(
-        "GET", manifest_url, headers=headers, timeout=timeout, allow_redirects=False
-    )
-    response.raise_for_status()
-    return response.json()
+    attempt = 0
+    while True:  # initial try + 2 retries
+        try:
+            response = HTTPClient.send_request(
+                "GET",
+                manifest_url,
+                headers=headers,
+                timeout=timeout,
+                allow_redirects=False,
+            )
+            response.raise_for_status()
+            return response.json()
+        except (requests.ConnectionError, requests.Timeout):
+            if attempt == 2:
+                raise
+            attempt += 1
+            time.sleep(attempt)
 
 
 def install_app(

--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -226,8 +226,13 @@ def fetch_manifest(
     for attempt in range(max_retries):
         try:
             return _get(attempt)
-        except (requests.ConnectionError, requests.Timeout):
-            continue
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            logger.info(
+                "Failed to fetch manifest (%s), retrying (attempt %d out of %d)...",
+                exc,
+                attempt + 1,
+                max_retries + 1,
+            )
     return _get(max_retries)  # final attempt, explicit return to satisfy ruff RET503
 
 

--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -203,31 +203,38 @@ def fetch_brand_data_async(
         )
 
 
-def fetch_manifest(manifest_url: str, timeout=settings.APP_MANIFEST_TIMEOUT):
+def fetch_manifest(
+    manifest_url: str,
+    timeout=settings.COMMON_REQUESTS_TIMEOUT,
+    max_retries: int = 0,
+):
     headers = {AppHeaders.SCHEMA_VERSION: schema_version}
-    attempt = 0
-    while True:  # initial try + 2 retries
+    connect_timeout, read_timeout = timeout
+
+    def _get(attempt: int):
+        response = HTTPClient.send_request(
+            "GET",
+            manifest_url,
+            headers=headers,
+            # Give subsequent retries an incremented connect timeout.
+            timeout=(connect_timeout + attempt, read_timeout),
+            allow_redirects=False,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    for attempt in range(max_retries):
         try:
-            response = HTTPClient.send_request(
-                "GET",
-                manifest_url,
-                headers=headers,
-                timeout=timeout,
-                allow_redirects=False,
-            )
-            response.raise_for_status()
-            return response.json()
+            return _get(attempt)
         except (requests.ConnectionError, requests.Timeout):
-            if attempt == 2:
-                raise
-            attempt += 1
-            time.sleep(attempt)
+            continue
+    return _get(max_retries)  # final attempt, explicit return to satisfy ruff RET503
 
 
 def install_app(
     app_installation: AppInstallation, activate: bool = False
 ) -> tuple[App, AppToken | None]:
-    manifest_data = fetch_manifest(app_installation.manifest_url)
+    manifest_data = fetch_manifest(app_installation.manifest_url, max_retries=2)
     assigned_permissions = app_installation.permissions.all()
 
     manifest_data["permissions"] = get_permission_names(assigned_permissions)

--- a/saleor/app/management/commands/install_app.py
+++ b/saleor/app/management/commands/install_app.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         manifest_url = options["manifest-url"]
 
         self.validate_manifest_url(manifest_url)
-        manifest_data = fetch_manifest(manifest_url)
+        manifest_data = fetch_manifest(manifest_url, max_retries=2)
         permissions = clean_permissions(manifest_data.get("permissions", []))
 
         if quiet and (

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1135,11 +1135,6 @@ REQUESTS_CONN_EST_TIMEOUT = 2
 # Default timeout for external requests.
 COMMON_REQUESTS_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, 18)
 
-# Default timeouts for fetching manifests to install saleor apps.
-# Standard REQUESTS_CONN_EST_TIMEOUT (2s) is too short for the US environment,
-# as it has to do a costly roundtrip to fetch the manifest from Vercel in Europe.
-APP_MANIFEST_TIMEOUT = (5, 18)
-
 WEBHOOK_WAITING_FOR_RESPONSE_TIMEOUT = 18
 
 WEBHOOK_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, WEBHOOK_WAITING_FOR_RESPONSE_TIMEOUT)

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1136,9 +1136,8 @@ REQUESTS_CONN_EST_TIMEOUT = 2
 COMMON_REQUESTS_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, 18)
 
 # Default timeouts for fetching manifests to install saleor apps.
-# Before, we used REQUESTS_CONN_EST_TIMEOUT - 2s was too short for the US environment,
+# Standard REQUESTS_CONN_EST_TIMEOUT (2s) is too short for the US environment,
 # as it has to do a costly roundtrip to fetch the manifest from Vercel in Europe.
-# our standard 18s for reads is okay.
 APP_MANIFEST_TIMEOUT = (5, 18)
 
 WEBHOOK_WAITING_FOR_RESPONSE_TIMEOUT = 18

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1135,6 +1135,12 @@ REQUESTS_CONN_EST_TIMEOUT = 2
 # Default timeout for external requests.
 COMMON_REQUESTS_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, 18)
 
+# Default timeouts for fetching manifests to install saleor apps.
+# Before, we used REQUESTS_CONN_EST_TIMEOUT - 2s was too short for the US environment,
+# as it has to do a costly roundtrip to fetch the manifest from Vercel in Europe.
+# our standard 18s for reads is okay.
+APP_MANIFEST_TIMEOUT = (5, 18)
+
 WEBHOOK_WAITING_FOR_RESPONSE_TIMEOUT = 18
 
 WEBHOOK_TIMEOUT = (REQUESTS_CONN_EST_TIMEOUT, WEBHOOK_WAITING_FOR_RESPONSE_TIMEOUT)


### PR DESCRIPTION
`crt` task in US failed due to timeout when establishing connection with Vercel (to fetch app manifest).

I am adding configurable retry mechanism, to account for potential transient issues on the edge.

To be ported back.