### PR TITLE
feat(checkout): make lines optional in checkoutCreate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,17 @@ database/cache or collide with another worktree's stack.
 - When comparing JSON payloads in tests, use `json.loads()` to compare dicts instead of comparing serialized strings with `json.dumps()`. String comparison breaks when key order changes.
 - When a test expects exactly one row, use `Model.objects.get()` instead of `.first()` followed by an `is not None` assertion. `get()` both fetches the object and asserts that exactly one exists, so drop the separate not-None check.
 - For presence/absence checks prefer `qs.exists()` over `qs.count() == 0` / `!= 0`. `exists()` is cheaper than a `COUNT`. Example: `assert checkout.lines.exists() is False`.
-- Use `@pytest.mark.parametrize` for variations of the same scenario instead of copy/pasting near-identical test bodies. Give readable `ids` for each case.
+- Use `@pytest.mark.parametrize` for variations of the same scenario instead of copy/pasting near-identical test bodies. Label each case with a leading `_case` string parameter rather than the `ids=` argument — it keeps the description next to the data and is easier to read and edit:
+  ```python
+  @pytest.mark.parametrize(
+      ("_case", "value"),
+      [
+          ("omitted", {}),
+          ("empty_list", {"lines": []}),
+      ],
+  )
+  def test_something(_case, value): ...
+  ```
 - When a mutation input is optional/nullable, test the explicit `null` value in addition to omitting the field — they are distinct inputs and can be handled differently.
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ database/cache or collide with another worktree's stack.
 - When testing graphQL cases with expected errors ALWAYS assert expected length of errors list
 - When setting up test data, extract values into variables and reuse them in assertions. Do not repeat literal values between setup and assertion — use the variable instead.
 - When comparing JSON payloads in tests, use `json.loads()` to compare dicts instead of comparing serialized strings with `json.dumps()`. String comparison breaks when key order changes.
+- When a test expects exactly one row, use `Model.objects.get()` instead of `.first()` followed by an `is not None` assertion. `get()` both fetches the object and asserts that exactly one exists, so drop the separate not-None check.
+- For presence/absence checks prefer `qs.exists()` over `qs.count() == 0` / `!= 0`. `exists()` is cheaper than a `COUNT`. Example: `assert checkout.lines.exists() is False`.
+- Use `@pytest.mark.parametrize` for variations of the same scenario instead of copy/pasting near-identical test bodies. Give readable `ids` for each case.
+- When a mutation input is optional/nullable, test the explicit `null` value in addition to omitting the field — they are distinct inputs and can be handled differently.
 
 
 # Webhooks and Events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### GraphQL API
 
 - Added `stockAvailability` and `stocks` filters to the `productVariants` query `where` input, allowing variants to be filtered by their stock status and stock quantity for a given channel - #17689 by @ayesha-waris
-- `lines` input on the `checkoutCreate` mutation is no longer required. When omitted, it defaults to an empty list, creating a checkout with no lines.
+- `lines` input on the `checkoutCreate` mutation is no longer required. When omitted, a checkout with no lines is created.
 
 ### Webhooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### GraphQL API
 
 - Added `stockAvailability` and `stocks` filters to the `productVariants` query `where` input, allowing variants to be filtered by their stock status and stock quantity for a given channel - #17689 by @ayesha-waris
+- `lines` input on the `checkoutCreate` mutation is no longer required. When omitted, it defaults to an empty list, creating a checkout with no lines.
 
 ### Webhooks
 

--- a/saleor/graphql/AGENTS.md
+++ b/saleor/graphql/AGENTS.md
@@ -33,6 +33,8 @@ def resolve_parent(root: models.Category, info):
 
 **Write exhaustive GraphQL descriptions on fields, including limits and behavior**
 
