### PR TITLE
[3.23] Allow editing Shop.name via shopSettingsUpdate

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23172,6 +23172,13 @@ type ShopSettingsUpdate @doc(category: "Shop") @webhookEventsInfo(asyncEvents: [
 }
 
 input ShopSettingsInput {
+  """
+  Shop's name.
+  
+  Added in Saleor 3.23.
+  """
+  name: String
+
   """Header text."""
   headerText: String
 

--- a/saleor/graphql/shop/mutations/shop_settings_update.py
+++ b/saleor/graphql/shop/mutations/shop_settings_update.py
@@ -239,9 +239,6 @@ class ShopSettingsUpdate(BaseMutation):
         data = data.get("input")
         cleaned_input = cls.clean_input(info, instance, data)
 
-        # `name` is stored on the `Site` object, not on `SiteSettings`.
-        name = cleaned_input.pop("name", None)
-
         metadata_list: list[MetadataInput] = cleaned_input.pop("metadata", None)
         private_metadata_list: list[MetadataInput] = cleaned_input.pop(
             "private_metadata", None
@@ -257,17 +254,20 @@ class ShopSettingsUpdate(BaseMutation):
         old_metadata = dict(instance.metadata)
         old_private_metadata = dict(instance.private_metadata)
 
+        # `name` is stored on the `Site` object, not on `SiteSettings`, so it must
+        # be popped before `construct_instance` runs over the remaining input.
+        name = cleaned_input.pop("name", None)
+        if name is not None and site.name != name:
+            site.name = name
+            cls.clean_instance(info, site)
+            site.save(update_fields=["name"])
+
         instance = cls.construct_instance(instance, cleaned_input)
         cls.validate_and_update_metadata(
             instance, metadata_collection, private_metadata_collection
         )
         cls.clean_instance(info, instance)
         instance.save()
-
-        if name is not None and site.name != name:
-            site.name = name
-            cls.clean_instance(info, site)
-            site.save(update_fields=["name"])
 
         if (
             instance.metadata != old_metadata

--- a/saleor/graphql/shop/mutations/shop_settings_update.py
+++ b/saleor/graphql/shop/mutations/shop_settings_update.py
@@ -24,6 +24,7 @@ from ..types import Shop
 
 
 class ShopSettingsInput(graphene.InputObjectType):
+    name = graphene.String(description="Shop's name." + ADDED_IN_323)
     header_text = graphene.String(description="Header text.")
     description = graphene.String(description="SEO description.")
     track_inventory_by_default = graphene.Boolean(
@@ -238,6 +239,9 @@ class ShopSettingsUpdate(BaseMutation):
         data = data.get("input")
         cleaned_input = cls.clean_input(info, instance, data)
 
+        # `name` is stored on the `Site` object, not on `SiteSettings`.
+        name = cleaned_input.pop("name", None)
+
         metadata_list: list[MetadataInput] = cleaned_input.pop("metadata", None)
         private_metadata_list: list[MetadataInput] = cleaned_input.pop(
             "private_metadata", None
@@ -259,6 +263,11 @@ class ShopSettingsUpdate(BaseMutation):
         )
         cls.clean_instance(info, instance)
         instance.save()
+
+        if name is not None and site.name != name:
+            site.name = name
+            cls.clean_instance(info, site)
+            site.save(update_fields=["name"])
 
         if (
             instance.metadata != old_metadata

--- a/saleor/graphql/shop/tests/mutations/test_shop_settings_update.py
+++ b/saleor/graphql/shop/tests/mutations/test_shop_settings_update.py
@@ -634,3 +634,68 @@ def test_shop_settings_update_password_login_mode_preserves_when_not_provided(
     assert data["shop"]["passwordLoginMode"] == login_mode.upper()
     site_settings.refresh_from_db()
     assert site_settings.password_login_mode == login_mode
+
+
+MUTATION_UPDATE_SHOP_NAME = """
+    mutation updateSettings($input: ShopSettingsInput!) {
+        shopSettingsUpdate(input: $input) {
+            shop {
+                name
+            }
+            errors {
+                field
+                message
+                code
+            }
+        }
+    }
+"""
+
+
+def test_shop_settings_update_name(
+    staff_api_client, site_settings, permission_manage_settings
+):
+    # given
+    new_name = "New shop name"
+    assert site_settings.site.name != new_name
+    variables = {"input": {"name": new_name}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_UPDATE_SHOP_NAME,
+        variables,
+        permissions=[permission_manage_settings],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["shopSettingsUpdate"]
+    assert not data["errors"]
+    assert data["shop"]["name"] == new_name
+    site = Site.objects.get_current()
+    assert site.name == new_name
+
+
+def test_shop_settings_update_name_too_long(
+    staff_api_client, site_settings, permission_manage_settings
+):
+    # given
+    # `Site.name` is limited to 50 characters.
+    too_long_name = "x" * 51
+    original_name = site_settings.site.name
+    variables = {"input": {"name": too_long_name}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_UPDATE_SHOP_NAME,
+        variables,
+        permissions=[permission_manage_settings],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    errors = content["data"]["shopSettingsUpdate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "name"
+    site = Site.objects.get_current()
+    assert site.name == original_name


### PR DESCRIPTION
Backport of #19469 

Field was missing in input, there was no way to update it.

Once we have it in API, I will also add it to the dashboard

Note: There is a legacy mutation `shopDomainUpdate` which allows to edit this field, but:
1. Its deprecated for a long time and it's meant to do something else
2. Logically `name` belongs to shopSettings, both according to input shape and how frontend part works (single mutation to save global settings