### PR TITLE
Attribute filters and the product CSV export no longer match values of attributes that are no longer assigned to the object's page type or product type

### DIFF
--- a/saleor/csv/tests/export/products_data/test_handle_relations_data.py
+++ b/saleor/csv/tests/export/products_data/test_handle_relations_data.py
@@ -246,6 +246,34 @@ def test_prepare_products_relations_data(
     assert result == expected_result
 
 
+def test_prepare_products_relations_data_ignores_unassigned_attribute_values(
+    product, color_attribute
+):
+    # given a product with an attribute value assigned
+    pk = product.pk
+    attribute_ids = [str(color_attribute.pk)]
+    qs = Product.objects.all()
+
+    result = prepare_products_relations_data(qs, set(), attribute_ids, [])
+
+    expected_result = add_product_attribute_data_to_expected_data(
+        {pk: {}}, product, attribute_ids, pk
+    )
+    assert expected_result[pk] != {}
+    assert result == expected_result
+
+    # given the attribute got unassigned from the product's product type,
+    # with the assigned value row left behind
+    product.product_type.product_attributes.remove(color_attribute)
+    assert product.attributevalues.filter(value__attribute=color_attribute).exists()
+
+    # when
+    result = prepare_products_relations_data(qs, set(), attribute_ids, [])
+
+    # then
+    assert result == {}
+
+
 def test_prepare_products_relations_data_only_fields(
     product_with_image, collection_list
 ):

--- a/saleor/csv/utils/products_data.py
+++ b/saleor/csv/utils/products_data.py
@@ -10,7 +10,12 @@ from django.db.models import Value as V
 from django.db.models.functions import Cast, Concat
 
 from ...attribute import AttributeInputType
-from ...attribute.models import AssignedVariantAttribute, Attribute, AttributeValue
+from ...attribute.models import (
+    AssignedVariantAttribute,
+    Attribute,
+    AttributeProduct,
+    AttributeValue,
+)
 from ...core.editorjs import editorjs_to_text
 from ...core.utils import build_absolute_uri
 from ...product.models import (
@@ -179,8 +184,13 @@ def prepare_products_relations_data(
         attr_values = AttributeValue.objects.filter(
             Exists(attributes.filter(id=OuterRef("attribute_id"))),
         )
+        attribute_assigned_to_product_type = AttributeProduct.objects.filter(
+            attribute_id=OuterRef("attributevalues__value__attribute_id"),
+            product_type_id=OuterRef("product_type_id"),
+        )
         relations_data = queryset.filter(
-            Exists(attr_values.filter(id=OuterRef("attributevalues__value_id")))
+            Exists(attr_values.filter(id=OuterRef("attributevalues__value_id"))),
+            Exists(attribute_assigned_to_product_type),
         )
         fields_for_attrs.update(attribute_fields.values())
         relations_data = relations_data.values(*fields_for_attrs)

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -4,7 +4,12 @@ import django_filters
 import graphene
 from django.db.models import Exists, OuterRef, Q, QuerySet
 
-from ...attribute.models import AssignedPageAttributeValue, Attribute, AttributeValue
+from ...attribute.models import (
+    AssignedPageAttributeValue,
+    Attribute,
+    AttributePage,
+    AttributeValue,
+)
 from ...page import models
 from ..attribute.shared_filters import (
     CONTAINS_TYPING,
@@ -74,10 +79,22 @@ def _get_assigned_page_attribute_for_attribute_value(
     attribute_values: QuerySet[AttributeValue],
     db_connection_name: str,
 ):
+    """Build an expression matching pages by assigned attribute values.
+
+    Values of attributes that are no longer assigned to the page's page type
+    are skipped, as such values are no longer exposed on the page.
+    """
+    attribute_assigned_to_page_type = AttributePage.objects.using(
+        db_connection_name
+    ).filter(
+        attribute_id=OuterRef("value__attribute_id"),
+        page_type_id=OuterRef(OuterRef("page_type_id")),
+    )
     return Q(
         Exists(
             AssignedPageAttributeValue.objects.using(db_connection_name).filter(
                 Exists(attribute_values.filter(id=OuterRef("value_id"))),
+                Exists(attribute_assigned_to_page_type),
                 page_id=OuterRef("id"),
             )
         )
@@ -619,11 +636,10 @@ def filter_pages_by_attributes(qs, value):
         atr_value_qs = AttributeValue.objects.using(qs.db).filter(
             attribute_id__in=[attr.id for attr in attr_without_values_input]
         )
-        assigned_attr_value = AssignedPageAttributeValue.objects.using(qs.db).filter(
-            Exists(atr_value_qs.filter(id=OuterRef("value_id"))),
-            page_id=OuterRef("id"),
+        attr_filter_expression = _get_assigned_page_attribute_for_attribute_value(
+            attribute_values=atr_value_qs,
+            db_connection_name=qs.db,
         )
-        attr_filter_expression = Q(Exists(assigned_attr_value))
 
     for attr_filter in value:
         attr_value = attr_filter.get("value")

--- a/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_references_variants.py
+++ b/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_references_variants.py
@@ -24,12 +24,13 @@ def test_pages_query_with_attribute_value_reference_to_product_variants(
     # given
     page_type.page_attributes.add(page_type_variant_reference_attribute)
     second_variant_reference_attribute = Attribute.objects.create(
-        slug="second-product-reference",
-        name="Product reference",
-        type=AttributeType.PRODUCT_TYPE,
+        slug="second-variant-reference",
+        name="Variant reference",
+        type=AttributeType.PAGE_TYPE,
         input_type=AttributeInputType.REFERENCE,
         entity_type=AttributeEntityType.PRODUCT_VARIANT,
     )
+    page_type.page_attributes.add(second_variant_reference_attribute)
 
     first_variant_sku = "test-variant-1"
     second_variant_sku = "test-variant-2"

--- a/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_unassigned_attribute.py
+++ b/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_unassigned_attribute.py
@@ -1,0 +1,91 @@
+import graphene
+import pytest
+
+from ......attribute.utils import associate_attribute_values_to_instance
+from .....tests.utils import get_graphql_content
+
+PAGE_UNASSIGN_ATTR_MUTATION = """
+    mutation PageAttributeUnassign($pageTypeId: ID!, $attributeIds: [ID!]!) {
+        pageAttributeUnassign(
+            pageTypeId: $pageTypeId, attributeIds: $attributeIds
+        ) {
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+QUERY_PAGES_WITH_WHERE_AND_ATTRIBUTES = """
+    query ($where: PageWhereInput) {
+        pages(first: 5, where: $where) {
+            edges {
+                node {
+                    id
+                    attributes {
+                        attribute {
+                            slug
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.parametrize("filter_by_value", [True, False])
+def test_page_not_filterable_by_attribute_after_unassign(
+    filter_by_value,
+    staff_api_client,
+    page_list,
+    page_type,
+    size_page_attribute,
+    permission_manage_page_types_and_attributes,
+):
+    # given
+    # a page type has attribute assiged and page has attribute value assigned
+    staff_api_client.user.user_permissions.add(
+        permission_manage_page_types_and_attributes
+    )
+    page_type.page_attributes.add(size_page_attribute)
+    page = page_list[0]
+    attr_value = size_page_attribute.values.first()
+    associate_attribute_values_to_instance(page, {size_page_attribute.pk: [attr_value]})
+
+    attribute_filter = {"slug": size_page_attribute.slug}
+    if filter_by_value:
+        attribute_filter["value"] = {"slug": {"eq": attr_value.slug}}
+    where_variables = {"where": {"attributes": [attribute_filter]}}
+
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE_AND_ATTRIBUTES, where_variables
+    )
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert len(pages_nodes) == 1
+
+    # unassign attribute from the page type
+    unassign_variables = {
+        "pageTypeId": graphene.Node.to_global_id("PageType", page_type.pk),
+        "attributeIds": [
+            graphene.Node.to_global_id("Attribute", size_page_attribute.pk)
+        ],
+    }
+    response = staff_api_client.post_graphql(
+        PAGE_UNASSIGN_ATTR_MUTATION, unassign_variables
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["pageAttributeUnassign"]["errors"] == []
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE_AND_ATTRIBUTES, where_variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert pages_nodes == []

--- a/saleor/graphql/product/filters/product_attributes.py
+++ b/saleor/graphql/product/filters/product_attributes.py
@@ -12,6 +12,7 @@ from ....attribute.models import (
     AssignedVariantAttribute,
     AssignedVariantAttributeValue,
     Attribute,
+    AttributeProduct,
     AttributeValue,
 )
 from ....product.models import Product, ProductVariant
@@ -199,10 +200,17 @@ def _clean_product_attributes_boolean_filter_input(
 
 def filter_products_by_attributes_values(qs, queries: T_PRODUCT_FILTER_QUERIES):
     filters = []
+    attribute_assigned_to_product_type = AttributeProduct.objects.using(qs.db).filter(
+        attribute_id=OuterRef("value__attribute_id"),
+        product_type_id=OuterRef(OuterRef("product_type_id")),
+    )
     for values in queries.values():
         assigned_product_attribute_values = AssignedProductAttributeValue.objects.using(
             qs.db
-        ).filter(value_id__in=values)
+        ).filter(
+            Exists(attribute_assigned_to_product_type),
+            value_id__in=values,
+        )
         product_attribute_filter = Q(
             Exists(assigned_product_attribute_values.filter(product_id=OuterRef("pk")))
         )
@@ -230,9 +238,16 @@ def filter_products_by_attributes_values(qs, queries: T_PRODUCT_FILTER_QUERIES):
 
 
 def filter_products_by_attributes_values_qs(qs, values_qs):
+    attribute_assigned_to_product_type = AttributeProduct.objects.using(qs.db).filter(
+        attribute_id=OuterRef("value__attribute_id"),
+        product_type_id=OuterRef(OuterRef("product_type_id")),
+    )
     assigned_product_attribute_values = AssignedProductAttributeValue.objects.using(
         qs.db
-    ).filter(value__in=values_qs)
+    ).filter(
+        Exists(attribute_assigned_to_product_type),
+        value__in=values_qs,
+    )
     product_attribute_filter = Q(
         Exists(assigned_product_attribute_values.filter(product_id=OuterRef("pk")))
     )
@@ -326,10 +341,22 @@ def _get_assigned_product_attribute_for_attribute_value(
     attribute_values: QuerySet[AttributeValue],
     db_connection_name: str,
 ):
+    """Build an expression matching products by assigned attribute values.
+
+    Values of attributes that are no longer assigned to the product's product
+    type are skipped, as such values are no longer exposed on the product.
+    """
+    attribute_assigned_to_product_type = AttributeProduct.objects.using(
+        db_connection_name
+    ).filter(
+        attribute_id=OuterRef("value__attribute_id"),
+        product_type_id=OuterRef(OuterRef("product_type_id")),
+    )
     return Q(
         Exists(
             AssignedProductAttributeValue.objects.using(db_connection_name).filter(
                 Exists(attribute_values.filter(id=OuterRef("value_id"))),
+                Exists(attribute_assigned_to_product_type),
                 product_id=OuterRef("id"),
             )
         )

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_variants.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_references_variants.py
@@ -43,6 +43,7 @@ def test_products_query_with_attribute_value_reference_to_product_variants(
         input_type=reference_attribute.input_type,
         entity_type=AttributeEntityType.PRODUCT_VARIANT,
     )
+    product_type.product_attributes.add(second_variant_reference_attribute)
 
     first_variant_sku = "test-variant-1"
     second_variant_sku = "test-variant-2"

--- a/saleor/graphql/product/tests/queries/products_filtrations/test_over_unassigned_attribute.py
+++ b/saleor/graphql/product/tests/queries/products_filtrations/test_over_unassigned_attribute.py
@@ -1,0 +1,91 @@
+import graphene
+import pytest
+
+from .....tests.utils import get_graphql_content
+
+PRODUCT_UNASSIGN_ATTR_MUTATION = """
+    mutation ProductAttributeUnassign($productTypeId: ID!, $attributeIds: [ID!]!) {
+        productAttributeUnassign(
+            productTypeId: $productTypeId, attributeIds: $attributeIds
+        ) {
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+PRODUCTS_WHERE_QUERY_WITH_ATTRIBUTES = """
+    query($where: ProductWhereInput!, $channel: String) {
+      products(first: 10, where: $where, channel: $channel) {
+        edges {
+          node {
+            id
+            attributes {
+              attribute {
+                slug
+              }
+            }
+          }
+        }
+      }
+    }
+"""
+
+
+@pytest.mark.parametrize("filter_by_value", [True, False])
+def test_product_not_filterable_by_attribute_after_unassign(
+    filter_by_value,
+    staff_api_client,
+    product_list,
+    product_type,
+    color_attribute,
+    channel_USD,
+    permission_manage_product_types_and_attributes,
+):
+    # given
+    # a product type has attribute assigned and every product in product_list
+    # has attribute value assigned by the fixture
+    staff_api_client.user.user_permissions.add(
+        permission_manage_product_types_and_attributes
+    )
+    assert product_type.product_attributes.first() == color_attribute
+    attr_value = color_attribute.values.first()
+
+    attribute_filter = {"slug": color_attribute.slug}
+    if filter_by_value:
+        attribute_filter["value"] = {"slug": {"eq": attr_value.slug}}
+    where_variables = {
+        "where": {"attributes": [attribute_filter]},
+        "channel": channel_USD.slug,
+    }
+
+    response = staff_api_client.post_graphql(
+        PRODUCTS_WHERE_QUERY_WITH_ATTRIBUTES, where_variables
+    )
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert len(products_nodes) == len(product_list)
+
+    # unassign attribute from the product type
+    unassign_variables = {
+        "productTypeId": graphene.Node.to_global_id("ProductType", product_type.pk),
+        "attributeIds": [graphene.Node.to_global_id("Attribute", color_attribute.pk)],
+    }
+    response = staff_api_client.post_graphql(
+        PRODUCT_UNASSIGN_ATTR_MUTATION, unassign_variables
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["productAttributeUnassign"]["errors"] == []
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCTS_WHERE_QUERY_WITH_ATTRIBUTES, where_variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_nodes = content["data"]["products"]["edges"]
+    assert products_nodes == []

--- a/saleor/graphql/product/tests/queries/test_product_variants_where_unassigned_attribute.py
+++ b/saleor/graphql/product/tests/queries/test_product_variants_where_unassigned_attribute.py
@@ -1,0 +1,95 @@
+import graphene
+import pytest
+
+from ....tests.utils import get_graphql_content
+
+PRODUCT_ATTRIBUTE_UNASSIGN_MUTATION = """
+    mutation ProductAttributeUnassign($productTypeId: ID!, $attributeIds: [ID!]!) {
+        productAttributeUnassign(
+            productTypeId: $productTypeId, attributeIds: $attributeIds
+        ) {
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+VARIANTS_WHERE_QUERY_WITH_ATTRIBUTES = """
+    query($where: ProductVariantWhereInput!, $channel: String) {
+      productVariants(first: 10, where: $where, channel: $channel) {
+        edges {
+          node {
+            id
+            attributes {
+              attribute {
+                slug
+              }
+            }
+          }
+        }
+      }
+    }
+"""
+
+
+@pytest.mark.parametrize("filter_by_value", [True, False])
+def test_variant_not_filterable_by_attribute_after_unassign(
+    filter_by_value,
+    staff_api_client,
+    product,
+    product_type,
+    size_attribute,
+    channel_USD,
+    permission_manage_product_types_and_attributes,
+):
+    # given
+    # a product type has variant attribute assigned and the product's variant
+    # has attribute value assigned by the fixture
+    staff_api_client.user.user_permissions.add(
+        permission_manage_product_types_and_attributes
+    )
+    assert product_type.variant_attributes.first() == size_attribute
+    variant = product.variants.first()
+    attr_value = size_attribute.values.first()
+
+    attribute_filter = {"slug": size_attribute.slug}
+    if filter_by_value:
+        attribute_filter["value"] = {"slug": {"eq": attr_value.slug}}
+    where_variables = {
+        "where": {"attributes": [attribute_filter]},
+        "channel": channel_USD.slug,
+    }
+
+    response = staff_api_client.post_graphql(
+        VARIANTS_WHERE_QUERY_WITH_ATTRIBUTES, where_variables
+    )
+    content = get_graphql_content(response)
+    variants_nodes = content["data"]["productVariants"]["edges"]
+    assert len(variants_nodes) == 1
+
+    # unassign attribute from the product type
+    unassign_variables = {
+        "productTypeId": graphene.Node.to_global_id("ProductType", product_type.pk),
+        "attributeIds": [graphene.Node.to_global_id("Attribute", size_attribute.pk)],
+    }
+    response = staff_api_client.post_graphql(
+        PRODUCT_ATTRIBUTE_UNASSIGN_MUTATION, unassign_variables
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["productAttributeUnassign"]["errors"] == []
+
+    # when
+    response = staff_api_client.post_graphql(
+        VARIANTS_WHERE_QUERY_WITH_ATTRIBUTES, where_variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    variants_nodes = content["data"]["productVariants"]["edges"]
+    assert variants_nodes == []
+    # the assigned values were physically deleted by the unassign cascade,
+    # unlike for pages and products where they are only hidden
+    assert variant.attributevalues.count() == 0


### PR DESCRIPTION
  1. `pages(where: {attributes: ...})` filter — pages still matched attribute filters through values of attributes that had been unassigned from their page type, even though those values were no longer exposed on the page itself.
  2. `products(where: {attributes: ...})` filter — same leak for products: orphaned values of attributes no longer assigned to the product's product type kept matching the modern `where` attribute filters.
  3. Deprecated `products(filter: {attributes: ...})` input — the legacy filter path shared the same unguarded value join and likewise matched products via unassigned attributes' leftover values.
  4. Product CSV export — exported files included column values for attributes no longer assigned to the product's type, resurrecting data invisible everywhere else in the API and leaking it into downstream systems.
