### PR TITLE
Trigger PRODUCT_VARIANT_STOCK_UPDATED when order flows change stock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Webhooks
 
 - Added `PRODUCT_TYPE_CREATED`, `PRODUCT_TYPE_UPDATED`, and `PRODUCT_TYPE_DELETED` webhook events, dispatched when a product type is created, updated, or deleted - #17574 by @ayesha-waris
+- `PRODUCT_VARIANT_STOCK_UPDATED` is now also triggered when order flows change stock quantities or allocations (checkout completion, fulfillment, order/fulfillment cancellation, restock) — previously it was only triggered by the explicit stock-edit mutations - by @xseignard
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Webhooks
 
 - Added `PRODUCT_TYPE_CREATED`, `PRODUCT_TYPE_UPDATED`, and `PRODUCT_TYPE_DELETED` webhook events, dispatched when a product type is created, updated, or deleted - #17574 by @ayesha-waris
-- `PRODUCT_VARIANT_STOCK_UPDATED` is now also triggered when order flows change stock quantities or allocations (checkout completion, fulfillment, order/fulfillment cancellation, restock) — previously it was only triggered by the explicit stock-edit mutations - by @xseignard
+- `PRODUCT_VARIANT_STOCK_UPDATED` is now also triggered when order flows change stock quantities or allocations (checkout completion, fulfillment, order/fulfillment cancellation, restock) — previously it was only triggered by the explicit stock-edit mutations - #19450 by @xseignard
 
 ### Other changes
 

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -824,7 +824,7 @@ def cancel_fulfillment(
             order=fulfillment.order, user=user, app=app, fulfillment=fulfillment
         )
         if warehouse:
