### PR TITLE
Remove deprecated ProductType.isDigital GraphQL surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Removed the deprecated `availableShippingMethods` field from the `Order` type. Use `shippingMethods` instead.
 - Removed the deprecated `variant` field from the `Product` type. Use the top-level `variant` query instead.
 - Removed the deprecated `note` field from the `Checkout` type. Use `customerNote` instead.
-- Removed the deprecated `isDigital` field from the `ProductType` type, the `isDigital` input from `ProductTypeInput`, and the `DIGITAL` value from the `ProductTypeEnum` filter. These had no effect; use metadata or attributes instead.
+- Removed the deprecated `isDigital` field from the `ProductType` type, the `isDigital` input from `ProductTypeInput`, the `DIGITAL` value from the `ProductTypeEnum` filter, and the `DIGITAL` value from `ProductTypeSortField`. These had no effect; use metadata or attributes instead (or `SHIPPING_REQUIRED` for sorting).
 
 ### Webhooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Removed the deprecated `availableShippingMethods` field from the `Order` type. Use `shippingMethods` instead.
 - Removed the deprecated `variant` field from the `Product` type. Use the top-level `variant` query instead.
 - Removed the deprecated `note` field from the `Checkout` type. Use `customerNote` instead.
+- Removed the deprecated `isDigital` field from the `ProductType` type, the `isDigital` input from `ProductTypeInput`, and the `DIGITAL` value from the `ProductTypeEnum` filter. These had no effect; use metadata or attributes instead.
 
 ### Webhooks
 

--- a/saleor/graphql/product/enums.py
+++ b/saleor/graphql/product/enums.py
@@ -49,23 +49,10 @@ class ProductTypeConfigurable(BaseEnum):
 
 
 class ProductTypeEnum(BaseEnum):
-    DIGITAL = "digital"
     SHIPPABLE = "shippable"
 
     class Meta:
         doc_category = DOC_CATEGORY_PRODUCTS
-
-    @property
-    def deprecation_reason(self):
-        deprecations = {
-            ProductTypeEnum.DIGITAL.name: (  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
-                "DIGITAL will removed in Saleor 3.24.0, use metadata or "
-                "attributes instead."
-            )
-        }
-        if self.name in deprecations:
-            return deprecations[self.name]
-        return None
 
 
 class VariantAttributeScope(BaseEnum):

--- a/saleor/graphql/product/filters/product_type.py
+++ b/saleor/graphql/product/filters/product_type.py
@@ -30,9 +30,7 @@ def filter_product_type_configurable(qs, _, value):
 
 
 def filter_product_type(qs, _, value):
-    if value == ProductTypeEnum.DIGITAL:
-        qs = qs.filter(is_digital=True)
-    elif value == ProductTypeEnum.SHIPPABLE:
+    if value == ProductTypeEnum.SHIPPABLE:
         qs = qs.filter(is_shipping_required=True)
     return qs
 

--- a/saleor/graphql/product/mutations/product_type/product_type_create.py
+++ b/saleor/graphql/product/mutations/product_type/product_type_create.py
@@ -48,16 +48,6 @@ class ProductTypeInput(BaseInputObjectType):
     is_shipping_required = graphene.Boolean(
         description="Determines if shipping is required for products of this variant."
     )
