### PR TITLE
Fix products and variants with the same id overwriting each other's attribute values

### DIFF
--- a/saleor/graphql/attribute/tests/test_utils.py
+++ b/saleor/graphql/attribute/tests/test_utils.py
@@ -2634,7 +2634,7 @@ def test_has_input_modified_attribute_values_no_changes_plain_text(
             plain_text_attribute: [
                 {
                     "attribute": plain_text_attribute,
-                    "slug": f"{variant.id}_{plain_text_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{plain_text_attribute.id}",
                     "defaults": {
                         "plain_text": text_value.plain_text,
                         "name": text_value.name,
@@ -2667,7 +2667,7 @@ def test_has_input_modified_attribute_values_with_changes_plain_text(
             plain_text_attribute: [
                 {
                     "attribute": plain_text_attribute,
-                    "slug": f"{variant.id}_{plain_text_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{plain_text_attribute.id}",
                     "defaults": {
                         "plain_text": different_text,
                         "name": different_text[:200],
@@ -2699,7 +2699,7 @@ def test_has_input_modified_attribute_values_no_changes_rich_text(
             rich_text_attribute: [
                 {
                     "attribute": rich_text_attribute,
-                    "slug": f"{variant.id}_{rich_text_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{rich_text_attribute.id}",
                     "defaults": {
                         "rich_text": rich_text_value.rich_text,
                         "name": rich_text_value.name,
@@ -2734,7 +2734,7 @@ def test_has_input_modified_attribute_values_with_changes_rich_text(
             rich_text_attribute: [
                 {
                     "attribute": rich_text_attribute,
-                    "slug": f"{variant.id}_{rich_text_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{rich_text_attribute.id}",
                     "defaults": {
                         "rich_text": different_rich_text,
                         "name": "New content"[:200],
@@ -2766,7 +2766,7 @@ def test_has_input_modified_attribute_values_no_changes_numeric(
             numeric_attribute: [
                 {
                     "attribute": numeric_attribute,
-                    "slug": f"{variant.id}_{numeric_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{numeric_attribute.id}",
                     "defaults": {
                         "name": str(numeric_value.numeric),
                         "numeric": numeric_value.numeric,
@@ -2799,7 +2799,7 @@ def test_has_input_modified_attribute_values_with_changes_numeric(
             numeric_attribute: [
                 {
                     "attribute": numeric_attribute,
-                    "slug": f"{variant.id}_{numeric_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{numeric_attribute.id}",
                     "defaults": {
                         "name": str(different_numeric),
                         "numeric": different_numeric,
@@ -2829,7 +2829,7 @@ def test_has_input_modified_attribute_values_no_changes_date(variant, date_attri
             date_attribute: [
                 {
                     "attribute": date_attribute,
-                    "slug": f"{variant.id}_{date_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{date_attribute.id}",
                     "defaults": {
                         "name": str(date_value.date_time.date()),
                         "date_time": date_value.date_time,
@@ -2863,7 +2863,7 @@ def test_has_input_modified_attribute_values_with_changes_date(variant, date_att
             date_attribute: [
                 {
                     "attribute": date_attribute,
-                    "slug": f"{variant.id}_{date_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{date_attribute.id}",
                     "defaults": {
                         "name": str(different_date),
                         "date_time": different_date_time,
@@ -2895,7 +2895,7 @@ def test_has_input_modified_attribute_values_no_changes_date_time(
             date_time_attribute: [
                 {
                     "attribute": date_time_attribute,
-                    "slug": f"{variant.id}_{date_time_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{date_time_attribute.id}",
                     "defaults": {
                         "name": str(date_time_value.date_time),
                         "date_time": date_time_value.date_time,
@@ -2928,7 +2928,7 @@ def test_has_input_modified_attribute_values_with_changes_date_time(
             date_time_attribute: [
                 {
                     "attribute": date_time_attribute,
-                    "slug": f"{variant.id}_{date_time_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{date_time_attribute.id}",
                     "defaults": {
                         "name": str(different_date_time),
                         "date_time": different_date_time,
@@ -2997,7 +2997,7 @@ def test_has_input_modified_attribute_values_mixed_bulk_actions(
             plain_text_attribute: [
                 {
                     "attribute": plain_text_attribute,
-                    "slug": f"{variant.id}_{plain_text_attribute.id}",
+                    "slug": f"productvariant-{variant.id}_{plain_text_attribute.id}",
                     "defaults": {
                         "plain_text": text_value.plain_text,
                         "name": text_value.name,

--- a/saleor/graphql/attribute/utils/attribute_assignment.py
+++ b/saleor/graphql/attribute/utils/attribute_assignment.py
@@ -311,7 +311,7 @@ class AttributeAssignmentMixin:
                 <Attribute>: [
                     {
                         "attribute": <Attribute>,
-                        "slug": "instance_id_attribute_id",
+                        "slug": "<assigned value slug or model_name-instance_id_attribute_id>",
                         "defaults": {"name": "...", "plain_text": "..."}
                     }
                 ],

--- a/saleor/graphql/attribute/utils/attribute_assignment.py
+++ b/saleor/graphql/attribute/utils/attribute_assignment.py
@@ -22,6 +22,7 @@ from .shared import (
     T_ERROR_DICT,
     T_INSTANCE,
     AttrValuesInput,
+    get_assigned_attribute_values_map,
     get_assignment_model_and_fk,
 )
 from .type_handlers import (
@@ -362,7 +363,37 @@ class AttributeAssignmentMixin:
                 for action, value_data in prepared_values:
                     pre_save_bulk[action][attribute].append(value_data)
 
+        cls._use_assigned_value_slugs(instance, pre_save_bulk)
         return pre_save_bulk
+
+    @classmethod
+    def _use_assigned_value_slugs(
+        cls, instance: T_INSTANCE, pre_save_bulk: T_PRE_SAVE_BULK
+    ):
+        """Update values assigned to the instance in place under their existing slug.
+
+        Update-or-create actions match values by slug, and the handlers
+        generate the entity-aware `{model name}-{instance pk}_{attribute pk}`
+        format. Values assigned before that format was introduced (or with
+        hand-crafted slugs) would not be matched and would be replaced with
+        new rows, losing their translations and external references — so for
+        attributes with a value already assigned to the instance, match that
+        value by its existing slug instead.
+        """
+        update_or_create = pre_save_bulk.get(
+            AttributeValueBulkActionEnum.UPDATE_OR_CREATE
+        )
+        if not update_or_create:
+            return
+        assigned_values = get_assigned_attribute_values_map(
+            instance, [attribute.pk for attribute in update_or_create]
+        )
+        for attribute, values in update_or_create.items():
+            assigned_value = assigned_values.get(attribute.pk)
+            if not assigned_value:
+                continue
+            for value_data in values:
+                value_data["slug"] = assigned_value.slug
 
     @classmethod
     def save(

--- a/saleor/graphql/attribute/utils/shared.py
+++ b/saleor/graphql/attribute/utils/shared.py
@@ -101,14 +101,14 @@ def get_assignment_model_and_fk(instance: T_INSTANCE):
     )
 
 
-def _get_assigned_attribute_values_qs(instance: T_INSTANCE, attribute: "Attribute"):
+def _get_assigned_attribute_values_qs(instance: T_INSTANCE, attribute_ids: list[int]):
     """Build a queryset of values currently assigned to the given instance."""
     if isinstance(instance, product_models.ProductVariant):
         # variant has old attribute structure so need to handle it differently
         attribute_variant = Exists(
             attribute_models.AttributeVariant.objects.filter(
                 pk=OuterRef("assignment_id"),
-                attribute_id=attribute.pk,
+                attribute_id__in=attribute_ids,
             )
         )
         assigned_variant = Exists(
@@ -125,7 +125,7 @@ def _get_assigned_attribute_values_qs(instance: T_INSTANCE, attribute: "Attribut
     assigned_values = assignment_model.objects.filter(**{instance_fk: instance.pk})
     return attribute_models.AttributeValue.objects.filter(
         Exists(assigned_values.filter(value_id=OuterRef("id"))),
-        attribute_id=attribute.pk,
+        attribute_id__in=attribute_ids,
     )
 
 
@@ -134,15 +134,20 @@ def get_assigned_attribute_value_if_exists(
 ):
     """Unified method to find an existing assigned value."""
     return (
-        _get_assigned_attribute_values_qs(instance, attribute)
+        _get_assigned_attribute_values_qs(instance, [attribute.pk])
         .filter(**{lookup_field: value})
         .first()
     )
 
 
-def get_assigned_attribute_value(instance: T_INSTANCE, attribute: "Attribute"):
-    """Return the value currently assigned to the instance for the attribute."""
-    return _get_assigned_attribute_values_qs(instance, attribute).first()
+def get_assigned_attribute_values_map(
+    instance: T_INSTANCE, attribute_ids: list[int]
+) -> dict[int, attribute_models.AttributeValue]:
+    """Map attribute id to the value currently assigned to the instance."""
+    values_map: dict[int, attribute_models.AttributeValue] = {}
+    for value in _get_assigned_attribute_values_qs(instance, attribute_ids):
+        values_map.setdefault(value.attribute_id, value)
+    return values_map
 
 
 def has_input_modified_attribute_values(

--- a/saleor/graphql/attribute/utils/shared.py
+++ b/saleor/graphql/attribute/utils/shared.py
@@ -1,7 +1,7 @@
 import datetime
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, NamedTuple, cast
+from typing import TYPE_CHECKING, NamedTuple
 
 import orjson
 from django.db.models import Model
@@ -101,46 +101,48 @@ def get_assignment_model_and_fk(instance: T_INSTANCE):
     )
 
 
-def get_assigned_attribute_value_if_exists(
-    instance: T_INSTANCE, attribute: "Attribute", lookup_field: str, value
-):
-    """Unified method to find an existing assigned value."""
+def _get_assigned_attribute_values_qs(instance: T_INSTANCE, attribute: "Attribute"):
+    """Build a queryset of values currently assigned to the given instance."""
     if isinstance(instance, product_models.ProductVariant):
         # variant has old attribute structure so need to handle it differently
-        return get_variant_assigned_attribute_value_if_exists(
-            instance, attribute, lookup_field, value
+        attribute_variant = Exists(
+            attribute_models.AttributeVariant.objects.filter(
+                pk=OuterRef("assignment_id"),
+                attribute_id=attribute.pk,
+            )
         )
+        assigned_variant = Exists(
+            attribute_models.AssignedVariantAttribute.objects.filter(
+                attribute_variant
+            ).filter(
+                variant_id=instance.pk,
+                values=OuterRef("pk"),
+            )
+        )
+        return attribute_models.AttributeValue.objects.filter(assigned_variant)
 
     assignment_model, instance_fk = get_assignment_model_and_fk(instance)
     assigned_values = assignment_model.objects.filter(**{instance_fk: instance.pk})
     return attribute_models.AttributeValue.objects.filter(
         Exists(assigned_values.filter(value_id=OuterRef("id"))),
         attribute_id=attribute.pk,
-        **{lookup_field: value},
-    ).first()
+    )
 
 
-def get_variant_assigned_attribute_value_if_exists(
-    instance: T_INSTANCE, attribute: "Attribute", lookup_field: str, value: str
+def get_assigned_attribute_value_if_exists(
+    instance: T_INSTANCE, attribute: "Attribute", lookup_field: str, value
 ):
-    variant = cast(product_models.ProductVariant, instance)
-    attribute_variant = Exists(
-        attribute_models.AttributeVariant.objects.filter(
-            pk=OuterRef("assignment_id"),
-            attribute_id=attribute.pk,
-        )
+    """Unified method to find an existing assigned value."""
+    return (
+        _get_assigned_attribute_values_qs(instance, attribute)
+        .filter(**{lookup_field: value})
+        .first()
     )
-    assigned_variant = Exists(
-        attribute_models.AssignedVariantAttribute.objects.filter(
-            attribute_variant
-        ).filter(
-            variant_id=variant.pk,
-            values=OuterRef("pk"),
-        )
-    )
-    return attribute_models.AttributeValue.objects.filter(
-        assigned_variant, **{lookup_field: value}
-    ).first()
+
+
+def get_assigned_attribute_value(instance: T_INSTANCE, attribute: "Attribute"):
+    """Return the value currently assigned to the instance for the attribute."""
+    return _get_assigned_attribute_values_qs(instance, attribute).first()
 
 
 def has_input_modified_attribute_values(

--- a/saleor/graphql/attribute/utils/type_handlers.py
+++ b/saleor/graphql/attribute/utils/type_handlers.py
@@ -29,6 +29,7 @@ from .shared import (
     T_INSTANCE,
     AttrValuesForSelectableFieldInput,
     AttrValuesInput,
+    get_assigned_attribute_value,
     get_assigned_attribute_value_if_exists,
 )
 
@@ -116,7 +117,24 @@ class AttributeTypeHandler(abc.ABC):
         instance: T_INSTANCE,
         value_defaults: dict,
     ):
-        slug = slugify(unidecode(f"{instance.id}_{self.attribute.id}"))
+        """Prepare an update-or-create action for a value owned by the instance.
+
+        The value currently assigned to the instance is updated in place under
+        its existing slug. The slug of a new value must encode the entity
+        type: products, variants and pages use independent pk sequences, so
+        the bare `{pk}_{attribute pk}` slug used historically made a product
+        and a variant with the same pk share (and overwrite) a single value
+        row.
+        """
+        assigned_value = get_assigned_attribute_value(instance, self.attribute)
+        if assigned_value:
+            slug = assigned_value.slug
+        else:
+            slug = slugify(
+                unidecode(
+                    f"{instance._meta.model_name}-{instance.pk}_{self.attribute.pk}"
+                )
+            )
         value = {
             "attribute": self.attribute,
             "slug": slug,

--- a/saleor/graphql/attribute/utils/type_handlers.py
+++ b/saleor/graphql/attribute/utils/type_handlers.py
@@ -29,7 +29,6 @@ from .shared import (
     T_INSTANCE,
     AttrValuesForSelectableFieldInput,
     AttrValuesInput,
-    get_assigned_attribute_value,
     get_assigned_attribute_value_if_exists,
 )
 
@@ -119,22 +118,19 @@ class AttributeTypeHandler(abc.ABC):
     ):
         """Prepare an update-or-create action for a value owned by the instance.
 
-        The value currently assigned to the instance is updated in place under
-        its existing slug. The slug of a new value must encode the entity
-        type: products, variants and pages use independent pk sequences, so
-        the bare `{pk}_{attribute pk}` slug used historically made a product
-        and a variant with the same pk share (and overwrite) a single value
-        row.
+        The slug must encode the entity type: products, variants and pages use
+        independent pk sequences, so the bare `{pk}_{attribute pk}` slug used
+        historically made a product and a variant with the same pk share (and
+        overwrite) a single value row.
+
+        The slug is a fallback for matching new values only — a value already
+        assigned to the instance is matched by the assignment and updated in
+        place under its existing slug; see
+        `AttributeAssignmentMixin._use_assigned_value_slugs`.
         """
-        assigned_value = get_assigned_attribute_value(instance, self.attribute)
-        if assigned_value:
-            slug = assigned_value.slug
-        else:
-            slug = slugify(
-                unidecode(
-                    f"{instance._meta.model_name}-{instance.pk}_{self.attribute.pk}"
-                )
-            )
+        slug = slugify(
+            unidecode(f"{instance._meta.model_name}-{instance.pk}_{self.attribute.pk}")
+        )
         value = {
             "attribute": self.attribute,
             "slug": slug,

--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -1050,7 +1050,7 @@ def test_create_page_with_date_attribute(
                 "dateTime": None,
                 "date": str(date_value),
                 "name": str(date_value),
-                "slug": f"{new_page_pk}_{date_attribute.id}",
+                "slug": f"page-{new_page_pk}_{date_attribute.id}",
             }
         ],
     }
@@ -1116,7 +1116,7 @@ def test_create_page_with_date_time_attribute(
                 "dateTime": date_time_value.isoformat(),
                 "date": None,
                 "name": str(date_time_value),
-                "slug": f"{new_page_pk}_{date_time_attribute.id}",
+                "slug": f"page-{new_page_pk}_{date_time_attribute.id}",
             }
         ],
     }
@@ -1183,7 +1183,7 @@ def test_create_page_with_plain_text_attribute(
                 "date": None,
                 "name": text,
                 "plainText": text,
-                "slug": f"{new_page_pk}_{plain_text_attribute_page_type.id}",
+                "slug": f"page-{new_page_pk}_{plain_text_attribute_page_type.id}",
             }
         ],
     }
@@ -2023,7 +2023,7 @@ def test_page_create_mutation_with_numeric_attribue(
     assert len(attribute["values"]) == 1
     assert (
         attribute["values"][0]["slug"]
-        == f"{Page.objects.get().id}_{numeric_attribute.id}"
+        == f"page-{Page.objects.get().id}_{numeric_attribute.id}"
     )
     assert attribute["values"][0]["name"] == numeric_name
 

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -733,7 +733,7 @@ def test_update_page_with_plain_text_attribute_new_value(
         "attribute": {"slug": plain_text_attribute_page_type.slug},
         "values": [
             {
-                "slug": f"{page.pk}_{plain_text_attribute_page_type.pk}",
+                "slug": f"page-{page.pk}_{plain_text_attribute_page_type.pk}",
                 "name": text,
                 "file": None,
                 "reference": None,
@@ -910,7 +910,7 @@ def test_update_page_with_plain_text_attribute_existing_value(
         "Attribute", plain_text_attribute_page_type.pk
     )
     attribute_value = plain_text_attribute_page_type.values.first()
-    attribute_value.slug = f"{page.pk}_{plain_text_attribute_page_type.pk}"
+    attribute_value.slug = f"page-{page.pk}_{plain_text_attribute_page_type.pk}"
     attribute_value.save(update_fields=["slug"])
 
     text = attribute_value.plain_text
@@ -977,7 +977,7 @@ def test_update_page_with_required_plain_text_attribute_empty_value(
         "Attribute", plain_text_attribute_page_type.pk
     )
     attribute_value = plain_text_attribute_page_type.values.first()
-    attribute_value.slug = f"{page.pk}_{plain_text_attribute_page_type.pk}"
+    attribute_value.slug = f"page-{page.pk}_{plain_text_attribute_page_type.pk}"
     attribute_value.save(update_fields=["slug"])
 
     plain_text_attribute_page_type.value_required = True
@@ -2007,7 +2007,9 @@ def test_update_page_with_numeric_attribute(
     assert len(attributes) == 1
     assert attributes[0]["attribute"]["slug"] == numeric_attribute.slug
     assert len(attributes[0]["values"]) == 1
-    assert attributes[0]["values"][0]["slug"] == f"{page.pk}_{numeric_attribute.pk}"
+    assert (
+        attributes[0]["values"][0]["slug"] == f"page-{page.pk}_{numeric_attribute.pk}"
+    )
     assert attributes[0]["values"][0]["name"] == numeric_name
 
     assigned_attributes = data["page"]["assignedAttributes"]

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -679,7 +679,7 @@ def test_create_product_with_rich_text_attribute(
             "attribute": {"slug": "text"},
             "values": [
                 {
-                    "slug": f"{product_id}_{rich_text_attribute.id}",
+                    "slug": f"product-{product_id}_{rich_text_attribute.id}",
                     "name": (
                         "test producttest producttest producttest producttest product"
                     ),
@@ -819,7 +819,7 @@ def test_create_product_with_plain_text_attribute(
             "attribute": {"slug": plain_text_attribute.slug},
             "values": [
                 {
-                    "slug": f"{product_id}_{plain_text_attribute.id}",
+                    "slug": f"product-{product_id}_{plain_text_attribute.id}",
                     "name": text_value,
                     "reference": None,
                     "richText": None,
@@ -949,7 +949,7 @@ def test_create_product_with_date_time_attribute(
         "attribute": {"slug": "release-date-time"},
         "values": [
             {
-                "slug": f"{product_id}_{date_time_attribute.id}",
+                "slug": f"product-{product_id}_{date_time_attribute.id}",
                 "name": str(value),
                 "reference": None,
                 "richText": None,
@@ -1018,7 +1018,7 @@ def test_create_product_with_date_attribute(
         "attribute": {"slug": "release-date"},
         "values": [
             {
-                "slug": f"{product_id}_{date_attribute.id}",
+                "slug": f"product-{product_id}_{date_attribute.id}",
                 "name": str(value),
                 "reference": None,
                 "richText": None,
@@ -3249,7 +3249,7 @@ def test_create_product_with_numeric_attribute_new_attribute_value(
     values = data["product"]["attributes"][0]["values"]
     assert len(values) == 1
     assert values[0]["name"] == expected_name
-    assert values[0]["slug"] == f"{product_pk}_{numeric_attribute.id}"
+    assert values[0]["slug"] == f"product-{product_pk}_{numeric_attribute.id}"
 
     assigned_attributes = data["product"]["assignedAttributes"]
     expected_assigned_attribute = {
@@ -3312,7 +3312,7 @@ def test_create_product_with_numeric_attribute_existing_value(
     values = data["product"]["attributes"][0]["values"]
     assert len(values) == 1
     assert values[0]["name"] == existing_value.name
-    assert values[0]["slug"] == f"{product_pk}_{numeric_attribute.id}"
+    assert values[0]["slug"] == f"product-{product_pk}_{numeric_attribute.id}"
 
     numeric_attribute.refresh_from_db()
     assert numeric_attribute.values.count() == values_count + 1

--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -799,7 +799,7 @@ def test_update_product_with_numeric_attribute_value(
                 "id": ANY,
                 "name": new_value,
                 "slug": slugify(
-                    f"{product.id}_{numeric_attribute.id}", allow_unicode=True
+                    f"product-{product.id}_{numeric_attribute.id}", allow_unicode=True
                 ),
                 "reference": None,
                 "file": None,
@@ -841,7 +841,9 @@ def test_update_product_with_numeric_attribute_value_new_value_is_not_created(
 
     attribute_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
     product_type.product_attributes.add(numeric_attribute)
-    slug_value = slugify(f"{product.id}_{numeric_attribute.id}", allow_unicode=True)
+    slug_value = slugify(
+        f"product-{product.id}_{numeric_attribute.id}", allow_unicode=True
+    )
     value = AttributeValue.objects.create(
         attribute=numeric_attribute, slug=slug_value, name="20.0", numeric=20.0
     )
@@ -1155,7 +1157,7 @@ def test_update_product_with_plain_text_attribute_value(
         "values": [
             {
                 "id": ANY,
-                "slug": f"{product.id}_{plain_text_attribute.id}",
+                "slug": f"product-{product.id}_{plain_text_attribute.id}",
                 "name": text,
                 "reference": None,
                 "file": None,
@@ -1220,7 +1222,7 @@ def test_update_product_with_plain_text_attribute_value_required(
         "values": [
             {
                 "id": ANY,
-                "slug": f"{product.id}_{plain_text_attribute.id}",
+                "slug": f"product-{product.id}_{plain_text_attribute.id}",
                 "name": text,
                 "reference": None,
                 "file": None,
@@ -2897,7 +2899,7 @@ def test_update_product_with_numeric_attribute_value_by_numeric_field(
                 "id": ANY,
                 "name": new_value,
                 "slug": slugify(
-                    f"{product.id}_{numeric_attribute.id}", allow_unicode=True
+                    f"product-{product.id}_{numeric_attribute.id}", allow_unicode=True
                 ),
                 "reference": None,
                 "file": None,
@@ -2936,7 +2938,9 @@ def test_update_product_with_numeric_attribute_by_numeric_field_null_value(
 
     attribute_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
     product_type.product_attributes.add(numeric_attribute)
-    slug_value = slugify(f"{product.id}_{numeric_attribute.id}", allow_unicode=True)
+    slug_value = slugify(
+        f"product-{product.id}_{numeric_attribute.id}", allow_unicode=True
+    )
     value = AttributeValue.objects.create(
         attribute=numeric_attribute, slug=slug_value, name="20.0", numeric=20.0
     )
@@ -2980,7 +2984,9 @@ def test_update_product_with_numeric_attribute_by_numeric_field_new_value_not_cr
 
     attribute_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
     product_type.product_attributes.add(numeric_attribute)
-    slug_value = slugify(f"{product.id}_{numeric_attribute.id}", allow_unicode=True)
+    slug_value = slugify(
+        f"product-{product.id}_{numeric_attribute.id}", allow_unicode=True
+    )
     value = AttributeValue.objects.create(
         attribute=numeric_attribute, slug=slug_value, name="20.0", numeric=20.0
     )

--- a/saleor/graphql/product/tests/mutations/test_product_variant_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_create.py
@@ -1865,7 +1865,7 @@ def test_create_variant_with_numeric_attribute(
     assert data["attributes"][0]["attribute"]["slug"] == variant_slug
     assert (
         data["attributes"][0]["values"][0]["slug"]
-        == f"{variant_pk}_{numeric_attribute.pk}"
+        == f"productvariant-{variant_pk}_{numeric_attribute.pk}"
     )
 
     assigned_attributes = data["assignedAttributes"]
@@ -2439,7 +2439,7 @@ def test_create_variant_with_date_attribute(
                 "dateTime": None,
                 "date": str(date_value),
                 "name": str(date_value),
-                "slug": f"{variant.id}_{date_attribute.id}",
+                "slug": f"productvariant-{variant.id}_{date_attribute.id}",
             }
         ],
     }
@@ -2509,7 +2509,7 @@ def test_create_variant_with_date_time_attribute(
                 "dateTime": date_time_value.isoformat(),
                 "date": None,
                 "name": str(date_time_value),
-                "slug": f"{variant.id}_{date_time_attribute.id}",
+                "slug": f"productvariant-{variant.id}_{date_time_attribute.id}",
             }
         ],
     }

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -13,6 +13,7 @@ from .....attribute import AttributeInputType
 from .....attribute.models import AttributeValue
 from .....attribute.utils import associate_attribute_values_to_instance
 from .....product.error_codes import ProductErrorCode
+from .....product.models import Product, ProductVariant
 from ....core.utils import snake_to_camel_case
 from ....tests.utils import get_graphql_content
 from ...mutations.product_variant.product_variant_create import ProductVariantInput
@@ -1377,7 +1378,9 @@ def test_update_variant_with_rich_text_attribute(
             {"id": attr_id, "richText": json.dumps(rich_text, sort_keys=True)},
         ],
     }
-    rich_text_attribute_value.slug = f"{variant.id}_{rich_text_attribute.id}"
+    rich_text_attribute_value.slug = (
+        f"productvariant-{variant.id}_{rich_text_attribute.id}"
+    )
     rich_text_attribute_value.save()
     values_count = rich_text_attribute.values.count()
     associate_attribute_values_to_instance(
@@ -1435,7 +1438,9 @@ def test_update_variant_with_plain_text_attribute(
             {"id": attr_id, "plainText": text},
         ],
     }
-    plain_text_attribute_value.slug = f"{variant.id}_{plain_text_attribute.id}"
+    plain_text_attribute_value.slug = (
+        f"productvariant-{variant.id}_{plain_text_attribute.id}"
+    )
     plain_text_attribute_value.save()
     values_count = plain_text_attribute.values.count()
     associate_attribute_values_to_instance(
@@ -1494,7 +1499,9 @@ def test_update_variant_with_plain_text_attribute_value_required(
             {"id": attr_id, "plainText": text},
         ],
     }
-    plain_text_attribute_value.slug = f"{variant.id}_{plain_text_attribute.id}"
+    plain_text_attribute_value.slug = (
+        f"productvariant-{variant.id}_{plain_text_attribute.id}"
+    )
     plain_text_attribute_value.save()
 
     plain_text_attribute.value_required = True
@@ -1549,7 +1556,9 @@ def test_update_variant_with_required_plain_text_attribute_no_value(
     attr_id = graphene.Node.to_global_id("Attribute", plain_text_attribute.id)
 
     plain_text_attribute_value = plain_text_attribute.values.first()
-    plain_text_attribute_value.slug = f"{variant.id}_{plain_text_attribute.id}"
+    plain_text_attribute_value.slug = (
+        f"productvariant-{variant.id}_{plain_text_attribute.id}"
+    )
     plain_text_attribute_value.save()
 
     associate_attribute_values_to_instance(
@@ -1632,7 +1641,7 @@ def test_update_variant_with_date_attribute(
                 "dateTime": None,
                 "date": str(date_value),
                 "name": str(date_value),
-                "slug": f"{variant.id}_{date_attribute.id}",
+                "slug": f"productvariant-{variant.id}_{date_attribute.id}",
             }
         ],
     }
@@ -1702,7 +1711,7 @@ def test_update_variant_with_date_time_attribute(
                 "dateTime": date_time_value.isoformat(),
                 "date": None,
                 "name": str(date_time_value),
-                "slug": f"{variant.id}_{date_time_attribute.id}",
+                "slug": f"productvariant-{variant.id}_{date_time_attribute.id}",
             }
         ],
     }
@@ -1746,7 +1755,7 @@ def test_update_variant_removes_numeric_attribute_value(
             {"id": attr_id, "values": []},
         ],
     }
-    attribute_value.slug = f"{variant.id}_{numeric_attribute.id}"
+    attribute_value.slug = f"productvariant-{variant.id}_{numeric_attribute.id}"
     attribute_value.save()
     values_count = numeric_attribute.values.count()
     associate_attribute_values_to_instance(
@@ -1834,6 +1843,348 @@ def test_update_variant_adds_numeric_attribute(
         name=numeric_name, numeric=numeric_value
     ).first()
     product_variant_updated.assert_called_once_with(product.variants.last())
+
+
+def test_update_variant_numeric_attribute_does_not_change_product_with_same_pk(
+    staff_api_client,
+    permission_manage_products,
+    numeric_attribute,
+    product_type_generator,
+    category,
+):
+    """Value slug `{instance.id}_{attribute.id}` must not collide across entity types.
+
+    A product and a variant sharing the same numeric pk must not resolve to the
+    same AttributeValue row when the same attribute is used as a product
+    attribute on one product type and as a variant attribute on another.
+    """
+    # given
+    product_type_with_product_attr = product_type_generator(
+        name="Type with product attribute",
+        slug="type-with-product-attribute",
+        has_variants=False,
+        product_attributes=[numeric_attribute],
+        variant_attributes=[],
+    )
+    product_type_with_variant_attr = product_type_generator(
+        name="Type with variant attribute",
+        slug="type-with-variant-attribute",
+        has_variants=True,
+        product_attributes=[],
+        variant_attributes=[numeric_attribute],
+    )
+
+    product = Product.objects.create(
+        name="Product with numeric attribute",
+        slug="product-with-numeric-attribute",
+        product_type=product_type_with_product_attr,
+        category=category,
+    )
+    other_product = Product.objects.create(
+        name="Unrelated product",
+        slug="unrelated-product",
+        product_type=product_type_with_variant_attr,
+        category=category,
+    )
+    # force the pk collision between the product and the variant
+    variant = ProductVariant.objects.create(
+        pk=product.pk, product=other_product, sku="colliding-variant"
+    )
+
+    product_numeric_name = "221"
+    product_numeric_value = 221.0
+    # the value uses the legacy slug format that did not encode the entity type
+    product_value = AttributeValue.objects.create(
+        attribute=numeric_attribute,
+        slug=slugify(f"{product.pk}_{numeric_attribute.pk}", allow_unicode=True),
+        name=product_numeric_name,
+        numeric=product_numeric_value,
+    )
+    associate_attribute_values_to_instance(
+        product, {numeric_attribute.pk: [product_value]}
+    )
+
+    variant_numeric_name = "999"
+    variant_numeric_value = 999.0
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    attr_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
+    variables = {
+        "id": variant_id,
+        "attributes": [
+            {"id": attr_id, "numeric": variant_numeric_name},
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_ATTRIBUTES,
+        variables,
+        permissions=[permission_manage_products],
+    )
+
+    # then
+    content = get_graphql_content(response)["data"]["productVariantUpdate"]
+    assert len(content["errors"]) == 0
+
+    assigned_attributes = content["productVariant"]["assignedAttributes"]
+    expected_assigned_attribute = {
+        "attribute": {"slug": numeric_attribute.slug},
+        "value": variant_numeric_value,
+    }
+    assert expected_assigned_attribute in assigned_attributes
+
+    # the variant got its own value row instead of hijacking the product's one
+    variant_value = variant.attributes.get().values.get()
+    assert variant_value.pk != product_value.pk
+    assert variant_value.name == variant_numeric_name
+    assert variant_value.numeric == variant_numeric_value
+
+    # the product's value is intact and still linked only to the product
+    product_value.refresh_from_db()
+    assert product_value.name == product_numeric_name
+    assert product_value.numeric == product_numeric_value
+    assert product_value.variantvalueassignment.exists() is False
+    assert product.attributevalues.get().value_id == product_value.pk
+
+
+def test_update_variant_numeric_attribute_keeps_updating_value_shared_with_product(
+    staff_api_client,
+    permission_manage_products,
+    numeric_attribute,
+    product_type_generator,
+    category,
+):
+    """Document the known limitation for values corrupted before the slug fix.
+
+    A value row that is already assigned to both a product and a variant (the
+    result of the historic `{instance.id}_{attribute.id}` slug collision) is
+    not healed automatically: updating the variant still updates the shared
+    row in place, changing the product's displayed value as well. Such rows
+    have to be split manually — see the instructions in the pull request that
+    introduced the entity-aware slug format.
+    """
+    # given
+    product_type_with_product_attr = product_type_generator(
+        name="Type with product attribute",
+        slug="type-with-product-attribute",
+        has_variants=False,
+        product_attributes=[numeric_attribute],
+        variant_attributes=[],
+    )
+    product_type_with_variant_attr = product_type_generator(
+        name="Type with variant attribute",
+        slug="type-with-variant-attribute",
+        has_variants=True,
+        product_attributes=[],
+        variant_attributes=[numeric_attribute],
+    )
+
+    product = Product.objects.create(
+        name="Product with numeric attribute",
+        slug="product-with-numeric-attribute",
+        product_type=product_type_with_product_attr,
+        category=category,
+    )
+    other_product = Product.objects.create(
+        name="Unrelated product",
+        slug="unrelated-product",
+        product_type=product_type_with_variant_attr,
+        category=category,
+    )
+    # force the pk collision between the product and the variant
+    variant = ProductVariant.objects.create(
+        pk=product.pk, product=other_product, sku="colliding-variant"
+    )
+
+    # the value was corrupted into cross-entity sharing before the slug fix:
+    # a single legacy-slug row assigned to both the product and the variant
+    shared_value = AttributeValue.objects.create(
+        attribute=numeric_attribute,
+        slug=slugify(f"{product.pk}_{numeric_attribute.pk}", allow_unicode=True),
+        name="221",
+        numeric=221.0,
+    )
+    associate_attribute_values_to_instance(
+        product, {numeric_attribute.pk: [shared_value]}
+    )
+    associate_attribute_values_to_instance(
+        variant, {numeric_attribute.pk: [shared_value]}
+    )
+    values_count = numeric_attribute.values.count()
+
+    variant_numeric_name = "999"
+    variant_numeric_value = 999.0
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    attr_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
+    variables = {
+        "id": variant_id,
+        "attributes": [
+            {"id": attr_id, "numeric": variant_numeric_name},
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_ATTRIBUTES,
+        variables,
+        permissions=[permission_manage_products],
+    )
+
+    # then
+    content = get_graphql_content(response)["data"]["productVariantUpdate"]
+    assert len(content["errors"]) == 0
+
+    # the shared row is updated in place — no new row is created
+    shared_value.refresh_from_db()
+    assert shared_value.name == variant_numeric_name
+    assert shared_value.numeric == variant_numeric_value
+    assert numeric_attribute.values.count() == values_count
+    assert variant.attributes.get().values.get() == shared_value
+
+    # the product still shares the row, so its displayed value changed too
+    assert product.attributevalues.get().value_id == shared_value.pk
+
+
+def test_deleting_shared_value_and_re_adding_separates_product_and_variant(
+    staff_api_client,
+    permission_manage_products,
+    permission_manage_product_types_and_attributes,
+    numeric_attribute,
+    product_type_generator,
+    category,
+):
+    """Verify the manual remediation flow for values corrupted before the slug fix.
+
+    Deleting the shared value row unlinks both entities at once; re-entering
+    the values afterwards gives the product and the variant separate rows that
+    can no longer affect each other.
+    """
+    # given
+    product_type_with_product_attr = product_type_generator(
+        name="Type with product attribute",
+        slug="type-with-product-attribute",
+        has_variants=False,
+        product_attributes=[numeric_attribute],
+        variant_attributes=[],
+    )
+    product_type_with_variant_attr = product_type_generator(
+        name="Type with variant attribute",
+        slug="type-with-variant-attribute",
+        has_variants=True,
+        product_attributes=[],
+        variant_attributes=[numeric_attribute],
+    )
+
+    product = Product.objects.create(
+        name="Product with numeric attribute",
+        slug="product-with-numeric-attribute",
+        product_type=product_type_with_product_attr,
+        category=category,
+    )
+    other_product = Product.objects.create(
+        name="Unrelated product",
+        slug="unrelated-product",
+        product_type=product_type_with_variant_attr,
+        category=category,
+    )
+    # force the pk collision between the product and the variant
+    variant = ProductVariant.objects.create(
+        pk=product.pk, product=other_product, sku="colliding-variant"
+    )
+
+    # the value was corrupted into cross-entity sharing before the slug fix
+    shared_value = AttributeValue.objects.create(
+        attribute=numeric_attribute,
+        slug=slugify(f"{product.pk}_{numeric_attribute.pk}", allow_unicode=True),
+        name="999",
+        numeric=999.0,
+    )
+    associate_attribute_values_to_instance(
+        product, {numeric_attribute.pk: [shared_value]}
+    )
+    associate_attribute_values_to_instance(
+        variant, {numeric_attribute.pk: [shared_value]}
+    )
+
+    attr_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    product_numeric_name = "221"
+    product_numeric_value = 221.0
+    variant_numeric_name = "999"
+    variant_numeric_value = 999.0
+
+    # when
+    # step 1: delete the shared value, unlinking both entities at once
+    delete_response = staff_api_client.post_graphql(
+        """
+        mutation AttributeValueDelete($id: ID!) {
+          attributeValueDelete(id: $id) {
+            errors {
+              field
+              message
+            }
+          }
+        }
+        """,
+        {"id": graphene.Node.to_global_id("AttributeValue", shared_value.pk)},
+        permissions=[permission_manage_product_types_and_attributes],
+    )
+
+    # step 2: re-enter the value on the product
+    product_response = staff_api_client.post_graphql(
+        """
+        mutation ProductUpdate($id: ID!, $attributes: [AttributeValueInput!]) {
+          productUpdate(id: $id, input: {attributes: $attributes}) {
+            errors {
+              field
+              message
+            }
+          }
+        }
+        """,
+        {
+            "id": product_id,
+            "attributes": [{"id": attr_id, "numeric": product_numeric_name}],
+        },
+        permissions=[permission_manage_products],
+    )
+
+    # step 3: re-enter the value on the variant
+    variant_response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_ATTRIBUTES,
+        {
+            "id": variant_id,
+            "attributes": [{"id": attr_id, "numeric": variant_numeric_name}],
+        },
+    )
+
+    # then
+    delete_content = get_graphql_content(delete_response)["data"]
+    product_content = get_graphql_content(product_response)["data"]
+    variant_content = get_graphql_content(variant_response)["data"]
+    assert len(delete_content["attributeValueDelete"]["errors"]) == 0
+    assert len(product_content["productUpdate"]["errors"]) == 0
+    assert len(variant_content["productVariantUpdate"]["errors"]) == 0
+
+    assert AttributeValue.objects.filter(pk=shared_value.pk).exists() is False
+
+    # each entity got its own value row
+    product_value = numeric_attribute.values.get(
+        slug=f"product-{product.pk}_{numeric_attribute.pk}"
+    )
+    variant_value = numeric_attribute.values.get(
+        slug=f"productvariant-{variant.pk}_{numeric_attribute.pk}"
+    )
+    assert product_value.pk != variant_value.pk
+    assert product_value.name == product_numeric_name
+    assert product_value.numeric == product_numeric_value
+    assert variant_value.name == variant_numeric_name
+    assert variant_value.numeric == variant_numeric_value
+    assert product.attributevalues.get().value_id == product_value.pk
+    assert variant.attributes.get().values.get() == variant_value
+    assert product_value.variantvalueassignment.exists() is False
+    assert variant_value.productvalueassignment.exists() is False
 
 
 def test_update_product_variant_with_new_attribute(


### PR DESCRIPTION
> [!IMPORTANT]
> To be backported. 

## What this fixes

`AttributeTypeHandler._update_or_create_value` generated attribute value slugs as `{instance.pk}_{attribute.pk}` for **numeric, plain text, rich text, date, and date/time** attributes. The slug did not encode the entity type, while products, variants, and pages use independent pk sequences. When the same attribute was assigned as a *product* attribute on one product type and as a *variant* attribute on another, a product and a variant sharing the same pk resolved to the **same `AttributeValue` row**: updating the attribute on one entity silently overwrote the value displayed on the other and linked the single row to both.

From the store's perspective: attribute values changed to numbers/texts nobody entered, on entities nobody edited — the corrupting write was a legitimate edit of an unrelated entity, possibly by another person or an integration, possibly much later.

## What this changes

- **Updating an existing value:** the value currently *assigned* to the entity is found via its assignment (not by reconstructing the slug) and updated in place under its existing slug. Existing values keep their slugs, translations, and external references.
- **Creating a new value:** the slug now encodes the entity type — `product-7_5`, `productvariant-7_5`, `page-7_5` — so a collision can never form again.

No database migration is included. Nothing parses these slugs on read; they are write-path idempotency keys only.

## ⚠️ Known limitation: values corrupted before this fix are not healed automatically

A value row that is *already* linked to both a product and a variant stays shared: editing either entity still updates the shared row for both. These rows must be cleaned up manually, **after deploying this fix** (on the old code, re-entering the values recreates the shared row). Covered by `test_update_variant_numeric_attribute_keeps_updating_value_shared_with_product` (limitation) and `test_deleting_shared_value_and_re_adding_separates_product_and_variant` (the cleanup flow below).

### Step 1 — Find affected values and the entities they're linked to

Detection requires SQL (the GraphQL API has no value → assigned-entities edge). Each returned row is one value shared by a product and a variant with the same pk; the global IDs are included for the follow-up API calls:

```sql
SELECT
    av.id,
    encode(convert_to('AttributeValue:' || av.id, 'UTF8'), 'base64') AS value_global_id,
    a.slug AS attribute,
    av.name AS current_value,
    av.external_reference,
    (SELECT string_agg(t.language_code, ', ')
     FROM attribute_attributevaluetranslation t
     WHERE t.attribute_value_id = av.id) AS translation_languages,
    split_part(av.slug, '_', 1)::int AS entity_pk,
    encode(convert_to('Product:' || split_part(av.slug, '_', 1), 'UTF8'), 'base64') AS product_global_id,
    encode(convert_to('ProductVariant:' || split_part(av.slug, '_', 1), 'UTF8'), 'base64') AS variant_global_id,
    (SELECT c.slug
     FROM product_productchannellisting pcl
     JOIN channel_channel c ON c.id = pcl.channel_id
     WHERE pcl.product_id = split_part(av.slug, '_', 1)::int
     LIMIT 1) AS product_channel_slug,
    (SELECT c.slug
     FROM product_productvariant pv
     JOIN product_productchannellisting pcl ON pcl.product_id = pv.product_id
     JOIN channel_channel c ON c.id = pcl.channel_id
     WHERE pv.id = split_part(av.slug, '_', 1)::int
     LIMIT 1) AS variant_channel_slug
FROM attribute_attributevalue av
JOIN attribute_attribute a ON a.id = av.attribute_id
WHERE a.input_type IN ('numeric', 'plain-text', 'rich-text', 'date', 'date-time')
  AND av.slug ~ '^\d+_\d+$'
  AND EXISTS (
      SELECT 1 FROM attribute_assignedproductattributevalue ap
      WHERE ap.value_id = av.id
        AND av.slug = ap.product_id::text || '_' || av.attribute_id::text)
  AND EXISTS (
      SELECT 1
      FROM attribute_assignedvariantattributevalue avv
      JOIN attribute_assignedvariantattribute ava ON ava.id = avv.assignment_id
      WHERE avv.value_id = av.id
        AND av.slug = ava.variant_id::text || '_' || av.attribute_id::text);

```

If the query returns no rows, this instance is unaffected and no further action is needed.

To identify the entities human-readably, query by the global IDs from the result **using a token with the `MANAGE_PRODUCTS` permission and no `channel` argument** — with that permission, the queries return the entities regardless of channel listings and publication status:

```graphql
query {
  product(id: "<product_global_id>") { name slug }
  productVariant(id: "<variant_global_id>") { name sku product { name } }
}
```

Without `MANAGE_PRODUCTS`, the queries require a `channel` argument and only return entities published in that channel — use the `product_channel_slug` / `variant_channel_slug` columns from the SQL result. Note the two channels usually differ (the entangled product and variant are unrelated catalog objects), and a `NULL` channel column means the entity has no channel listings at all and is unreachable through any channel-scoped query — identify it with the permissioned query above, or directly in SQL (`SELECT id, name FROM product_product WHERE id = <entity_pk>;`).

### Step 2 — Delete each shared value (GraphQL)

Requires the `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permission. One call unlinks both entities (the assignments cascade on delete); this also works for `value_required` attributes.

> [!IMPORTANT]
> **Before deleting:** if the SQL result shows a non-empty `external_reference` or `translation_languages` for a row, record those values — deleting the value removes its translations and external reference, and they must be re-created (via `attributeValueTranslate` / `externalReference` input) on the new per-entity values after step 3.

```graphql
mutation {
  attributeValueDelete(id: "<value_global_id>") {
    errors { field message }
  }
}
```

Both entities will show no value for that attribute until step 3.

### Step 3 — Re-enter the values (Dashboard)

For each pair from step 1, open the **product** and the **variant** in the Dashboard and enter the correct attribute value on each. Each save now creates an independent value row, so the entities can no longer affect each other.

Note: the pre-corruption values are unrecoverable (the shared row held whichever entity wrote last), so the correct values must come from your source of truth (ERP/PIM or staff knowledge).

