### PR TITLE
Release 3.22.60

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.59",
+  "version": "3.22.60",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.59",
+      "version": "3.22.60",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.59",
+  "version": "3.22.60",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.22.59"
+version = "3.22.60"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.59"
+__version__ = "3.22.60"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2543,7 +2543,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.22.59"
+version = "3.22.60"
 source = { virtual = "." }
 dependencies = [
     { name = "adyen", marker = "platform_python_implementation != 'PyPy'" },


### PR DESCRIPTION
* Release 3.22.60 (02683fec82)
* [3.22] Deprecate legacy Payments API in favor of Transactions API (#19497) (e622a5376b)
* Attribute filters (`attributes` in `where` and `filter` inputs of the `pages` and `products` queries) and the product CSV export no longer match values of attributes that are no longer assigned to the object's page type or product type. Previously, unassigning an attribute from a page type or product type left the assigned values in place — hidden on the object, but still matched by attribute filters and included in CSV exports. (#19487) (#19494) (9d3d14aacf)
