### PR TITLE
fix(tests): frequent SQL timeouts during cleanups

### DIFF
--- a/saleor/product/tests/fixtures/product.py
+++ b/saleor/product/tests/fixtures/product.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from django.core.files import File
-from django.db import connection
+from django.db import connection, transaction
 
 from ....attribute import AttributeInputType, AttributeType
 from ....attribute.models import Attribute, AttributeValue
@@ -1093,44 +1093,54 @@ def lots_of_products_with_variants(product_type, channel_USD):
     products_count = 10000
     slug_generator = (f"test-slug-{i}" for i in range(products_count))
 
-    for batch in chunks(range(products_count), 500):
-        batch_len = len(batch)
-        variants = []
-        product_listings = []
-        products = [
-            Product(
-                name=i,
-                slug=next(slug_generator),
-                product_type_id=product_type.pk,
-            )
-            for i in range(batch_len)
-        ]
-        for product in Product.objects.bulk_create(products):
-            product_listings.append(
-                ProductChannelListing(
-                    channel=channel_USD,
-                    product=product,
-                    visible_in_listings=True,
-                    available_for_purchase_at="2022-01-01",
-                    currency=channel_USD.currency_code,
+    # Starts a transaction in order to allow us to delete the data immediately
+    # as soon as the test case completes
+    with transaction.atomic():
+        sid = transaction.savepoint()
+
+        for batch in chunks(range(products_count), 500):
+            batch_len = len(batch)
+            variants = []
+            product_listings = []
+            products = [
+                Product(
+                    name=i,
+                    slug=next(slug_generator),
+                    product_type_id=product_type.pk,
                 )
-            )
-            for x in range(variants_per_product):
-                variant = ProductVariant(name=x, product_id=product.id)
-                variants.append(variant)
-        ProductVariant.objects.bulk_create(variants)
-        variant_listings = []
-        for variant in variants:
-            price = random.randint(1, 100)
-            variant_listings.append(
-                ProductVariantChannelListing(
-                    variant=variant,
-                    channel=channel_USD,
-                    currency=channel_USD.currency_code,
-                    price_amount=price,
-                    discounted_price_amount=price,
+                for i in range(batch_len)
+            ]
+            for product in Product.objects.bulk_create(products):
+                product_listings.append(
+                    ProductChannelListing(
+                        channel=channel_USD,
+                        product=product,
+                        visible_in_listings=True,
+                        available_for_purchase_at="2022-01-01",
+                        currency=channel_USD.currency_code,
+                    )
                 )
-            )
-        ProductVariantChannelListing.objects.bulk_create(variant_listings)
-        ProductChannelListing.objects.bulk_create(product_listings)
-    return Product.objects.all()
+                for x in range(variants_per_product):
+                    variant = ProductVariant(name=x, product_id=product.id)
+                    variants.append(variant)
+            ProductVariant.objects.bulk_create(variants)
+            variant_listings = []
+            for variant in variants:
+                price = random.randint(1, 100)
+                variant_listings.append(
+                    ProductVariantChannelListing(
+                        variant=variant,
+                        channel=channel_USD,
+                        currency=channel_USD.currency_code,
+                        price_amount=price,
+                        discounted_price_amount=price,
+                    )
+                )
+            ProductVariantChannelListing.objects.bulk_create(variant_listings)
+            ProductChannelListing.objects.bulk_create(product_listings)
+        yield Product.objects.all()
+
+        # Manually rolls back the data created by this mutation. This avoids
+        # having SQL timeouts during Django's internal test clean-ups due to
+        # having large amounts of data to process
+        transaction.savepoint_rollback(sid)


### PR DESCRIPTION
This fixes `test_mem_usage_recalculate_discounted_price_for_products_task` frequently failing due to SQL timeouts when SQL timeouts are configured (in our instance 30s), this was happening during the teardown phase of Django's test fixtures at this location: https://github.com/django/django/blob/19e24f2fa0e8e660baefad3acbaf0fb79c83ab8d/django/test/testcases.py#L1495

The issue only recently surfaced due to the test only being enabled by default since d2f8f357f79dbb5fae202f855d3402809ac9ee12 (https://github.com/saleor/saleor/pull/19431)

PostgreSQL logs (with `statement_timeout` set to 10s):

```
2026-07-14 09:36:07.242 UTC [15129] LOG:  statement: INSERT INTO "product_productchannellisting" ("published_at", "is_published", "product_id", "channel_id", "visible_in_listings", "available_for_purchase_at", "currency", "discounted_price_amount", "discounted_price_dirty") SELECT * FROM UNNEST(('[TRUNCATED --- LOTS OF DATA]}'::bool[])::boolean[]) RETURNING "product_productchannellisting"."id"
2026-07-14 09:36:07.271 UTC [15129] LOG:  statement: SELECT "product_productchannellisting"."id" AS "id", "product_productchannellisting"."product_id" AS "product_id" FROM "product_productchannellisting" WHERE "product_productchannellisting"."discounted_price_dirty" ORDER BY 1 ASC LIMIT 2000
2026-07-14 09:36:07.289 UTC [15129] LOG:  statement: RELEASE SAVEPOINT "s281473633277152_x66"
2026-07-14 09:36:07.292 UTC [15129] LOG:  statement: SELECT 1
2026-07-14 09:36:07.292 UTC [15129] LOG:  statement: SET CONSTRAINTS ALL IMMEDIATE
2026-07-14 09:36:17.296 UTC [15129] ERROR:  canceling statement due to statement timeout
2026-07-14 09:36:17.296 UTC [15129] CONTEXT:  SQL statement "SELECT 1 FROM ONLY "example"."product_productvariant" x WHERE "id" OPERATOR(pg_catalog.=) $1 FOR KEY SHARE OF x"
2026-07-14 09:36:17.296 UTC [15129] STATEMENT:  SET CONSTRAINTS ALL IMMEDIATE
```

This is resolved by cleaning-up the large dataset from database before Django's internal cleanup/teardown runs; thus preventing Django from working over very large datasets thus resolving the timeouts

This could only be preproduced locally by running the whole test module, thus meaning:

```
$ pytest -n0 --reuse-db  saleor/product/tests/test_tasks.py --durations=0 -s
```

When running only the test `test_mem_usage_recalculate_discounted_price_for_products_task`, this wouldn't occur (perhaps some Django cleanups that only run before the next test?)



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
