### PR TITLE
feat(asgi): add random filename into gzip responses

### DIFF
--- a/saleor/asgi/gzip_compression.py
+++ b/saleor/asgi/gzip_compression.py
@@ -3,6 +3,7 @@
 
 import gzip
 import io
+import secrets
 
 from asgiref.typing import (
     ASGI3Application,
@@ -12,6 +13,20 @@ from asgiref.typing import (
     HTTPResponseStartEvent,
     Scope,
 )
+
+
+def _get_random_filename() -> str:
+    """Generate a random filename with up to 100 bytes (inclusive, i.e., [0,100]).
+
+    This ensures the HTTP content-length is random thus making it more difficult
+    to guess whether a given character is present in the response
+    (see https://ieeexplore.ieee.org/document/9754554).
+
+    Note: this doesn't use `random.randint()` because the `secrets` generates
+          stronger random numbers by utilizing the operating system's random
+          number generator (such as `/dev/urandom` or CryptGenRandom on Windows)
+    """
+    return "x" * secrets.randbelow(101)
 
 
 def gzip_compression(
@@ -35,7 +50,10 @@ def gzip_compression(
                 started = False
                 gzip_buffer = io.BytesIO()
                 gzip_file = gzip.GzipFile(
-                    mode="wb", fileobj=gzip_buffer, compresslevel=compresslevel
+                    mode="wb",
+                    fileobj=gzip_buffer,
+                    compresslevel=compresslevel,
+                    filename=_get_random_filename(),
                 )
 
                 async def send_compressed(message: ASGISendEvent) -> None:

--- a/saleor/asgi/tests/test_gzip.py
+++ b/saleor/asgi/tests/test_gzip.py
@@ -204,5 +204,4 @@ async def test_response_content_length_is_random(
     # On average, the filename's length should be higher than 1 byte, and thus
     # on average it should exceed the length of 'length_1byte_filename'
     avg: float = sum(lengths) / float(len(lengths))
-    assert avg.is_integer() is False, "Number shouldn't be whole"
     assert avg > length_1byte_filename

--- a/saleor/asgi/tests/test_gzip.py
+++ b/saleor/asgi/tests/test_gzip.py
@@ -1,4 +1,5 @@
 import gzip
+from unittest import mock
 
 from asgiref.typing import (
     ASGI3Application,
@@ -68,8 +69,15 @@ async def test_no_compression(large_asgi_app: ASGI3Application, settings):
 
 async def test_with_supported_compression(large_asgi_app: ASGI3Application, settings):
     settings.ALLOWED_GRAPHQL_ORIGINS = ["*"]
-    cors_app = gzip_compression(large_asgi_app)
-    events = await run_app(cors_app, build_scope("http://localhost:3000", b"gzip"))
+
+    with mock.patch(
+        # Returns an empty 'random' filename in order to make the HTTP response
+        # predictable for this test case
+        "saleor.asgi.gzip_compression._get_random_filename",
+        wraps=lambda: "",
+    ):
+        cors_app = gzip_compression(large_asgi_app)
+        events = await run_app(cors_app, build_scope("http://localhost:3000", b"gzip"))
     expected_payload = gzip.compress(10000 * b"x", compresslevel=9)
     assert events == [
         HTTPResponseStartEvent(
@@ -86,3 +94,115 @@ async def test_with_supported_compression(large_asgi_app: ASGI3Application, sett
             type="http.response.body", body=expected_payload, more_body=False
         ),
     ]
+
+
+async def test_response_content_length_includes_random_filename(
+    large_asgi_app: ASGI3Application,
+):
+    """Ensure the response contains a random filename when compressed.
+
+    This is done by mocking the random number generator so that it always returns
+    a random 8 bytes filename (meaning it always returns `xxxxxxxx` as the random
+    filename), then we check that this random filename is present in the HTTP
+    response as well as in the `content-length` header.
+    """
+
+    cors_app = gzip_compression(large_asgi_app)
+
+    dummy_random_filename_length = 8
+    expected_random_filename = b"x" * dummy_random_filename_length
+
+    with mock.patch(
+        "secrets.randbelow", wraps=lambda _upperbound: dummy_random_filename_length
+    ):
+        events = await run_app(cors_app, build_scope("http://localhost:3000", b"gzip"))
+
+    assert len(events) == 2
+    resp_event, body_event = events
+
+    # Note: this is a TypeDict thus can't do `isinstance(..., HTTPResponseBodyEvent)`
+    resp_event: HTTPResponseStartEvent
+    assert resp_event["type"] == "http.response.start"
+
+    body_event: HTTPResponseBodyEvent
+    assert isinstance(body_event, dict)
+    assert body_event["type"] == "http.response.body"
+
+    resp_headers = dict(resp_event["headers"])
+    assert resp_headers == {
+        b"content-encoding": b"gzip",
+        b"content-type": b"text/plain",
+        b"content-length": str(
+            # content-length should include the random filename
+            len(gzip.compress(10000 * b"x", compresslevel=9))
+            + dummy_random_filename_length
+            + 1  # NUL (0x00) which separates the filename
+        ).encode("latin1"),
+    }
+
+    body: bytes = body_event["body"]
+
+    # Ensure this is a Gzip response (by checking the magic number)
+    # and that it contains a filename
+    # 1F 8B 08 08
+    #          ^^
+    #           |--> Means a filename is included
+    #       ^^
+    #        |-----> Means compression method is a deflate
+    # ^^^^^
+    #    |---------> Means this is a gzip file (magic number)
+    assert body.startswith(b"\x1f\x8b\x08\x08"), "should be a gzip response w/ filename"
+
+    # Ensure the body contains the random filename
+    filename = body[10:]  # 4 + 6 bytes (magic number + 6 bytes separator)
+    assert filename.startswith(expected_random_filename + b"\x00")
+
+
+async def test_response_content_length_is_random(
+    large_asgi_app: ASGI3Application,
+):
+    """Ensure the response is random when compressed.
+
+    This is done by generating multiple responses, then getting the average value
+    which should be a float rather than an integer which would indicate a constant
+    content-length instead of being random.
+    """
+
+    cors_app = gzip_compression(large_asgi_app)
+
+    async def _send_request() -> bytes:
+        """Send a request and return the body."""
+
+        events = await run_app(cors_app, build_scope("http://localhost:3000", b"gzip"))
+
+        assert len(events) == 2
+        resp_event, body_event = events
+
+        resp_event: HTTPResponseStartEvent
+        assert resp_event["type"] == "http.response.start"
+
+        body_event: HTTPResponseBodyEvent
+        assert isinstance(body_event, dict)
+        assert body_event["type"] == "http.response.body"
+
+        return body_event["body"]
+
+    # Retrieves the length with a 1-byte filename
+    with mock.patch("secrets.randbelow", wraps=lambda _upperbound: 1):
+        body = await _send_request()
+
+        # Should start with 1F 8B 8B 08 - meaning this is a deflate gzip file
+        # with a filename
+        assert body.startswith(b"\x1f\x8b\x08\x08")
+        length_1byte_filename = len(body)
+
+    lengths = []
+
+    for _i in range(10):
+        lengths.append(len(await _send_request()))
+
+    # On average, the filename's length should be higher than 1 byte, and thus
+    # on average it should exceed the length of 'length_1byte_filename'
+    avg: float = sum(lengths) / float(len(lengths))
+    assert avg.is_integer() is False, "Number shouldn't be whole"
+    assert avg > length_1byte_filename


### PR DESCRIPTION
Implements https://ieeexplore.ieee.org/document/9754554 to make gzip responses lengths random thus ensuring an actor cannot effectively guess whether a given character is present in the response.



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