-    is_digital = graphene.Boolean(
-        description=(
-            "Determines if products are digital - doesn't have any effect, "
-            "it's present for backward-compatibility."
-        ),
-        deprecation_reason=(
-            "Will be removed in v3.24.0, use metadata or attributes instead."
-        ),
-        required=False,
-    )
     weight = WeightScalar(description="Weight of the ProductType items.")
     tax_code = graphene.String(
         description=(

--- a/saleor/graphql/product/sorters.py
+++ b/saleor/graphql/product/sorters.py
@@ -328,7 +328,6 @@ class ProductVariantSortingInput(SortInputObjectType):
 
 class ProductTypeSortField(BaseEnum):
     NAME = ["name", "slug"]
-    DIGITAL = ["is_digital", "name", "slug"]
     SHIPPING_REQUIRED = ["is_shipping_required", "name", "slug"]
 
     class Meta:
@@ -339,23 +338,11 @@ class ProductTypeSortField(BaseEnum):
         # pylint: disable=no-member
         descriptions = {
             ProductTypeSortField.NAME.name: "name",  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
-            ProductTypeSortField.DIGITAL.name: "type",  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
             ProductTypeSortField.SHIPPING_REQUIRED.name: "shipping",  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
         }
         if self.name in descriptions:
             return f"Sort products by {descriptions[self.name]}."
         raise ValueError(f"Unsupported enum value: {self.value}")
-
-    @property
-    def deprecation_reason(self):
-        deprecations = {
-            ProductTypeSortField.DIGITAL.name: (  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
-                "DIGITAL will removed in Saleor 3.24.0. Use SHIPPING_REQUIRED instead."
-            ),
-        }
-        if self.name in deprecations:
-            return deprecations[self.name]
-        return None
 
 
 class ProductTypeSortingInput(SortInputObjectType):

--- a/saleor/graphql/product/tests/queries/test_product_types_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_types_query.py
@@ -39,7 +39,6 @@ def test_product_types(user_api_client, product_type, channel_USD):
     [
         ({"configurable": "CONFIGURABLE"}, 2),  # has_variants
         ({"configurable": "SIMPLE"}, 1),  # !has_variants
-        ({"productType": "DIGITAL"}, 1),
         ({"productType": "SHIPPABLE"}, 2),  # is_shipping_required
         ({"kind": "NORMAL"}, 2),
         ({"kind": "GIFT_CARD"}, 1),

--- a/saleor/graphql/product/tests/queries/test_product_types_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_types_query.py
@@ -117,15 +117,6 @@ QUERY_PRODUCT_TYPES_WITH_SORT = """
     [
         ({"field": "NAME", "direction": "ASC"}, ["Digital", "Subscription", "Tools"]),
         ({"field": "NAME", "direction": "DESC"}, ["Tools", "Subscription", "Digital"]),
-        # is_digital
-        (
-            {"field": "DIGITAL", "direction": "ASC"},
-            ["Subscription", "Tools", "Digital"],
-        ),
-        (
-            {"field": "DIGITAL", "direction": "DESC"},
-            ["Digital", "Tools", "Subscription"],
-        ),
         # is_shipping_required
         (
             {"field": "SHIPPING_REQUIRED", "direction": "ASC"},

--- a/saleor/graphql/product/tests/test_product_pagination.py
+++ b/saleor/graphql/product/tests/test_product_pagination.py
@@ -961,10 +961,6 @@ def test_product_types_pagination_with_sorting(
         ),
         ({"search": "ProductType1"}, ["ProductType1", "ProductTypeProductType1"]),
         ({"search": "pt_pt"}, ["ProductTypeProductType1", "ProductTypeProductType2"]),
-        (
-            {"productType": "DIGITAL"},
-            ["ProductType1", "ProductType3"],
-        ),
         ({"productType": "SHIPPABLE"}, ["ProductType2", "ProductTypeProductType2"]),
         ({"configurable": "CONFIGURABLE"}, ["ProductType1", "ProductTypeProductType1"]),
         ({"configurable": "SIMPLE"}, ["ProductType2", "ProductType3"]),

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -1736,16 +1736,6 @@ class ProductType(ModelObjectType[models.ProductType]):
     is_shipping_required = graphene.Boolean(
         required=True, description="Whether shipping is required for this product type."
     )
-    is_digital = graphene.Boolean(
-        required=True,
-        description=(
-            "Whether the product type is digital - doesn't have any effect, "
-            "it's present for backward-compatibility."
-        ),
-        deprecation_reason=(
-            "Will be removed in v3.24.0, use metadata or attributes instead."
-        ),
-    )
     weight = graphene.Field(Weight, description="Weight of the product type.")
     kind = ProductTypeKindEnum(description="The product type kind.", required=True)
     products = ConnectionField(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7277,11 +7277,6 @@ type ProductType implements Node & ObjectWithMetadata @doc(category: "Products")
   """Whether shipping is required for this product type."""
   isShippingRequired: Boolean!
 
-  """
-  Whether the product type is digital - doesn't have any effect, it's present for backward-compatibility.
-  """
-  isDigital: Boolean! @deprecated(reason: "Will be removed in v3.24.0, use metadata or attributes instead.")
-
   """Weight of the product type."""
   weight: Weight
 
@@ -15446,7 +15441,6 @@ enum ProductTypeConfigurable @doc(category: "Products") {
 }
 
 enum ProductTypeEnum @doc(category: "Products") {
-  DIGITAL @deprecated(reason: "DIGITAL will removed in Saleor 3.24.0, use metadata or attributes instead.")
   SHIPPABLE
 }
 
@@ -25197,11 +25191,6 @@ input ProductTypeInput @doc(category: "Products") {
 
   """Determines if shipping is required for products of this variant."""
   isShippingRequired: Boolean
-
-  """
-  Determines if products are digital - doesn't have any effect, it's present for backward-compatibility.
-  """
-  isDigital: Boolean
 
   """Weight of the ProductType items."""
   weight: WeightScalar

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15456,9 +15456,6 @@ enum ProductTypeSortField @doc(category: "Products") {
   """Sort products by name."""
   NAME
 
-  """Sort products by type."""
-  DIGITAL @deprecated(reason: "DIGITAL will removed in Saleor 3.24.0. Use SHIPPING_REQUIRED instead.")
-
   """Sort products by shipping."""
   SHIPPING_REQUIRED
 }

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -130,8 +130,8 @@ class ProductType(ModelWithMetadata):
     kind = models.CharField(max_length=32, choices=ProductTypeKind.CHOICES)
     is_shipping_required = models.BooleanField(default=True)
 
-    # Note: has no effect, it's only kept for backward-compatibility as some users
-    #       use that field. Will be removed in Saleor v3.24.0
+    # TODO: remove this column. Has no effect and the GraphQL field/input were
+    #       removed in Saleor v3.24.0. Drop with a migration once no longer read.
     is_digital = models.BooleanField(default=False)
 
     weight = MeasurementField(

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -130,8 +130,8 @@ class ProductType(ModelWithMetadata):
     kind = models.CharField(max_length=32, choices=ProductTypeKind.CHOICES)
     is_shipping_required = models.BooleanField(default=True)
 
-    # TODO: remove this column. Has no effect and the GraphQL field/input were
-    #       removed in Saleor v3.24.0. Drop with a migration once no longer read.
+    # TODO: remove this column with a migration. Has no effect and the whole
+    #       GraphQL surface (field, input, filter, sort) was removed in v3.24.0.
     is_digital = models.BooleanField(default=False)
 
     weight = MeasurementField(

--- a/saleor/tests/e2e/checkout/test_buy_gift_card_in_the_checkout.py
+++ b/saleor/tests/e2e/checkout/test_buy_gift_card_in_the_checkout.py
@@ -30,7 +30,6 @@ def prepare_product_gift_card(
         product_type_name="Gift card product type",
         slug="gc-type",
         is_shipping_required=False,
-        is_digital=True,
         kind="GIFT_CARD",
     )
     assert product_type_data["kind"] == "GIFT_CARD"

--- a/saleor/tests/e2e/product/utils/product_type.py
+++ b/saleor/tests/e2e/product/utils/product_type.py
@@ -14,7 +14,6 @@ mutation createProductType($input: ProductTypeInput!) {
       slug
       kind
       isShippingRequired
-      isDigital
       hasVariants
       productAttributes {
         id
@@ -36,7 +35,6 @@ def create_product_type(
     product_type_name="Test type",
     slug="test-type",
     is_shipping_required=True,
-    is_digital=False,
     has_variants=False,
     product_attributes=None,
     variant_attributes=None,
@@ -53,7 +51,6 @@ def create_product_type(
             "name": product_type_name,
             "slug": slug,
             "isShippingRequired": is_shipping_required,
-            "isDigital": is_digital,
             "hasVariants": has_variants,
             "productAttributes": product_attributes,
             "variantAttributes": variant_attributes,
@@ -71,6 +68,5 @@ def create_product_type(
     assert data["name"] == product_type_name
     assert data["slug"] == slug
     assert data["isShippingRequired"] is is_shipping_required
-    assert data["isDigital"] is is_digital
 
     return data

--- a/saleor/tests/e2e/product/utils/product_type_update.py
+++ b/saleor/tests/e2e/product/utils/product_type_update.py
@@ -14,7 +14,6 @@ mutation ProductTypeUpdate($id: ID!, $input: ProductTypeInput!) {
       slug
       kind
       isShippingRequired
-      isDigital
       hasVariants
       productAttributes {
         id


### PR DESCRIPTION
The `isDigital` field/input had no effect and was marked for removal in v3.24.0. Remove the deprecated API surface:

- `ProductType.isDigital` output field
- `ProductTypeInput.isDigital` mutation input
- `DIGITAL` value from `ProductTypeEnum` (product type filter), which was the last GraphQL reader of the `is_digital` column

Part of ENG-1375
