### PR TITLE
Release 3.23.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.23.18",
+  "version": "3.23.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.23.18",
+      "version": "3.23.19",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.23.18",
+  "version": "3.23.19",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.23.18"
+version = "3.23.19"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,7 +1,7 @@
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.23.18"
+__version__ = "3.23.19"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2506,7 +2506,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.23.18"
+version = "3.23.19"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
* Release 3.23.19 (81ae3c620f)
* Add reason for price override (#19466) (bc6b1ab3d6)
* Attribute filters (`attributes` in `where` and `filter` inputs of the `pages` and `products` queries) and the product CSV export no longer match values of attributes that are no longer assigned to the object's page type or product type. Previously, unassigning an attribute from a page type or product type left the assigned values in place — hidden on the object, but still matched by attribute filters and included in CSV exports. (#19487) (#19493) (3d4707c356)
* fix(clearorders): crash when checkout delivery is assigned (#19496) (f52436a613)
* Deprecate legacy Payments API in favor of Transactions API (#19478) (5e5ac7081a)
* Improved Gift Card APIs (#19442) (aa83dc0cac)
* app installation improvements - fetch_manifest can be retried up to two times (#19448) (#19489) (1af2505548)
* Add identifier field to AppExtension (#19393) (4c798ac38d)
* Deprecate OBSERVABILITY event type and MANAGE_OBSERVABILITY permission (#19467) (0cece53a1a)
