### PR TITLE
fix(accounts): disallow running confirmAccount on disabled accounts

### DIFF
--- a/saleor/graphql/account/mutations/account/confirm_account.py
+++ b/saleor/graphql/account/mutations/account/confirm_account.py
@@ -53,7 +53,7 @@ class ConfirmAccount(BaseMutation):
     def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
         error = False
         try:
-            user = models.User.objects.get(email=data["email"])
+            user = models.User.objects.get(email=data["email"], is_active=True)
         except ObjectDoesNotExist:
             # If user doesn't exists in the database we create fake user for calculation
             # purpose, as we don't want to indicate non existence of user in the system.
@@ -75,9 +75,8 @@ class ConfirmAccount(BaseMutation):
                 }
             )
 
-        user.is_active = True
         user.is_confirmed = True
-        user.save(update_fields=["is_active", "is_confirmed", "updated_at"])
+        user.save(update_fields=["is_confirmed", "updated_at"])
 
         match_orders_with_new_user(user)
         assign_user_gift_cards(user)

--- a/saleor/graphql/account/tests/mutations/account/test_confirm_account.py
+++ b/saleor/graphql/account/tests/mutations/account/test_confirm_account.py
@@ -223,3 +223,69 @@ def test_account_confirmation_accepts_legacy_account_confirm_token(
     match_orders_with_new_user_mock.assert_called_once_with(customer_user)
     assign_gift_cards_mock.assert_called_once_with(customer_user)
     mocked_account_confirmed.assert_called_once_with(customer_user)
+
+
+@patch(
+    "saleor.graphql.account.mutations.account.confirm_account.assign_user_gift_cards"
+)
+@patch(
+    "saleor.graphql.account.mutations.account.confirm_account.match_orders_with_new_user"
+)
+@patch("saleor.plugins.manager.PluginsManager.account_confirmed")
+def test_account_confirmation_rejects_disabled_accounts(
+    mocked_account_confirmed,
+    match_orders_with_new_user_mock,
+    assign_gift_cards_mock,
+    api_client,
+    customer_user,
+):
+    """Ensure a user with `is_active=False` cannot confirm their account.
+
+    A disabled account shouldn't be able to interact with our API, thus we
+    are ensuring `is_active=False` results to the request being rejected.
+    """
+
+    # given
+    customer_user.is_confirmed = False
+    customer_user.is_active = False
+    customer_user.save(update_fields=("is_confirmed", "is_active"))
+    token = account_confirm_token_generator.make_token(customer_user)
+    variables = {
+        "email": customer_user.email,
+        "token": token,
+    }
+
+    # when
+    response = get_graphql_content(
+        api_client.post_graphql(CONFIRM_ACCOUNT_MUTATION, variables)
+    )
+
+    # then
+    data = response["data"]["confirmAccount"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "token"
+    assert errors[0]["code"] == AccountErrorCode.INVALID.name
+    assert data["user"] is None
+    customer_user.refresh_from_db(fields=("is_confirmed",))
+
+    # Shouldn't have activated the account
+    assert customer_user.is_confirmed is False
+    match_orders_with_new_user_mock.assert_not_called()
+    assign_gift_cards_mock.assert_not_called()
+    mocked_account_confirmed.assert_not_called()
+
+    # Sanity check: should work when is_active=True
+    customer_user.is_active = True
+    customer_user.save(update_fields=("is_active",))
+    response = get_graphql_content(
+        api_client.post_graphql(CONFIRM_ACCOUNT_MUTATION, variables)
+    )
+    assert not response["data"]["confirmAccount"]["errors"], (
+        "should have accepted the token"
+    )
+    customer_user.refresh_from_db(fields=("is_confirmed",))
+    assert customer_user.is_confirmed is True, "shouldh have activated the account"
+    match_orders_with_new_user_mock.assert_called_once_with(customer_user)
+    assign_gift_cards_mock.assert_called_once_with(customer_user)
+    mocked_account_confirmed.assert_called_once_with(customer_user)


### PR DESCRIPTION
Partial backport of #19459 which fixes the following issues:
- An inactive account could call the mutation
- An inactive account could get re-activated

This omits the change that ensures an account that already was confirmed cannot be confirmed again. This is omitted due to potentially being a breaking change.



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