+**Do not rely on `default_value` for optional list inputs.** In the graphene version used here `default_value` is passed to the resolver as a literal, not a factory — `default_value=[]` shares one mutable list instance across all requests, and `default_value=list` passes the `list` class itself (not an empty list). Prefer `required=False` without a default and normalize the absent/`None` case in the resolver (e.g. `lines = data.pop("lines", None) or []`).
+
 # Input validation
 
 For complex input shapes prefer using Pydantic model. Ensure Pydantic errors are mapped to Django ValidationError using `pydantic_to_validation_error` from `saleor/graphql/error.py`:

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -136,9 +136,11 @@ class CheckoutCreateInput(BaseInputObjectType):
         CheckoutLineInput,
         description=(
             "A list of checkout lines, each containing information about "
-            "an item in the checkout."
+            "an item in the checkout. Defaults to an empty list, creating a "
+            "checkout with no lines."
         ),
-        required=True,
+        required=False,
+        default_value=[],
     )
     email = graphene.String(description="The customer's email address.")
     save_shipping_address = graphene.Boolean(

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -136,11 +136,10 @@ class CheckoutCreateInput(BaseInputObjectType):
         CheckoutLineInput,
         description=(
             "A list of checkout lines, each containing information about "
-            "an item in the checkout. Defaults to an empty list, creating a "
-            "checkout with no lines."
+            "an item in the checkout. When omitted, a checkout with no lines "
+            "is created."
         ),
         required=False,
-        default_value=[],
     )
     email = graphene.String(description="The customer's email address.")
     save_shipping_address = graphene.Boolean(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -626,6 +626,59 @@ def test_checkout_create(api_client, stock, graphql_address_data, channel_USD):
     assert new_checkout.shipping_address.validation_skipped is False
 
 
+def test_checkout_create_without_lines(api_client, channel_USD):
+    """Create checkout without providing lines - defaults to empty list."""
+    # given
+    variables = {
+        "checkoutInput": {
+            "channel": channel_USD.slug,
+        }
+    }
+    assert not Checkout.objects.exists()
+
+    # when
+    response = api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)["data"]["checkoutCreate"]
+    assert content["errors"] == []
+
+    new_checkout = Checkout.objects.first()
+    assert new_checkout is not None
+    assert new_checkout.lines.count() == 0
+    checkout_data = content["checkout"]
+    assert checkout_data["token"] == str(new_checkout.token)
+    assert checkout_data["lines"] == []
+    assert checkout_data["quantity"] == 0
+
+
+def test_checkout_create_with_empty_lines(api_client, channel_USD):
+    """Create checkout with an explicitly empty lines list."""
+    # given
+    variables = {
+        "checkoutInput": {
+            "channel": channel_USD.slug,
+            "lines": [],
+        }
+    }
+    assert not Checkout.objects.exists()
+
+    # when
+    response = api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)["data"]["checkoutCreate"]
+    assert content["errors"] == []
+
+    new_checkout = Checkout.objects.first()
+    assert new_checkout is not None
+    assert new_checkout.lines.count() == 0
+    checkout_data = content["checkout"]
+    assert checkout_data["token"] == str(new_checkout.token)
+    assert checkout_data["lines"] == []
+    assert checkout_data["quantity"] == 0
+
+
 def test_checkout_create_with_custom_price(
     app_api_client,
     stock,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -627,15 +627,14 @@ def test_checkout_create(api_client, stock, graphql_address_data, channel_USD):
 
 
 @pytest.mark.parametrize(
-    "lines_input",
+    ("_case", "lines_input"),
     [
-        {},
-        {"lines": []},
-        {"lines": None},
+        ("omitted", {}),
+        ("empty_list", {"lines": []}),
+        ("explicit_null", {"lines": None}),
     ],
-    ids=["omitted", "empty_list", "explicit_null"],
 )
-def test_checkout_create_without_lines(lines_input, api_client, channel_USD):
+def test_checkout_create_without_lines(_case, lines_input, api_client, channel_USD):
     """Create checkout when lines are omitted, empty, or null - no lines are created."""
     # given
     variables = {

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -627,7 +627,7 @@ def test_checkout_create(api_client, stock, graphql_address_data, channel_USD):
 
 
 def test_checkout_create_without_lines(api_client, channel_USD):
-    """Create checkout without providing lines - defaults to empty list."""
+    """Create checkout without providing lines - creates a checkout with no lines."""
     # given
     variables = {
         "checkoutInput": {
@@ -643,9 +643,8 @@ def test_checkout_create_without_lines(api_client, channel_USD):
     content = get_graphql_content(response)["data"]["checkoutCreate"]
     assert content["errors"] == []
 
-    new_checkout = Checkout.objects.first()
-    assert new_checkout is not None
-    assert new_checkout.lines.count() == 0
+    new_checkout = Checkout.objects.get()
+    assert new_checkout.lines.exists() is False
     checkout_data = content["checkout"]
     assert checkout_data["token"] == str(new_checkout.token)
     assert checkout_data["lines"] == []
@@ -670,9 +669,8 @@ def test_checkout_create_with_empty_lines(api_client, channel_USD):
     content = get_graphql_content(response)["data"]["checkoutCreate"]
     assert content["errors"] == []
 
-    new_checkout = Checkout.objects.first()
-    assert new_checkout is not None
-    assert new_checkout.lines.count() == 0
+    new_checkout = Checkout.objects.get()
+    assert new_checkout.lines.exists() is False
     checkout_data = content["checkout"]
     assert checkout_data["token"] == str(new_checkout.token)
     assert checkout_data["lines"] == []

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -626,38 +626,22 @@ def test_checkout_create(api_client, stock, graphql_address_data, channel_USD):
     assert new_checkout.shipping_address.validation_skipped is False
 
 
-def test_checkout_create_without_lines(api_client, channel_USD):
-    """Create checkout without providing lines - creates a checkout with no lines."""
+@pytest.mark.parametrize(
+    "lines_input",
+    [
+        {},
+        {"lines": []},
+        {"lines": None},
+    ],
+    ids=["omitted", "empty_list", "explicit_null"],
+)
+def test_checkout_create_without_lines(lines_input, api_client, channel_USD):
+    """Create checkout when lines are omitted, empty, or null - no lines are created."""
     # given
     variables = {
         "checkoutInput": {
             "channel": channel_USD.slug,
-        }
-    }
-    assert not Checkout.objects.exists()
-
-    # when
-    response = api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
-
-    # then
-    content = get_graphql_content(response)["data"]["checkoutCreate"]
-    assert content["errors"] == []
-
-    new_checkout = Checkout.objects.get()
-    assert new_checkout.lines.exists() is False
-    checkout_data = content["checkout"]
-    assert checkout_data["token"] == str(new_checkout.token)
-    assert checkout_data["lines"] == []
-    assert checkout_data["quantity"] == 0
-
-
-def test_checkout_create_with_empty_lines(api_client, channel_USD):
-    """Create checkout with an explicitly empty lines list."""
-    # given
-    variables = {
-        "checkoutInput": {
-            "channel": channel_USD.slug,
-            "lines": [],
+            **lines_input,
         }
     }
     assert not Checkout.objects.exists()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -30628,9 +30628,9 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   channel: String
 
   """
-  A list of checkout lines, each containing information about an item in the checkout.
+  A list of checkout lines, each containing information about an item in the checkout. Defaults to an empty list, creating a checkout with no lines.
   """
-  lines: [CheckoutLineInput!]!
+  lines: [CheckoutLineInput!] = []
 
   """The customer's email address."""
   email: String

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -30628,9 +30628,9 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   channel: String
 
   """
-  A list of checkout lines, each containing information about an item in the checkout. Defaults to an empty list, creating a checkout with no lines.
+  A list of checkout lines, each containing information about an item in the checkout. When omitted, a checkout with no lines is created.
   """
-  lines: [CheckoutLineInput!] = []
+  lines: [CheckoutLineInput!]
 
   """The customer's email address."""
   email: String


### PR DESCRIPTION
The `lines` input field on the `checkoutCreate` mutation is no longer required. When omitted, it now defaults to an empty list, allowing a checkout to be created with no lines.

Creating checkout is a valid case, so requiring passing `lines: []` into input is poor DX only