-            restock_fulfillment_lines(fulfillment, warehouse)
+            restock_fulfillment_lines(fulfillment, warehouse, requestor=app or user)
             events.fulfillment_restocked_items_event(
                 order=fulfillment.order,
                 user=user,

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -659,7 +659,7 @@ def delete_order_line(
     line_info.line.delete()
 
 
-def restock_fulfillment_lines(fulfillment, warehouse):
+def restock_fulfillment_lines(fulfillment, warehouse, requestor=None):
     """Return fulfilled products to corresponding stocks.
 
     Return products to stocks and update order lines quantity fulfilled values.
@@ -667,7 +667,13 @@ def restock_fulfillment_lines(fulfillment, warehouse):
     order_lines = []
     for line in fulfillment:
         if line.order_line.variant and line.order_line.variant.track_inventory:
-            increase_stock(line.order_line, warehouse, line.quantity, allocate=True)
+            increase_stock(
+                line.order_line,
+                warehouse,
+                line.quantity,
+                allocate=True,
+                requestor=requestor,
+            )
         order_line = line.order_line
         order_line.quantity_fulfilled -= line.quantity
         order_lines.append(order_line)

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -42,6 +42,7 @@ from .models import (
 from .webhooks.stock_events import (
     trigger_product_variant_back_in_stock,
     trigger_product_variant_out_of_stock,
+    trigger_product_variant_stocks_updated,
 )
 
 if TYPE_CHECKING:
@@ -458,6 +459,7 @@ def increase_stock(
     warehouse: Warehouse,
     quantity: int,
     allocate: bool = False,
+    requestor: T_REQUESTOR = None,
 ):
     """Increse stock quantity for given `order_line` in a given warehouse.
 
@@ -492,6 +494,9 @@ def increase_stock(
             )
         stock.quantity_allocated = F("quantity_allocated") + quantity
         stock.save(update_fields=["quantity_allocated"])
+    transaction.on_commit(
+        partial(trigger_product_variant_stocks_updated, [stock], requestor)
+    )
 
 
 def _reduce_quantity_allocated_for_stocks(
@@ -633,12 +638,16 @@ def decrease_stock(
         quantity_allocation_for_stocks[allocation["stock"]] += allocation[
             "quantity_allocated__sum"
         ]
-    _decrease_stocks_quantity(
+    updated_stocks = _decrease_stocks_quantity(
         order_lines_info,
         variant_and_warehouse_to_stock,
         quantity_allocation_for_stocks,
         allow_stock_to_be_exceeded,
     )
+    if updated_stocks:
+        transaction.on_commit(
+            partial(trigger_product_variant_stocks_updated, updated_stocks, requestor)
+        )
 
     stock_ids = (s.id for s in stocks)
     for stock in Stock.objects.filter(id__in=stock_ids).annotate_available_quantity():
@@ -653,7 +662,7 @@ def _decrease_stocks_quantity(
     variant_and_warehouse_to_stock: dict[int, dict[UUID, Stock]],
     quantity_allocation_for_stocks: dict[int, int],
     allow_stock_to_be_exceeded: bool = False,
-):
+) -> list[Stock]:
     insufficient_stocks: list[InsufficientStockData] = []
     stocks_to_update = []
     for line_info in order_lines_info:
@@ -700,6 +709,7 @@ def _decrease_stocks_quantity(
         raise InsufficientStock(insufficient_stocks)
 
     Stock.objects.bulk_update(stocks_to_update, ["quantity"])
+    return stocks_to_update
 
 
 def _get_variant_for_order_line_info(

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -213,6 +213,14 @@ def allocate_stocks(
 
         Stock.objects.bulk_update(stocks_to_update_map.values(), ["quantity_allocated"])
 
+        transaction.on_commit(
+            partial(
+                trigger_product_variant_stocks_updated,
+                list(stocks_to_update_map.values()),
+                requestor,
+            )
+        )
+
         legacy_stock_availability = (
             site_settings.use_legacy_shipping_zone_stock_availability
         )
@@ -361,7 +369,8 @@ def deallocate_stock(
     order_lines_data: list["OrderLineInfo"],
     site_settings: "SiteSettings",
     requestor: T_REQUESTOR,
-):
+    trigger_stock_updated: bool = True,
+) -> list[Stock]:
     """Deallocate stocks for given `order_lines`.
 
     Function lock for update stocks and allocations related to given `order_lines`.
@@ -369,6 +378,9 @@ def deallocate_stock(
     as needed of available in stock for order line, until deallocated all required
     quantity for the order line. If there is less quantity in stocks then
     raise an exception.
+
+    Return the updated stocks. When `trigger_stock_updated` is False, the caller
+    is responsible for firing PRODUCT_VARIANT_STOCK_UPDATED for them.
     """
     # local import: to be removed when all webhook logic will be moved outside plugin
     from .channel_stock_availability import (
@@ -449,8 +461,17 @@ def deallocate_stock(
 
     Stock.objects.bulk_update(stocks_to_update, ["quantity_allocated"])
 
+    # the same stock can be appended once per allocation - deduplicate
+    unique_stocks = list({stock.pk: stock for stock in stocks_to_update}.values())
+    if trigger_stock_updated and unique_stocks:
+        transaction.on_commit(
+            partial(trigger_product_variant_stocks_updated, unique_stocks, requestor)
+        )
+
     if not_dellocated_lines:
         raise AllocationError(not_dellocated_lines)
+
+    return unique_stocks
 
 
 @traced_atomic_transaction()
@@ -574,17 +595,28 @@ def decrease_allocations(
     lines_info: list["OrderLineInfo"],
     site_settings: "SiteSettings",
     requestor: T_REQUESTOR,
-):
-    """Decrease allocations for provided order lines."""
+    trigger_stock_updated: bool = True,
+) -> list[Stock]:
+    """Decrease allocations for provided order lines.
+
+    Return the updated stocks. When `trigger_stock_updated` is False, the caller
+    is responsible for firing PRODUCT_VARIANT_STOCK_UPDATED for them.
+    """
     lines_to_deallocate = get_order_lines_to_deallocate(lines_info)
     if not lines_to_deallocate:
-        return
+        return []
     try:
-        deallocate_stock(lines_info, site_settings, requestor)
+        return deallocate_stock(
+            lines_info,
+            site_settings,
+            requestor,
+            trigger_stock_updated=trigger_stock_updated,
+        )
     except AllocationError as exc:
         Allocation.objects.order_by("stock_id").filter(
             order_line__in=exc.order_lines
         ).update(quantity_allocated=0)
+        return []
 
 
 @traced_atomic_transaction()
@@ -603,10 +635,22 @@ def decrease_stock(
     function decrease it by given value.
     If allow_stock_to_be_exceeded flag is True then quantity could be < 0.
     """
-    decrease_allocations(order_lines_info, site_settings, requestor)
+    # deallocation + quantity decrease are one logical operation; a single
+    # PRODUCT_VARIANT_STOCK_UPDATED with the final stock state is fired below
+    deallocated_stocks = decrease_allocations(
+        order_lines_info, site_settings, requestor, trigger_stock_updated=False
+    )
 
     order_lines_info = get_order_lines_with_track_inventory(order_lines_info)
     if not order_lines_info:
+        if deallocated_stocks:
+            transaction.on_commit(
+                partial(
+                    trigger_product_variant_stocks_updated,
+                    deallocated_stocks,
+                    requestor,
+                )
+            )
         return
     variants = [line_info.variant for line_info in order_lines_info]
     warehouse_pks = [line_info.warehouse_pk for line_info in order_lines_info]
@@ -644,9 +688,17 @@ def decrease_stock(
         quantity_allocation_for_stocks,
         allow_stock_to_be_exceeded,
     )
-    if updated_stocks:
+    # fire once per stock touched by either the deallocation or the quantity
+    # decrease; prefer the quantity-updated instance which holds the final state
+    stocks_to_notify = {stock.pk: stock for stock in deallocated_stocks}
+    stocks_to_notify.update({stock.pk: stock for stock in updated_stocks})
+    if stocks_to_notify:
         transaction.on_commit(
-            partial(trigger_product_variant_stocks_updated, updated_stocks, requestor)
+            partial(
+                trigger_product_variant_stocks_updated,
+                list(stocks_to_notify.values()),
+                requestor,
+            )
         )
 
     stock_ids = (s.id for s in stocks)
@@ -815,6 +867,11 @@ def deallocate_stock_for_orders(
 
     allocations.update(quantity_allocated=0)
     Stock.objects.bulk_update(stocks_to_update, ["quantity_allocated"])
+
+    if stocks_to_update:
+        transaction.on_commit(
+            partial(trigger_product_variant_stocks_updated, stocks_to_update, requestor)
+        )
 
 
 @traced_atomic_transaction()

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -1710,3 +1710,92 @@ def test_deallocate_stock_for_orders_skips_channel_event_when_legacy_flag_enable
 
     # then
     mocked_trigger.assert_not_called()
+
+
+@mock.patch("saleor.warehouse.management.trigger_product_variant_stocks_updated")
+def test_decrease_stock_triggers_stock_updated_webhook(
+    stocks_updated_webhook_mock,
+    allocation,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    stock = allocation.stock
+    stock.quantity = 100
+    stock.quantity_allocated = 80
+    stock.save(update_fields=["quantity", "quantity_allocated"])
+    allocation.quantity_allocated = 80
+    allocation.save(update_fields=["quantity_allocated"])
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        decrease_stock(
+            [
+                OrderLineInfo(
+                    line=allocation.order_line,
+                    quantity=50,
+                    variant=stock.product_variant,
+                    warehouse_pk=allocation.stock.warehouse.pk,
+                )
+            ],
+            site_settings=site_settings,
+            requestor=None,
+        )
+
+    # then
+    stocks_updated_webhook_mock.assert_called_once_with([stock], None)
+
+
+@mock.patch("saleor.warehouse.management.trigger_product_variant_stocks_updated")
+def test_decrease_stock_with_track_inventory_off_does_not_trigger_stock_updated(
+    stocks_updated_webhook_mock,
+    allocation,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    stock = allocation.stock
+    variant = stock.product_variant
+    variant.track_inventory = False
+    variant.save(update_fields=["track_inventory"])
+    allocation.quantity_allocated = 0
+    allocation.save(update_fields=["quantity_allocated"])
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        decrease_stock(
+            [
+                OrderLineInfo(
+                    line=allocation.order_line,
+                    quantity=50,
+                    variant=variant,
+                    warehouse_pk=allocation.stock.warehouse.pk,
+                )
+            ],
+            site_settings=site_settings,
+            requestor=None,
+        )
+
+    # then
+    stocks_updated_webhook_mock.assert_not_called()
+
+
+@mock.patch("saleor.warehouse.management.trigger_product_variant_stocks_updated")
+def test_increase_stock_triggers_stock_updated_webhook(
+    stocks_updated_webhook_mock,
+    allocation,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    stock = allocation.stock
+    stock.quantity = 10
+    stock.save(update_fields=["quantity"])
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        increase_stock(allocation.order_line, stock.warehouse, 50, allocate=False)
+
+    # then
+    stock.refresh_from_db()
+    assert stock.quantity == 60
+    stocks_updated_webhook_mock.assert_called_once_with([stock], None)

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -1799,3 +1799,106 @@ def test_increase_stock_triggers_stock_updated_webhook(
     stock.refresh_from_db()
     assert stock.quantity == 60
     stocks_updated_webhook_mock.assert_called_once_with([stock], None)
+
+
+@mock.patch("saleor.warehouse.management.trigger_product_variant_stocks_updated")
+def test_allocate_stocks_triggers_stock_updated_webhook(
+    stocks_updated_webhook_mock,
+    order_line,
+    stock,
+    channel_USD,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    stock.quantity = 100
+    stock.save(update_fields=["quantity"])
+    line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=50)
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        allocate_stocks(
+            [line_data],
+            COUNTRY_CODE,
+            channel_USD,
+            site_settings=site_settings,
+            requestor=None,
+            calculate_stocks_with_shipping_zones=True,
+        )
+
+    # then
+    stocks_updated_webhook_mock.assert_called_once_with([stock], None)
+
+
+@mock.patch("saleor.warehouse.management.trigger_product_variant_stocks_updated")
+def test_deallocate_stock_triggers_stock_updated_webhook_with_deduplicated_stocks(
+    stocks_updated_webhook_mock,
+    allocations,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given - two allocations of two order lines on the same stock
+    first_allocation = allocations[0]
+    second_allocation = allocations[1]
+    Allocation.objects.exclude(
+        pk__in=[first_allocation.pk, second_allocation.pk]
+    ).delete()
+    second_allocation.stock = first_allocation.stock
+    second_allocation.quantity_allocated = 10
+    second_allocation.save(update_fields=["stock", "quantity_allocated"])
+    first_allocation.quantity_allocated = 20
+    first_allocation.save(update_fields=["quantity_allocated"])
+    stock = first_allocation.stock
+    stock.quantity = 100
+    stock.quantity_allocated = 30
+    stock.save(update_fields=["quantity", "quantity_allocated"])
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        deallocate_stock(
+            [
+                OrderLineInfo(
+                    line=first_allocation.order_line,
+                    quantity=20,
+                    variant=first_allocation.order_line.variant,
+                ),
+                OrderLineInfo(
+                    line=second_allocation.order_line,
+                    quantity=10,
+                    variant=second_allocation.order_line.variant,
+                ),
+            ],
+            site_settings=site_settings,
+            requestor=None,
+        )
+
+    # then - one call with the stock listed once despite two updated allocations
+    stocks_updated_webhook_mock.assert_called_once_with([stock], None)
+
+
+@mock.patch("saleor.warehouse.management.trigger_product_variant_stocks_updated")
+def test_deallocate_stock_for_orders_triggers_stock_updated_webhook(
+    stocks_updated_webhook_mock,
+    allocation,
+    site_settings,
+    django_capture_on_commit_callbacks,
+):
+    # given
+    stock = allocation.stock
+    stock.quantity = 100
+    stock.quantity_allocated = 80
+    stock.save(update_fields=["quantity", "quantity_allocated"])
+    allocation.quantity_allocated = 80
+    allocation.save(update_fields=["quantity_allocated"])
+    order = allocation.order_line.order
+
+    # when
+    with django_capture_on_commit_callbacks(execute=True):
+        deallocate_stock_for_orders(
+            [order.id],
+            site_settings=site_settings,
+            requestor=None,
+        )
+
+    # then
+    stocks_updated_webhook_mock.assert_called_once_with([stock], None)


### PR DESCRIPTION
I want to merge this change because `PRODUCT_VARIANT_STOCK_UPDATED` is currently only triggered by the explicit stock-edit mutations (`productVariantStocksUpdate`, `stockBulkUpdate`), leaving webhook subscribers blind to stock changes caused by orders. Fixes #19449.

Two commits so the two semantic halves can be reviewed (or dropped) independently:

1. **Physical quantity changes**: fire from `decrease_stock` (fulfillment) and `increase_stock` (restock on fulfillment cancellation).
2. **Allocation changes**: fire from `allocate_stocks` (checkout completion), `deallocate_stock` and `deallocate_stock_for_orders` (order cancellation). `decrease_stock` suppresses the trigger of its nested deallocation and fires a single event per stock with the final state (covering the union of deallocated + decremented stocks).

Notes:
- Reuses the existing `trigger_product_variant_stocks_updated` helper; triggers registered with `transaction.on_commit(partial(...))`.
- `deallocate_stock` deduplicates stocks (one event per stock even with several allocations on it).
- `increase_allocations` is not instrumented directly: it delegates re-allocation to `allocate_stocks`, which fires.
- No API surface change, no migrations. Event volume increases for existing `PRODUCT_VARIANT_STOCK_UPDATED` subscribers (documented in CHANGELOG).

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

Event enum descriptions are unchanged (generated from the schema); no saleor-docs change required.

- [ ] Link to documentation: n/a

# Pull Request Checklist

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [x] All migrations have proper dependencies
