### PR TITLE
Handle duplicate slugs in productBulkCreate

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -232,7 +232,13 @@ class ProductBulkCreate(BaseMutation):
 
     @classmethod
     def clean_base_fields(
-        cls, cleaned_input, new_slugs, product_index, index_error_map
+        cls,
+        cleaned_input,
+        duplicated_slugs,
+        existing_slugs,
+        new_slugs,
+        product_index,
+        index_error_map,
     ):
         base_fields_errors_count = 0
 
@@ -247,12 +253,29 @@ class ProductBulkCreate(BaseMutation):
             )
             base_fields_errors_count += 1
 
+        slug = cleaned_input.get("slug")
+        if slug:
+            if slug in duplicated_slugs or slug in existing_slugs:
+                message = (
+                    "Product with this Slug already exists."
+                    if slug in existing_slugs
+                    else "Duplicated slug."
+                )
+                index_error_map[product_index].append(
+                    ProductBulkCreateError(
+                        path="slug",
+                        message=message,
+                        code=ProductBulkCreateErrorCode.UNIQUE.value,
+                    )
+                )
+                base_fields_errors_count += 1
+            new_slugs.append(slug)
+
         description = cleaned_input.get("description")
         cleaned_input["description_plaintext"] = (
             editorjs_to_text(description) if description else ""
         )
 
-        slug = cleaned_input.get("slug")
         if not slug and "name" in cleaned_input:
             slug = cls.generate_unique_slug(cleaned_input["name"], new_slugs)
             cleaned_input["slug"] = slug
@@ -558,6 +581,8 @@ class ProductBulkCreate(BaseMutation):
         channel_global_id_to_instance_map: dict,
         warehouse_global_id_to_instance_map: dict,
         duplicated_sku: set,
+        duplicated_slugs: set,
+        existing_slugs: set,
         new_slugs: list,
         product_index: int,
         index_error_map: dict,
@@ -575,6 +600,8 @@ class ProductBulkCreate(BaseMutation):
 
         base_fields_errors_count += cls.clean_base_fields(
             cleaned_input,
+            duplicated_slugs,
+            existing_slugs,
             new_slugs,
             product_index,
             index_error_map,
@@ -638,6 +665,15 @@ class ProductBulkCreate(BaseMutation):
                 if variant.sku
             ]
         )
