### PR TITLE
fix(account): prevent account reactivation via accountConfirm after staff deactivation

### DIFF
--- a/saleor/graphql/account/mutations/account/confirm_account.py
+++ b/saleor/graphql/account/mutations/account/confirm_account.py
@@ -75,9 +75,8 @@ class ConfirmAccount(BaseMutation):
                 }
             )
 
-        user.is_active = True
         user.is_confirmed = True
-        user.save(update_fields=["is_active", "is_confirmed", "updated_at"])
+        user.save(update_fields=["is_confirmed", "updated_at"])
 
         match_orders_with_new_user(user)
         assign_user_gift_cards(user)


### PR DESCRIPTION
## The Bug

The `ConfirmAccount` mutation unconditionally sets `is_active=True` on the user. This means that if a staff user deactivates an account (e.g., when offboarding an employee), the user can re-activate themselves by calling `accountConfirm()` with their existing token.

## The Fix

Remove the `user.is_active = True` assignment and `"is_active"` from the `save(update_fields=...)` call. The mutation should only set `is_confirmed` — it should not override the active status set by staff.

## Changes

`saleor/graphql/account/mutations/account/confirm_account.py` — remove `is_active = True` from `ConfirmAccount.perform_mutation`

Closes #19423
