### PR TITLE
fix(release): add `--repo` flag to `gh pr create`

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -36,7 +36,7 @@
     "after:release": [
       "git push origin release-${version}",
       "npx release-it --changelog > .release_changelog.txt",
-      "gh pr create --base `cat .base_ver_release.txt` --head release-${version} --title \"Release ${version}\" --body-file '.release_changelog.txt' --label release --assignee @me",
+      "gh pr create --base `cat .base_ver_release.txt` --head release-${version} --title \"Release ${version}\" --body-file '.release_changelog.txt' --label release --assignee @me -R saleor/saleor",
       "rm .release_changelog.txt .base_ver_release.txt"
     ]
   }


### PR DESCRIPTION
This adds the missing `--repo`/`-R` flag to the `gh pr create` command which resolves the inability to create pull requests when multiple origins are configured, namely this error:

```
$ gh pr create --base 3.21 --head release-3.21.65 --title "Release 3.21.65" --body= --label release --assignee @me
X No default remote repository has been set. To learn more about the default repository, run: gh repo set-default --help

please run `gh repo set-default` to select a default remote repository.
```



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