+        input_slugs = [
+            product_data.slug for product_data in products_data if product_data.slug
+        ]
+        duplicated_slugs = get_duplicated_values(input_slugs)
+        existing_slugs = set(
+            models.Product.objects.filter(slug__in=input_slugs).values_list(
+                "slug", flat=True
+            )
+        )
 
         for product_index, product_data in enumerate(products_data):
             cleaned_input = cls.clean_product_input(
@@ -646,6 +682,8 @@ class ProductBulkCreate(BaseMutation):
                 channel_global_id_to_instance_map,
                 warehouse_global_id_to_instance_map,
                 duplicated_sku,
+                duplicated_slugs,
+                existing_slugs,
                 new_slugs,
                 product_index,
                 index_error_map,

--- a/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
@@ -560,6 +560,131 @@ def test_product_bulk_create_with_same_name_and_no_slug(
     assert data["results"][1]["product"]["slug"] == "test-name-2"
 
 
+def test_product_bulk_create_with_existing_slug_and_reject_failed_rows(
+    staff_api_client,
+    product,
+    product_type,
+    permission_manage_products,
+):
+    # given
+    product_count = Product.objects.count()
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    new_product_slug = "new-product-slug"
+
+    products = [
+        {
+            "productType": product_type_id,
+            "name": "New product",
+            "slug": new_product_slug,
+        },
+        {
+            "productType": product_type_id,
+            "name": "Product with existing slug",
+            "slug": product.slug,
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_BULK_CREATE_MUTATION,
+        {"products": products, "errorPolicy": ErrorPolicyEnum.REJECT_FAILED_ROWS.name},
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productBulkCreate"]
+
+    # then
+    assert data["count"] == 1
+    assert data["results"][0]["product"]["slug"] == new_product_slug
+    assert not data["results"][0]["errors"]
+    assert not data["results"][1]["product"]
+    errors = data["results"][1]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["path"] == "slug"
+    assert errors[0]["code"] == ProductBulkCreateErrorCode.UNIQUE.name
+    assert Product.objects.count() == product_count + 1
+
+
+def test_product_bulk_create_with_duplicated_slug_in_input(
+    staff_api_client,
+    product_type,
+    permission_manage_products,
+):
+    # given
+    product_count = Product.objects.count()
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    duplicated_slug = "duplicated-product-slug"
+
+    products = [
+        {
+            "productType": product_type_id,
+            "name": "First product",
+            "slug": duplicated_slug,
+        },
+        {
+            "productType": product_type_id,
+            "name": "Second product",
+            "slug": duplicated_slug,
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_BULK_CREATE_MUTATION,
+        {"products": products},
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productBulkCreate"]
+
+    # then
+    assert data["count"] == 0
+    assert Product.objects.count() == product_count
+    for result in data["results"]:
+        assert not result["product"]
+        errors = result["errors"]
+        assert len(errors) == 1
+        assert errors[0]["path"] == "slug"
+        assert errors[0]["code"] == ProductBulkCreateErrorCode.UNIQUE.name
+
+
+def test_product_bulk_create_generates_slug_unique_to_explicit_batch_slug(
+    staff_api_client,
+    product_type,
+    permission_manage_products,
+):
+    # given
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+
+    products = [
+        {
+            "productType": product_type_id,
+            "name": "First product",
+            "slug": "test-name",
+        },
+        {
+            "productType": product_type_id,
+            "name": "test name",
+        },
+    ]
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_BULK_CREATE_MUTATION,
+        {"products": products},
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productBulkCreate"]
+
+    # then
+    assert data["count"] == 2
+    assert data["results"][0]["product"]["slug"] == "test-name"
+    assert data["results"][1]["product"]["slug"] == "test-name-2"
+    assert not data["results"][0]["errors"]
+    assert not data["results"][1]["errors"]
+
+
 def test_product_bulk_create_with_invalid_attributes(
     staff_api_client,
     product_type,


### PR DESCRIPTION
I want to merge this change because `productBulkCreate` can still reach `bulk_create` with duplicate product slugs from the same request, which raises an unhandled `IntegrityError` for the `product_product_slug_key` constraint.

Fixes #17908.

This adds pre-save validation for explicit slugs in `productBulkCreate`:
- collects duplicate slugs from the submitted batch before row validation
- checks submitted slugs that already exist with a single query
- reports `UNIQUE` errors on the affected rows before `bulk_create`
- reserves valid explicit slugs so generated slugs later in the batch avoid them

The approach follows the existing bulk validation shape used for duplicate variant SKUs and preserves `errorPolicy` handling.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields or mutations

# Docs

No documentation update required; this is validation behavior for an existing mutation.

- [ ] Link to documentation:

# Pull Request Checklist

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [x] All migrations have proper dependencies
- [x] All indexes are added concurrently in migrations
- [x] All RunSql and RunPython migrations have revert option defined

Validation:
- `uv run poe test saleor/graphql/product/tests/mutations/test_product_bulk_create.py -n0`
- `uv run ruff check saleor/graphql/product/bulk_mutations/product_bulk_create.py saleor/graphql/product/tests/mutations/test_product_bulk_create.py`

Disclosure: I used AI-assisted coding tools while preparing this PR. I reviewed the changes myself, tested them, and take responsibility for the implementation and any follow-up revisions needed.

If this project does not accept AI-assisted contributions, please let us know up front so we can avoid spending time on a contribution that the project is unwilling to consider.
