### PR TITLE
Deprecate OBSERVABILITY event type and MANAGE_OBSERVABILITY permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,11 @@ All notable, unreleased changes to this project will be documented in this file.
 - Added `PasswordLoginMode` setting to control password-based authentication. When set to `DISABLED`, all password authentication mutations (`tokenCreate`, `setPassword`, `passwordChange`, `requestPasswordReset`, `tokenRefresh`) return errors. When set to `CUSTOMERS_ONLY`, staff users who log in with a password are treated as customers without staff
 permissions.
 - `staffDelete` mutation now always deletes the staff user. Previously, staff members with existing orders were only deactivated (`is_staff` set to `False`); now they are fully removed regardless of order history.
+- Deprecated the `MANAGE_OBSERVABILITY` permission (`PermissionEnum`). The observability feature is no longer supported and the permission will be removed in Saleor 3.24.
 
 ### Webhooks
 
+- Deprecated the `OBSERVABILITY` webhook event type (`WebhookEventTypeEnum`, `WebhookEventTypeAsyncEnum`, `WebhookSampleEventTypeEnum`). The observability feature is no longer supported and the event will be removed in Saleor 3.24.
 - For order webhook events, sync webhooks (such as `ORDER_CALCULATE_TAXES` and `ORDER_FILTER_SHIPPING_METHODS`) are no longer pre-fired before sending async webhook events. Sync webhooks are now only triggered when their data is actually requested, improving performance and decoupling async event delivery from sync webhook execution.
 -  Building payloads for webhook order events (including draft orders and fulfillments) is now delegated to a separate background task. This speeds up the execution of most order mutations by deferring the expensive payload serialization out of the request path.
 

--- a/saleor/graphql/core/enums.py
+++ b/saleor/graphql/core/enums.py
@@ -25,7 +25,7 @@ from ...menu import error_codes as menu_error_codes
 from ...order import error_codes as order_error_codes
 from ...page import error_codes as page_error_codes
 from ...payment import error_codes as payment_error_codes
-from ...permission.enums import get_permissions_enum_list
+from ...permission.enums import AppPermission, get_permissions_enum_list
 from ...plugins import error_codes as plugin_error_codes
 from ...product import error_codes as product_error_codes
 from ...shipping import error_codes as shipping_error_codes
@@ -117,8 +117,20 @@ LanguageCodeEnum = graphene.Enum(
 
 JobStatusEnum: Final[graphene.Enum] = to_enum(JobStatus)
 
+
+def permission_enum_deprecation_reason(enum):
+    if enum.value == AppPermission.MANAGE_OBSERVABILITY.value:
+        return (
+            "The observability feature is no longer supported. "
+            "This permission will be removed in Saleor 3.24."
+        )
+    return None
+
+
 PermissionEnum: Final[graphene.Enum] = graphene.Enum(
-    "PermissionEnum", get_permissions_enum_list()
+    "PermissionEnum",
+    get_permissions_enum_list(),
+    deprecation_reason=permission_enum_deprecation_reason,
 )
 PermissionEnum.doc_category = DOC_CATEGORY_USERS
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2217,7 +2217,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   VOUCHER_CODE_EXPORT_COMPLETED
 
   """An observability event is created."""
-  OBSERVABILITY
+  OBSERVABILITY @deprecated(reason: "The observability feature is no longer supported. This event will be removed in Saleor 3.24.")
 
   """A thumbnail is created."""
   THUMBNAIL_CREATED
@@ -2821,7 +2821,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   VOUCHER_CODE_EXPORT_COMPLETED
 
   """An observability event is created."""
-  OBSERVABILITY
+  OBSERVABILITY @deprecated(reason: "The observability feature is no longer supported. This event will be removed in Saleor 3.24.")
 
   """A thumbnail is created."""
   THUMBNAIL_CREATED
@@ -3034,7 +3034,7 @@ enum PermissionEnum @doc(category: "Users") {
   MANAGE_STAFF
   IMPERSONATE_USER
   MANAGE_APPS
-  MANAGE_OBSERVABILITY
+  MANAGE_OBSERVABILITY @deprecated(reason: "The observability feature is no longer supported. This permission will be removed in Saleor 3.24.")
   MANAGE_CHECKOUTS
   HANDLE_CHECKOUTS
   HANDLE_TAXES
@@ -14253,7 +14253,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   CHECKOUT_FULLY_AUTHORIZED
   CHECKOUT_FULLY_PAID
   CHECKOUT_METADATA_UPDATED
-  NOTIFY_USER
+  NOTIFY_USER @deprecated(reason: "See the docs for more details about migrating from NOTIFY_USER to other events: https://docs.saleor.io/upgrade-guides/core/3-16-to-3-17#migrating-from-notify_user")
   PAGE_CREATED
   PAGE_UPDATED
   PAGE_DELETED
@@ -14288,7 +14288,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   VOUCHER_CODES_DELETED
   VOUCHER_METADATA_UPDATED
   VOUCHER_CODE_EXPORT_COMPLETED
-  OBSERVABILITY
+  OBSERVABILITY @deprecated(reason: "The observability feature is no longer supported. This event will be removed in Saleor 3.24.")
   THUMBNAIL_CREATED
   SHOP_METADATA_UPDATED
 }

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -282,6 +282,11 @@ def deprecation_reason(enum):
             "See the docs for more details about migrating from NOTIFY_USER to other events: "
             "https://docs.saleor.io/upgrade-guides/core/3-16-to-3-17#migrating-from-notify_user"
         )
+    if enum.value == WebhookEventAsyncType.OBSERVABILITY:
+        return (
+            "The observability feature is no longer supported. "
+            "This event will be removed in Saleor 3.24."
+        )
     if enum.value == WebhookEventAsyncType.ANY:
         return DEFAULT_DEPRECATION_REASON
     return None
@@ -322,6 +327,7 @@ WebhookSampleEventTypeEnum = graphene.Enum(
         for e_type in WebhookEventAsyncType.CHOICES
         if e_type[0] != WebhookEventAsyncType.ANY
     ],
+    deprecation_reason=deprecation_reason,
 )
 WebhookSampleEventTypeEnum.doc_category = DOC_CATEGORY_WEBHOOKS
 


### PR DESCRIPTION
legacy OBSERVABILITY will be removed in 3.24, so deprecating it here
https://github.com/saleor/saleor/pull/19465