### PR TITLE
Add the Customer Type CRUD API with webhook events

### DIFF
--- a/saleor/account/error_codes.py
+++ b/saleor/account/error_codes.py
@@ -53,6 +53,30 @@ class CustomerBulkUpdateErrorCode(Enum):
     MAX_LENGTH = "max_length"
 
 
+class CustomerTypeCreateErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    INVALID = "invalid"
+    NOT_FOUND = "not_found"
+    REQUIRED = "required"
+    UNIQUE = "unique"
+
+
+class CustomerTypeUpdateErrorCode(Enum):
+    CANNOT_UNSET_DEFAULT = "cannot_unset_default"
+    GRAPHQL_ERROR = "graphql_error"
+    INVALID = "invalid"
+    NOT_FOUND = "not_found"
+    REQUIRED = "required"
+    UNIQUE = "unique"
+
+
+class CustomerTypeDeleteErrorCode(Enum):
+    CANNOT_DELETE_DEFAULT = "cannot_delete_default"
+    GRAPHQL_ERROR = "graphql_error"
+    INVALID = "invalid"
+    NOT_FOUND = "not_found"
+
+
 class PermissionGroupErrorCode(Enum):
     REQUIRED = "required"
     UNIQUE = "unique"

--- a/saleor/account/lock_objects.py
+++ b/saleor/account/lock_objects.py
@@ -1,5 +1,9 @@
-from .models import User
+from .models import CustomerType, User
 
 
 def user_qs_select_for_update():
     return User.objects.order_by("pk").select_for_update(of=("self",))
+
+
+def customer_type_qs_select_for_update():
+    return CustomerType.objects.order_by("pk").select_for_update(of=("self",))

--- a/saleor/account/migrations/tasks/saleor3_23.py
+++ b/saleor/account/migrations/tasks/saleor3_23.py
@@ -70,7 +70,7 @@ ASSIGN_DEFAULT_CUSTOMER_TYPE_BATCH_SIZE = 100
 def assign_default_customer_type_to_users_task():
     """Assign the default customer type to users that don't have any type yet."""
 
-    default_customer_type = get_default_customer_type(allow_replica=False)
+    default_customer_type = get_default_customer_type()
 
     with transaction.atomic():
         batch_pks = list(

--- a/saleor/account/utils.py
+++ b/saleor/account/utils.py
@@ -56,16 +56,13 @@ class RequestorAwareContext:
         }
 
 
-def get_default_customer_type(allow_replica: bool = True) -> CustomerType:
+def get_default_customer_type(
+    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+) -> CustomerType:
     """Return the default customer type.
 
     :raises NoDefaultCustomerType: When the default customer type is missing.
     """
-    if allow_replica:
-        database_connection_name = settings.DATABASE_CONNECTION_REPLICA_NAME
-    else:
-        database_connection_name = settings.DATABASE_CONNECTION_DEFAULT_NAME
-
     customer_type = (
         CustomerType.objects.using(database_connection_name)
         .filter(is_default=True)

--- a/saleor/graphql/account/dataloaders.py
+++ b/saleor/graphql/account/dataloaders.py
@@ -2,7 +2,9 @@ from collections import defaultdict
 from collections.abc import Iterable
 from typing import TypeVar, cast
 
-from ...account.models import Address, CustomerEvent, Group, User
+from ...account.exceptions import NoDefaultCustomerType
+from ...account.models import Address, CustomerEvent, CustomerType, Group, User
+from ...account.utils import get_default_customer_type
 from ...channel.models import Channel
 from ...permission.models import Permission
 from ...thumbnail.models import Thumbnail
@@ -24,6 +26,32 @@ class UserByUserIdLoader(DataLoader[str, User]):
     def batch_load(self, keys):
         user_map = User.objects.using(self.database_connection_name).in_bulk(keys)
         return [user_map.get(user_id) for user_id in keys]
+
+
+class CustomerTypeByIdLoader(DataLoader[int, CustomerType]):
+    context_key = "customer_type_by_id"
+
+    def batch_load(self, keys):
+        customer_type_map = CustomerType.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys)
+        return [customer_type_map.get(customer_type_id) for customer_type_id in keys]
+
+
+DEFAULT_CUSTOMER_TYPE_LOADER_KEY = "default"
+
+
+class DefaultCustomerTypeLoader(DataLoader[str, CustomerType]):
+    context_key = "default_customer_type"
+
+    def batch_load(self, keys):
+        try:
+            default_customer_type = get_default_customer_type(
+                database_connection_name=self.database_connection_name
+            )
+        except NoDefaultCustomerType:
+            default_customer_type = None
+        return [default_customer_type for _ in keys]
 
 
 class CustomerEventsByUserLoader(DataLoader[str, list[CustomerEvent]]):

--- a/saleor/graphql/account/filters.py
+++ b/saleor/graphql/account/filters.py
@@ -1,5 +1,5 @@
 import django_filters
-from django.db.models import Count, Exists, OuterRef
+from django.db.models import Count, Exists, OuterRef, Q
 
 from ...account.models import Address, User
 from ...core.search import prefix_search
@@ -109,6 +109,50 @@ class CustomerFilter(MetadataFilterBase):
             "placed_orders",
             "search",
         ]
+
+
+def filter_customer_type_search(qs, _, value):
+    if not value:
+        return qs
+    return qs.filter(Q(name__trigram_similar=value) | Q(slug__trigram_similar=value))
+
+
+class CustomerTypeWhere(MetadataWhereBase):
+    ids = GlobalIDMultipleChoiceWhereFilter(method=filter_by_ids("CustomerType"))
+    name = ObjectTypeWhereFilter(
+        input_class=StringFilterInput,
+        method="filter_name",
+        help_text="Filter by customer type name.",
+    )
+    slug = ObjectTypeWhereFilter(
+        input_class=StringFilterInput,
+        method="filter_slug",
+        help_text="Filter by customer type slug.",
+    )
+    is_default = BooleanWhereFilter(
+        method="filter_is_default",
+        help_text="Filter by whether the customer type is the default one.",
+    )
+
+    @staticmethod
+    def filter_name(qs, _, value):
+        return filter_where_by_value_field(qs, "name", value)
+
+    @staticmethod
+    def filter_slug(qs, _, value):
+        return filter_where_by_value_field(qs, "slug", value)
+
+    @staticmethod
+    def filter_is_default(qs, _, value):
+        if value is None:
+            return qs.none()
+        return qs.filter(is_default=value)
+
+
+class CustomerTypeWhereInput(WhereInputObjectType):
+    class Meta:
+        doc_category = DOC_CATEGORY_USERS
+        filterset_class = CustomerTypeWhere
 
 
 class CountryCodeEnumFilterInput(BaseInputObjectType):

--- a/saleor/graphql/account/mutations/account/account_register.py
+++ b/saleor/graphql/account/mutations/account/account_register.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError, transaction
 from .....account import models
 from .....account.error_codes import AccountErrorCode
 from .....account.tasks import finish_creating_user
-from .....account.utils import RequestorAwareContext
+from .....account.utils import RequestorAwareContext, get_default_customer_type
 from .....core.utils.url import validate_storefront_url
 from .....webhook.event_types import WebhookEventAsyncType
 from ....channel.utils import clean_channel
@@ -237,6 +237,7 @@ class AccountRegister(DeprecatedModelMutation):
             cleaned_input["password"]
         )
         instance.is_confirmed = False
+        instance.customer_type = get_default_customer_type()
 
         user_created = False
         if not user_exists:

--- a/saleor/graphql/account/mutations/customer_type/__init__.py
+++ b/saleor/graphql/account/mutations/customer_type/__init__.py
@@ -1,0 +1,9 @@
+from .customer_type_create import CustomerTypeCreate
+from .customer_type_delete import CustomerTypeDelete
+from .customer_type_update import CustomerTypeUpdate
+
+__all__ = [
+    "CustomerTypeCreate",
+    "CustomerTypeDelete",
+    "CustomerTypeUpdate",
+]

--- a/saleor/graphql/account/mutations/customer_type/customer_type_create.py
+++ b/saleor/graphql/account/mutations/customer_type/customer_type_create.py
@@ -1,0 +1,114 @@
+from collections import defaultdict
+
+import graphene
+from django.core.exceptions import ValidationError
+
+from .....account import models
+from .....account.lock_objects import customer_type_qs_select_for_update
+from .....core.tracing import traced_atomic_transaction
+from .....permission.enums import CustomerTypePermissions
+from .....webhook.event_types import WebhookEventAsyncType
+from ....core import ResolveInfo
+from ....core.descriptions import ADDED_IN_323
+from ....core.doc_category import DOC_CATEGORY_USERS
+from ....core.enums import CustomerTypeCreateErrorCode
+from ....core.mutations import DeprecatedModelMutation
+from ....core.types import BaseInputObjectType, Error
+from ....core.utils import WebhookEventInfo
+from ....core.validators import validate_slug_and_generate_if_needed
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import CustomerType
+
+
+class CustomerTypeCreateError(Error):
+    code = CustomerTypeCreateErrorCode(description="The error code.", required=True)
+
+    class Meta:
+        doc_category = DOC_CATEGORY_USERS
+
+
+class CustomerTypeCreateInput(BaseInputObjectType):
+    name = graphene.String(description="Name of the customer type.")
+    slug = graphene.String(
+        description=(
+            "Slug of the customer type. If not provided, it will be generated "
+            "from the name."
+        )
+    )
+    is_default = graphene.Boolean(
+        description=(
+            "Determines if the customer type should become the default one, "
+            "assigned to every newly created user. Passing `true` clears the "
+            "flag on the current default customer type - exactly one default "
+            "customer type always exists."
+        )
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_USERS
+
+
+class CustomerTypeDefaultTransferMixin:
+    """Atomically transfer the default flag when `isDefault: true` is passed.
+
+    The whole mutation runs in a transaction that locks customer type rows and
+    clears the current default before the instance is validated and saved, so
+    the partial unique constraint on `is_default` is never violated.
+    """
+
+    @classmethod
+    def perform_mutation(cls, root, info: ResolveInfo, /, **data):
+        input_data = data.get("input") or {}
+        if not input_data.get("is_default"):
+            return super().perform_mutation(root, info, **data)  # type: ignore[misc]
+        with traced_atomic_transaction():
+            locked_pks = list(
+                customer_type_qs_select_for_update().values_list("pk", flat=True)
+            )
+            models.CustomerType.objects.filter(
+                pk__in=locked_pks, is_default=True
+            ).update(is_default=False)
+            return super().perform_mutation(root, info, **data)  # type: ignore[misc]
+
+
+class CustomerTypeCreate(CustomerTypeDefaultTransferMixin, DeprecatedModelMutation):
+    class Arguments:
+        input = CustomerTypeCreateInput(
+            description="Fields required to create a customer type.", required=True
+        )
+
+    class Meta:
+        description = "Creates a new customer type." + ADDED_IN_323
+        model = models.CustomerType
+        object_type = CustomerType
+        permissions = (CustomerTypePermissions.MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES,)
+        error_type_class = CustomerTypeCreateError
+        doc_category = DOC_CATEGORY_USERS
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.CUSTOMER_TYPE_CREATED,
+                description="A new customer type was created.",
+            ),
+        ]
+
+    @classmethod
+    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+        errors = defaultdict(list)
+        try:
+            cleaned_input = validate_slug_and_generate_if_needed(
+                instance, "name", cleaned_input
+            )
+        except ValidationError as error:
+            error.code = CustomerTypeCreateErrorCode.REQUIRED.value
+            errors["slug"].append(error)
+
+        if errors:
+            raise ValidationError(errors)
+
+        return cleaned_input
+
+    @classmethod
+    def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
+        manager = get_plugin_manager_promise(info.context).get()
+        cls.call_event(manager.customer_type_created, instance)

--- a/saleor/graphql/account/mutations/customer_type/customer_type_create.py
+++ b/saleor/graphql/account/mutations/customer_type/customer_type_create.py
@@ -51,9 +51,10 @@ class CustomerTypeCreateInput(BaseInputObjectType):
 class CustomerTypeDefaultTransferMixin:
     """Atomically transfer the default flag when `isDefault: true` is passed.
 
-    The whole mutation runs in a transaction that locks customer type rows and
-    clears the current default before the instance is validated and saved, so
-    the partial unique constraint on `is_default` is never violated.
+    The whole mutation runs in a transaction that locks all customer type rows
+    to serialize concurrent default transfers, then clears the current default
+    before the instance is validated and saved, so the partial unique
+    constraint on `is_default` is never violated and the last writer wins.
     """
 
     @classmethod
@@ -62,12 +63,10 @@ class CustomerTypeDefaultTransferMixin:
         if not input_data.get("is_default"):
             return super().perform_mutation(root, info, **data)  # type: ignore[misc]
         with traced_atomic_transaction():
-            locked_pks = list(
-                customer_type_qs_select_for_update().values_list("pk", flat=True)
-            )
-            models.CustomerType.objects.filter(
-                pk__in=locked_pks, is_default=True
-            ).update(is_default=False)
+            # Evaluate the queryset to acquire the locks.
+            # Deliberately do not use the queryset for clearing the default flag.
+            list(customer_type_qs_select_for_update())
+            models.CustomerType.objects.filter(is_default=True).update(is_default=False)
             return super().perform_mutation(root, info, **data)  # type: ignore[misc]
 
 

--- a/saleor/graphql/account/mutations/customer_type/customer_type_delete.py
+++ b/saleor/graphql/account/mutations/customer_type/customer_type_delete.py
@@ -1,0 +1,81 @@
+import graphene
+from django.core.exceptions import ValidationError
+
+from .....account import models
+from .....account.utils import get_default_customer_type
+from .....core.tracing import traced_atomic_transaction
+from .....permission.enums import CustomerTypePermissions
+from .....webhook.event_types import WebhookEventAsyncType
+from ....core import ResolveInfo
+from ....core.descriptions import ADDED_IN_323
+from ....core.doc_category import DOC_CATEGORY_USERS
+from ....core.enums import CustomerTypeDeleteErrorCode
+from ....core.mutations import ModelDeleteMutation
+from ....core.types import Error
+from ....core.utils import WebhookEventInfo
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import CustomerType
+
+
+class CustomerTypeDeleteError(Error):
+    code = CustomerTypeDeleteErrorCode(description="The error code.", required=True)
+
+    class Meta:
+        doc_category = DOC_CATEGORY_USERS
+
+
+class CustomerTypeDelete(ModelDeleteMutation):
+    class Arguments:
+        id = graphene.ID(
+            description="ID of the customer type to delete.", required=True
+        )
+
+    class Meta:
+        description = (
+            "Deletes a customer type. Users of the deleted customer type are "
+            "reassigned to the default customer type." + ADDED_IN_323
+        )
+        model = models.CustomerType
+        object_type = CustomerType
+        permissions = (CustomerTypePermissions.MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES,)
+        error_type_class = CustomerTypeDeleteError
+        doc_category = DOC_CATEGORY_USERS
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.CUSTOMER_TYPE_DELETED,
+                description="A customer type was deleted.",
+            ),
+        ]
+
+    @classmethod
+    def clean_instance(cls, _info: ResolveInfo, instance, /):
+        if instance.is_default:
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        "The default customer type cannot be deleted. Mark "
+                        "another customer type as the default first.",
+                        code=CustomerTypeDeleteErrorCode.CANNOT_DELETE_DEFAULT.value,
+                    )
+                }
+            )
+
+    @classmethod
+    def perform_mutation(  # type: ignore[override]
+        cls, _root, info: ResolveInfo, /, *, id: str
+    ):
+        customer_type_pk = cls.get_global_id_or_error(
+            id, only_type=CustomerType, field="pk"
+        )
+        with traced_atomic_transaction():
+            default_customer_type = get_default_customer_type()
+            if str(default_customer_type.pk) != str(customer_type_pk):
+                models.User.objects.filter(customer_type_id=customer_type_pk).update(
+                    customer_type=default_customer_type
+                )
+            return super().perform_mutation(_root, info, id=id)
+
+    @classmethod
+    def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
+        manager = get_plugin_manager_promise(info.context).get()
+        cls.call_event(manager.customer_type_deleted, instance)

--- a/saleor/graphql/account/mutations/customer_type/customer_type_delete.py
+++ b/saleor/graphql/account/mutations/customer_type/customer_type_delete.py
@@ -2,6 +2,7 @@ import graphene
 from django.core.exceptions import ValidationError
 
 from .....account import models
+from .....account.lock_objects import customer_type_qs_select_for_update
 from .....account.utils import get_default_customer_type
 from .....core.tracing import traced_atomic_transaction
 from .....permission.enums import CustomerTypePermissions
@@ -68,8 +69,13 @@ class CustomerTypeDelete(ModelDeleteMutation):
             id, only_type=CustomerType, field="pk"
         )
         with traced_atomic_transaction():
+            # Evaluate the queryset to acquire the locks.
+            list(customer_type_qs_select_for_update())
             default_customer_type = get_default_customer_type()
             if str(default_customer_type.pk) != str(customer_type_pk):
+                # Deliberate lack of CUSTOMER_UPDATED events due to
+                # an unbounded number of users that may be affected.
+                # CUSTOMER_TYPE_DELETED event already implies the change.
                 models.User.objects.filter(customer_type_id=customer_type_pk).update(
                     customer_type=default_customer_type
                 )

--- a/saleor/graphql/account/mutations/customer_type/customer_type_update.py
+++ b/saleor/graphql/account/mutations/customer_type/customer_type_update.py
@@ -1,0 +1,89 @@
+from collections import defaultdict
+
+import graphene
+from django.core.exceptions import ValidationError
+
+from .....account import models
+from .....permission.enums import CustomerTypePermissions
+from .....webhook.event_types import WebhookEventAsyncType
+from ....core import ResolveInfo
+from ....core.descriptions import ADDED_IN_323
+from ....core.doc_category import DOC_CATEGORY_USERS
+from ....core.enums import CustomerTypeUpdateErrorCode
+from ....core.mutations import DeprecatedModelMutation
+from ....core.types import Error
+from ....core.utils import WebhookEventInfo
+from ....core.validators import validate_slug_and_generate_if_needed
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import CustomerType
+from .customer_type_create import (
+    CustomerTypeCreateInput,
+    CustomerTypeDefaultTransferMixin,
+)
+
+
+class CustomerTypeUpdateError(Error):
+    code = CustomerTypeUpdateErrorCode(description="The error code.", required=True)
+
+    class Meta:
+        doc_category = DOC_CATEGORY_USERS
+
+
+class CustomerTypeUpdateInput(CustomerTypeCreateInput):
+    class Meta:
+        doc_category = DOC_CATEGORY_USERS
+
+
+class CustomerTypeUpdate(CustomerTypeDefaultTransferMixin, DeprecatedModelMutation):
+    class Arguments:
+        id = graphene.ID(
+            description="ID of the customer type to update.", required=True
+        )
+        input = CustomerTypeUpdateInput(
+            description="Fields required to update a customer type.", required=True
+        )
+
+    class Meta:
+        description = "Updates a customer type." + ADDED_IN_323
+        model = models.CustomerType
+        object_type = CustomerType
+        permissions = (CustomerTypePermissions.MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES,)
+        error_type_class = CustomerTypeUpdateError
+        doc_category = DOC_CATEGORY_USERS
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.CUSTOMER_TYPE_UPDATED,
+                description="A customer type was updated.",
+            ),
+        ]
+
+    @classmethod
+    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+        errors = defaultdict(list)
+        try:
+            cleaned_input = validate_slug_and_generate_if_needed(
+                instance, "name", cleaned_input
+            )
+        except ValidationError as error:
+            error.code = CustomerTypeUpdateErrorCode.REQUIRED.value
+            errors["slug"].append(error)
+
+        if cleaned_input.get("is_default") is False and instance.is_default:
+            errors["is_default"].append(
+                ValidationError(
+                    "The default flag cannot be unset. Mark another customer "
+                    "type as the default instead.",
+                    code=CustomerTypeUpdateErrorCode.CANNOT_UNSET_DEFAULT.value,
+                )
+            )
+
+        if errors:
+            raise ValidationError(errors)
+
+        return cleaned_input
+
+    @classmethod
+    def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
+        manager = get_plugin_manager_promise(info.context).get()
+        cls.call_event(manager.customer_type_updated, instance)

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -7,6 +7,7 @@ from .....account import events as account_events
 from .....account import models
 from .....account.notifications import send_set_password_notification
 from .....account.search import update_user_search_vector
+from .....account.utils import get_default_customer_type
 from .....core.tokens import password_reset_token_generator
 from .....core.tracing import traced_atomic_transaction
 from .....core.utils.url import prepare_url
@@ -107,6 +108,9 @@ class CustomerCreate(BaseCustomerCreate):
         if default_billing_address := cleaned_input.get(BILLING_ADDRESS_FIELD):
             addresses_to_set_on_user.append(default_billing_address)
             default_billing_address.save()
+
+        if instance.customer_type_id is None:
+            instance.customer_type = get_default_customer_type()
 
         cls._save(instance)
 

--- a/saleor/graphql/account/mutations/staff/staff_create.py
+++ b/saleor/graphql/account/mutations/staff/staff_create.py
@@ -9,6 +9,7 @@ from .....account import models
 from .....account.error_codes import AccountErrorCode
 from .....account.notifications import send_set_password_notification
 from .....account.search import USER_SEARCH_FIELDS, update_user_search_vector
+from .....account.utils import get_default_customer_type
 from .....core.exceptions import PermissionDenied
 from .....core.tokens import password_reset_token_generator
 from .....core.tracing import traced_atomic_transaction
@@ -171,6 +172,8 @@ class StaffCreate(DeprecatedModelMutation):
     ):
         if any(field in cleaned_input for field in USER_SEARCH_FIELDS):
             update_user_search_vector(user, attach_addresses_data=False, save=False)
+        if user.customer_type_id is None:
+            user.customer_type = get_default_customer_type()
         user.save()
         redirect_url = cleaned_input.get("redirect_url")
         if redirect_url and send_notification:

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -42,6 +42,20 @@ def resolve_customers(info):
     )
 
 
+def resolve_customer_type(info, id):
+    return (
+        models.CustomerType.objects.using(get_database_connection_name(info.context))
+        .filter(id=id)
+        .first()
+    )
+
+
+def resolve_customer_types(info):
+    return models.CustomerType.objects.using(
+        get_database_connection_name(info.context)
+    ).all()
+
+
 def resolve_permission_group(info, id):
     return (
         models.Group.objects.using(get_database_connection_name(info.context))

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -2,12 +2,16 @@ import graphene
 
 from ...core.search import prefix_search
 from ...permission.auth_filters import AuthorizationFilters
-from ...permission.enums import AccountPermissions, OrderPermissions
+from ...permission.enums import (
+    AccountPermissions,
+    CustomerTypePermissions,
+    OrderPermissions,
+)
 from ...permission.utils import message_one_of_permissions_required
 from ..app.dataloaders import app_promise_callback
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.descriptions import ADDED_IN_322, DEPRECATED_IN_3X_INPUT
+from ..core.descriptions import ADDED_IN_322, ADDED_IN_323, DEPRECATED_IN_3X_INPUT
 from ..core.doc_category import DOC_CATEGORY_USERS
 from ..core.fields import BaseField, FilterConnectionField, PermissionsField
 from ..core.filters import FilterInputObjectType
@@ -25,9 +29,11 @@ from .bulk_mutations import (
 from .enums import CountryCodeEnum
 from .filters import (
     CustomerFilter,
+    CustomerTypeWhereInput,
     CustomerWhereInput,
     PermissionGroupFilter,
     StaffUserFilter,
+    filter_customer_type_search,
 )
 from .mutations.account import (
     AccountAddressCreate,
@@ -57,6 +63,11 @@ from .mutations.authentication import (
     SetPassword,
     VerifyToken,
 )
+from .mutations.customer_type import (
+    CustomerTypeCreate,
+    CustomerTypeDelete,
+    CustomerTypeUpdate,
+)
 from .mutations.permission_group import (
     PermissionGroupCreate,
     PermissionGroupDelete,
@@ -79,16 +90,25 @@ from .mutations.staff import (
 from .resolvers import (
     resolve_address,
     resolve_address_validation_rules,
+    resolve_customer_type,
+    resolve_customer_types,
     resolve_customers,
     resolve_permission_group,
     resolve_permission_groups,
     resolve_staff_users,
     resolve_user,
 )
-from .sorters import PermissionGroupSortingInput, UserSortField, UserSortingInput
+from .sorters import (
+    CustomerTypeSortingInput,
+    PermissionGroupSortingInput,
+    UserSortField,
+    UserSortingInput,
+)
 from .types import (
     Address,
     AddressValidationData,
+    CustomerType,
+    CustomerTypeCountableConnection,
     Group,
     GroupCountableConnection,
     User,
@@ -158,6 +178,36 @@ class AccountQueries(graphene.ObjectType):
         search=graphene.String(description="Search customers." + ADDED_IN_322),
         description="List of the shop's customers. This list includes all users who registered through the accountRegister mutation. Additionally, staff users who have placed an order using their account will also appear in this list.",
         permissions=[OrderPermissions.MANAGE_ORDERS, AccountPermissions.MANAGE_USERS],
+        doc_category=DOC_CATEGORY_USERS,
+    )
+    customer_type = PermissionsField(
+        CustomerType,
+        id=graphene.Argument(
+            graphene.ID, description="ID of the customer type.", required=True
+        ),
+        description="Look up a customer type by ID." + ADDED_IN_323,
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+            CustomerTypePermissions.MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES,
+            AccountPermissions.MANAGE_USERS,
+        ],
+        doc_category=DOC_CATEGORY_USERS,
+    )
+    customer_types = FilterConnectionField(
+        CustomerTypeCountableConnection,
+        where=CustomerTypeWhereInput(
+            description="Where filtering options for customer types."
+        ),
+        search=graphene.String(description="Search customer types by name or slug."),
+        sort_by=CustomerTypeSortingInput(description="Sort customer types."),
+        description="List of the customer types." + ADDED_IN_323,
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+            CustomerTypePermissions.MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES,
+            AccountPermissions.MANAGE_USERS,
+        ],
         doc_category=DOC_CATEGORY_USERS,
     )
     permission_groups = FilterConnectionField(
@@ -241,6 +291,23 @@ class AccountQueries(graphene.ObjectType):
             qs, kwargs, allow_replica=info.context.allow_replica
         )
         return create_connection_slice(qs, info, kwargs, UserCountableConnection)
+
+    @staticmethod
+    def resolve_customer_type(_root, info: ResolveInfo, *, id):
+        _, id = from_global_id_or_error(id, CustomerType)
+        return resolve_customer_type(info, id)
+
+    @staticmethod
+    def resolve_customer_types(_root, info: ResolveInfo, **kwargs):
+        qs = resolve_customer_types(info)
+        if search := kwargs.get("search"):
+            qs = filter_customer_type_search(qs, None, search)
+        qs = filter_connection_queryset(
+            qs, kwargs, allow_replica=info.context.allow_replica
+        )
+        return create_connection_slice(
+            qs, info, kwargs, CustomerTypeCountableConnection
+        )
 
     @staticmethod
     def resolve_permission_groups(_root, info: ResolveInfo, **kwargs):
@@ -327,6 +394,10 @@ class AccountMutations(graphene.ObjectType):
     customer_delete = CustomerDelete.Field()
     customer_bulk_delete = CustomerBulkDelete.Field()
     customer_bulk_update = CustomerBulkUpdate.Field()
+
+    customer_type_create = CustomerTypeCreate.Field()
+    customer_type_update = CustomerTypeUpdate.Field()
+    customer_type_delete = CustomerTypeDelete.Field()
 
     staff_create = StaffCreate.Field()
     staff_update = StaffUpdate.Field()

--- a/saleor/graphql/account/sorters.py
+++ b/saleor/graphql/account/sorters.py
@@ -35,6 +35,28 @@ class UserSortField(BaseEnum):
         return queryset.annotate(order_count=Count("orders__id"))
 
 
+class CustomerTypeSortField(BaseEnum):
+    NAME = ["name", "slug"]
+    SLUG = ["slug"]
+
+    class Meta:
+        doc_category = DOC_CATEGORY_USERS
+
+    @property
+    def description(self):
+        if self.name in CustomerTypeSortField.__enum__._member_names_:
+            sort_name = self.name.lower().replace("_", " ")
+            return f"Sort customer types by {sort_name}."
+        raise ValueError(f"Unsupported enum value: {self.value}")
+
+
+class CustomerTypeSortingInput(SortInputObjectType):
+    class Meta:
+        doc_category = DOC_CATEGORY_USERS
+        sort_enum = CustomerTypeSortField
+        type_name = "customer types"
+
+
 class UserSortingInput(SortInputObjectType):
     class Meta:
         doc_category = DOC_CATEGORY_USERS

--- a/saleor/graphql/account/tests/mutations/account/test_account_register.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_register.py
@@ -584,3 +584,28 @@ def test_validates_password_length(
         ],
         "user": None,
     }
+
+
+@override_settings(ALLOWED_CLIENT_HOSTS=["localhost"])
+def test_register_assigns_default_customer_type(
+    api_client, channel_PLN, default_customer_type
+):
+    # given
+    email = "customer-type@example.com"
+    variables = {
+        "input": {
+            "email": email,
+            "password": "Password",
+            "redirectUrl": "http://localhost:3000",
+            "channel": channel_PLN.slug,
+        }
+    }
+
+    # when
+    response = api_client.post_graphql(ACCOUNT_REGISTER_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["accountRegister"]["errors"]
+    new_user = User.objects.get(email=email)
+    assert new_user.customer_type == default_customer_type

--- a/saleor/graphql/account/tests/mutations/customer_type/test_customer_type_create.py
+++ b/saleor/graphql/account/tests/mutations/customer_type/test_customer_type_create.py
@@ -1,0 +1,183 @@
+from unittest.mock import patch
+
+from ......account.error_codes import CustomerTypeCreateErrorCode
+from ......account.models import CustomerType
+from .....tests.utils import assert_no_permission, get_graphql_content
+
+CUSTOMER_TYPE_CREATE_MUTATION = """
+    mutation CustomerTypeCreate($input: CustomerTypeCreateInput!) {
+        customerTypeCreate(input: $input) {
+            customerType {
+                id
+                name
+                slug
+                isDefault
+            }
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+
+def test_create_by_staff_with_permission(
+    staff_api_client, permission_manage_customer_types_and_attributes
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    name = "Wholesale"
+    variables = {"input": {"name": name}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeCreate"]
+    assert data["errors"] == []
+
+    customer_type = CustomerType.objects.get(slug="wholesale")
+    assert data["customerType"]["name"] == customer_type.name
+    assert data["customerType"]["slug"] == customer_type.slug
+    assert data["customerType"]["isDefault"] is False
+    assert customer_type.name == name
+    assert customer_type.is_default is False
+
+
+def test_create_with_explicit_slug(
+    staff_api_client, permission_manage_customer_types_and_attributes
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    name = "Wholesale"
+    slug = "custom-slug"
+    variables = {"input": {"name": name, "slug": slug}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeCreate"]
+    assert data["errors"] == []
+
+    customer_type = CustomerType.objects.get(slug=slug)
+    assert customer_type.name == name
+    assert data["customerType"]["slug"] == slug
+
+
+def test_create_as_default_transfers_default_flag(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    default_customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {"input": {"name": "Wholesale", "isDefault": True}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeCreate"]
+    assert data["errors"] == []
+    assert data["customerType"]["isDefault"] is True
+
+    default_customer_type.refresh_from_db()
+    assert default_customer_type.is_default is False
+
+    customer_type = CustomerType.objects.get(slug="wholesale")
+    assert customer_type.is_default is True
+    assert CustomerType.objects.filter(is_default=True).count() == 1
+
+
+def test_create_with_duplicated_slug(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {"input": {"name": "Another", "slug": customer_type.slug}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeCreate"]
+    assert data["customerType"] is None
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "slug"
+    assert error["code"] == CustomerTypeCreateErrorCode.UNIQUE.name
+
+
+def test_create_without_name(
+    staff_api_client, permission_manage_customer_types_and_attributes
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {"input": {}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeCreate"]
+    assert data["customerType"] is None
+    assert len(data["errors"]) == 2
+    errors_by_field = {error["field"]: error for error in data["errors"]}
+    assert errors_by_field.keys() == {"name", "slug"}
+    assert errors_by_field["name"]["code"] == CustomerTypeCreateErrorCode.REQUIRED.name
+    assert errors_by_field["slug"]["code"] == CustomerTypeCreateErrorCode.REQUIRED.name
+
+
+def test_create_by_staff_without_permission(staff_api_client):
+    # given
+    variables = {"input": {"name": "Wholesale"}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_CREATE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)
+    assert not CustomerType.objects.filter(slug="wholesale").exists()
+
+
+@patch("saleor.plugins.manager.PluginsManager.customer_type_created")
+def test_create_triggers_webhook(
+    mocked_customer_type_created,
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {"input": {"name": "Wholesale"}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["customerTypeCreate"]["errors"] == []
+
+    customer_type = CustomerType.objects.get(slug="wholesale")
+    mocked_customer_type_created.assert_called_once_with(customer_type)

--- a/saleor/graphql/account/tests/mutations/customer_type/test_customer_type_create.py
+++ b/saleor/graphql/account/tests/mutations/customer_type/test_customer_type_create.py
@@ -101,6 +101,44 @@ def test_create_as_default_transfers_default_flag(
     assert CustomerType.objects.filter(is_default=True).count() == 1
 
 
+@patch(
+    "saleor.graphql.account.mutations.customer_type.customer_type_create"
+    ".customer_type_qs_select_for_update"
+)
+def test_create_as_default_clears_default_row_invisible_to_locking_statement(
+    mocked_lock_qs,
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    default_customer_type,
+):
+    # given: the locking statement does not return the default row - as
+    # happens when a concurrent transaction inserted it while this one waited
+    # for the lock (a blocked SELECT FOR UPDATE cannot see newly inserted
+    # rows), the default-clearing update must still find and clear it
+    mocked_lock_qs.return_value = CustomerType.objects.exclude(
+        pk=default_customer_type.pk
+    )
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {"input": {"name": "Wholesale", "isDefault": True}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeCreate"]
+    assert data["errors"] == []
+    assert data["customerType"]["isDefault"] is True
+
+    default_customer_type.refresh_from_db()
+    assert default_customer_type.is_default is False
+    customer_type = CustomerType.objects.get(slug="wholesale")
+    assert customer_type.is_default is True
+    assert CustomerType.objects.filter(is_default=True).count() == 1
+
+
 def test_create_with_duplicated_slug(
     staff_api_client,
     permission_manage_customer_types_and_attributes,

--- a/saleor/graphql/account/tests/mutations/customer_type/test_customer_type_delete.py
+++ b/saleor/graphql/account/tests/mutations/customer_type/test_customer_type_delete.py
@@ -1,0 +1,134 @@
+from unittest.mock import patch
+
+import graphene
+
+from ......account.error_codes import CustomerTypeDeleteErrorCode
+from ......account.models import CustomerType
+from .....tests.utils import assert_no_permission, get_graphql_content
+
+CUSTOMER_TYPE_DELETE_MUTATION = """
+    mutation CustomerTypeDelete($id: ID!) {
+        customerTypeDelete(id: $id) {
+            customerType {
+                id
+                name
+                slug
+            }
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+
+def test_delete_by_staff_with_permission(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {"id": graphene.Node.to_global_id("CustomerType", customer_type.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_DELETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeDelete"]
+    assert data["errors"] == []
+    assert data["customerType"]["slug"] == customer_type.slug
+    assert not CustomerType.objects.filter(pk=customer_type.pk).exists()
+
+
+def test_delete_reassigns_users_to_default(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    customer_type,
+    default_customer_type,
+    customer_user,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    customer_user.customer_type = customer_type
+    customer_user.save(update_fields=["customer_type"])
+    variables = {"id": graphene.Node.to_global_id("CustomerType", customer_type.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_DELETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeDelete"]
+    assert data["errors"] == []
+    assert not CustomerType.objects.filter(pk=customer_type.pk).exists()
+
+    customer_user.refresh_from_db()
+    assert customer_user.customer_type == default_customer_type
+
+
+def test_delete_default_type_is_forbidden(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    default_customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", default_customer_type.pk)
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_DELETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeDelete"]
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "id"
+    assert error["code"] == CustomerTypeDeleteErrorCode.CANNOT_DELETE_DEFAULT.name
+    assert CustomerType.objects.filter(pk=default_customer_type.pk).exists()
+
+
+def test_delete_by_staff_without_permission(staff_api_client, customer_type):
+    # given
+    variables = {"id": graphene.Node.to_global_id("CustomerType", customer_type.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_DELETE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)
+    assert CustomerType.objects.filter(pk=customer_type.pk).exists()
+
+
+@patch("saleor.plugins.manager.PluginsManager.customer_type_deleted")
+def test_delete_triggers_webhook(
+    mocked_customer_type_deleted,
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {"id": graphene.Node.to_global_id("CustomerType", customer_type.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_DELETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["customerTypeDelete"]["errors"] == []
+    mocked_customer_type_deleted.assert_called_once_with(customer_type)

--- a/saleor/graphql/account/tests/mutations/customer_type/test_customer_type_update.py
+++ b/saleor/graphql/account/tests/mutations/customer_type/test_customer_type_update.py
@@ -1,0 +1,296 @@
+from unittest.mock import patch
+
+import graphene
+
+from ......account.error_codes import CustomerTypeUpdateErrorCode
+from ......account.models import CustomerType
+from .....tests.utils import assert_no_permission, get_graphql_content
+
+CUSTOMER_TYPE_UPDATE_MUTATION = """
+    mutation CustomerTypeUpdate($id: ID!, $input: CustomerTypeUpdateInput!) {
+        customerTypeUpdate(id: $id, input: $input) {
+            customerType {
+                id
+                name
+                slug
+                isDefault
+            }
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+
+def test_update_name_and_slug(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    new_name = "Business"
+    new_slug = "business"
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", customer_type.pk),
+        "input": {"name": new_name, "slug": new_slug},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeUpdate"]
+    assert data["errors"] == []
+
+    customer_type.refresh_from_db()
+    assert customer_type.name == new_name
+    assert customer_type.slug == new_slug
+    assert data["customerType"]["name"] == customer_type.name
+    assert data["customerType"]["slug"] == customer_type.slug
+
+
+def test_update_name_keeps_slug(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    old_slug = customer_type.slug
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", customer_type.pk),
+        "input": {"name": "Renamed"},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeUpdate"]
+    assert data["errors"] == []
+
+    customer_type.refresh_from_db()
+    assert customer_type.name == "Renamed"
+    assert customer_type.slug == old_slug
+
+
+def test_update_default_type_is_renamable(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    default_customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    new_name = "Standard"
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", default_customer_type.pk),
+        "input": {"name": new_name},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeUpdate"]
+    assert data["errors"] == []
+
+    default_customer_type.refresh_from_db()
+    assert default_customer_type.name == new_name
+    assert default_customer_type.is_default is True
+
+
+def test_update_is_default_transfers_default_flag(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    customer_type,
+    default_customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", customer_type.pk),
+        "input": {"isDefault": True},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeUpdate"]
+    assert data["errors"] == []
+    assert data["customerType"]["isDefault"] is True
+
+    customer_type.refresh_from_db()
+    default_customer_type.refresh_from_db()
+    assert customer_type.is_default is True
+    assert default_customer_type.is_default is False
+    assert CustomerType.objects.filter(is_default=True).count() == 1
+
+
+def test_update_is_default_true_on_current_default_is_noop(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    default_customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", default_customer_type.pk),
+        "input": {"isDefault": True},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeUpdate"]
+    assert data["errors"] == []
+
+    default_customer_type.refresh_from_db()
+    assert default_customer_type.is_default is True
+    assert CustomerType.objects.filter(is_default=True).count() == 1
+
+
+def test_update_cannot_unset_default(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    default_customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", default_customer_type.pk),
+        "input": {"isDefault": False},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeUpdate"]
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "isDefault"
+    assert error["code"] == CustomerTypeUpdateErrorCode.CANNOT_UNSET_DEFAULT.name
+
+    default_customer_type.refresh_from_db()
+    assert default_customer_type.is_default is True
+
+
+def test_update_is_default_false_on_non_default_is_noop(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    customer_type,
+    default_customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", customer_type.pk),
+        "input": {"isDefault": False},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeUpdate"]
+    assert data["errors"] == []
+
+    customer_type.refresh_from_db()
+    default_customer_type.refresh_from_db()
+    assert customer_type.is_default is False
+    assert default_customer_type.is_default is True
+
+
+def test_update_with_duplicated_slug(
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    customer_type,
+    default_customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", customer_type.pk),
+        "input": {"slug": default_customer_type.slug},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerTypeUpdate"]
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "slug"
+    assert error["code"] == CustomerTypeUpdateErrorCode.UNIQUE.name
+
+
+def test_update_by_staff_without_permission(staff_api_client, customer_type):
+    # given
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", customer_type.pk),
+        "input": {"name": "Renamed"},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_UPDATE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+@patch("saleor.plugins.manager.PluginsManager.customer_type_updated")
+def test_update_triggers_webhook(
+    mocked_customer_type_updated,
+    staff_api_client,
+    permission_manage_customer_types_and_attributes,
+    customer_type,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_customer_types_and_attributes
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("CustomerType", customer_type.pk),
+        "input": {"name": "Renamed"},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["customerTypeUpdate"]["errors"] == []
+
+    customer_type.refresh_from_db()
+    mocked_customer_type_updated.assert_called_once_with(customer_type)

--- a/saleor/graphql/account/tests/mutations/staff/test_customer_create.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_customer_create.py
@@ -596,3 +596,22 @@ def test_customer_create_race_condition(
 
         # make sure that addresses were not saved.
         assert not Address.objects.exclude(id=address.id).exists()
+
+
+def test_create_assigns_default_customer_type(
+    staff_api_client, permission_manage_users, default_customer_type
+):
+    # given
+    email = "customer-type@example.com"
+    variables = {"email": email}
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_CREATE_MUTATION, variables, permissions=[permission_manage_users]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["customerCreate"]["errors"]
+    new_user = User.objects.get(email=email)
+    assert new_user.customer_type == default_customer_type

--- a/saleor/graphql/account/tests/mutations/staff/test_staff_create.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_staff_create.py
@@ -509,3 +509,22 @@ def test_staff_create_with_upper_case_email(
     data = content["data"]["staffCreate"]
     assert not data["errors"]
     assert data["user"]["email"] == email.lower()
+
+
+def test_create_assigns_default_customer_type(
+    staff_api_client, permission_manage_staff, default_customer_type
+):
+    # given
+    email = "staff-customer-type@example.com"
+    variables = {"input": {"email": email}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        STAFF_CREATE_MUTATION, variables, permissions=[permission_manage_staff]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["staffCreate"]["errors"]
+    new_user = User.objects.get(email=email)
+    assert new_user.customer_type == default_customer_type

--- a/saleor/graphql/account/tests/queries/test_customer_types.py
+++ b/saleor/graphql/account/tests/queries/test_customer_types.py
@@ -1,0 +1,200 @@
+import graphene
+
+from ....core.enums import OrderDirection
+from ....tests.utils import assert_no_permission, get_graphql_content
+from ...sorters import CustomerTypeSortField
+
+CUSTOMER_TYPE_QUERY = """
+    query CustomerType($id: ID!) {
+        customerType(id: $id) {
+            id
+            name
+            slug
+            isDefault
+        }
+    }
+"""
+
+CUSTOMER_TYPES_QUERY = """
+    query CustomerTypes(
+        $where: CustomerTypeWhereInput,
+        $search: String,
+        $sortBy: CustomerTypeSortingInput
+    ) {
+        customerTypes(first: 10, where: $where, search: $search, sortBy: $sortBy) {
+            edges {
+                node {
+                    id
+                    name
+                    slug
+                    isDefault
+                }
+            }
+            totalCount
+        }
+    }
+"""
+
+
+def test_customer_type_query_by_staff_without_permissions(
+    staff_api_client, customer_type
+):
+    # given
+    variables = {"id": graphene.Node.to_global_id("CustomerType", customer_type.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPE_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    customer_type_data = content["data"]["customerType"]
+    assert customer_type_data["name"] == customer_type.name
+    assert customer_type_data["slug"] == customer_type.slug
+    assert customer_type_data["isDefault"] == customer_type.is_default
+
+
+def test_customer_type_query_by_app(app_api_client, customer_type):
+    # given
+    variables = {"id": graphene.Node.to_global_id("CustomerType", customer_type.pk)}
+
+    # when
+    response = app_api_client.post_graphql(CUSTOMER_TYPE_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    customer_type_data = content["data"]["customerType"]
+    assert customer_type_data["slug"] == customer_type.slug
+
+
+def test_customer_type_query_by_customer_no_permission(user_api_client, customer_type):
+    # given
+    variables = {"id": graphene.Node.to_global_id("CustomerType", customer_type.pk)}
+
+    # when
+    response = user_api_client.post_graphql(CUSTOMER_TYPE_QUERY, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_customer_type_query_by_anonymous_no_permission(api_client, customer_type):
+    # given
+    variables = {"id": graphene.Node.to_global_id("CustomerType", customer_type.pk)}
+
+    # when
+    response = api_client.post_graphql(CUSTOMER_TYPE_QUERY, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_customer_types_query_by_staff(
+    staff_api_client, customer_type, default_customer_type
+):
+    # given
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPES_QUERY, {})
+
+    # then
+    content = get_graphql_content(response)
+    customer_types_data = content["data"]["customerTypes"]
+    assert customer_types_data["totalCount"] == 2
+    slugs = {edge["node"]["slug"] for edge in customer_types_data["edges"]}
+    assert slugs == {customer_type.slug, default_customer_type.slug}
+
+
+def test_customer_types_query_by_customer_no_permission(user_api_client, customer_type):
+    # when
+    response = user_api_client.post_graphql(CUSTOMER_TYPES_QUERY, {})
+
+    # then
+    assert_no_permission(response)
+
+
+def test_customer_types_query_search(
+    staff_api_client, customer_type, default_customer_type
+):
+    # given
+    variables = {"search": customer_type.name}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPES_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    customer_types_data = content["data"]["customerTypes"]
+    assert customer_types_data["totalCount"] == 1
+    assert customer_types_data["edges"][0]["node"]["slug"] == customer_type.slug
+
+
+def test_customer_types_query_where_slug_one_of(
+    staff_api_client, customer_type, default_customer_type
+):
+    # given
+    variables = {"where": {"slug": {"oneOf": [default_customer_type.slug]}}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPES_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    customer_types_data = content["data"]["customerTypes"]
+    assert customer_types_data["totalCount"] == 1
+    assert customer_types_data["edges"][0]["node"]["slug"] == default_customer_type.slug
+
+
+def test_customer_types_query_where_ids(
+    staff_api_client, customer_type, default_customer_type
+):
+    # given
+    customer_type_id = graphene.Node.to_global_id("CustomerType", customer_type.pk)
+    variables = {"where": {"ids": [customer_type_id]}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPES_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    customer_types_data = content["data"]["customerTypes"]
+    assert customer_types_data["totalCount"] == 1
+    assert customer_types_data["edges"][0]["node"]["id"] == customer_type_id
+
+
+def test_customer_types_query_where_is_default(
+    staff_api_client, customer_type, default_customer_type
+):
+    # given
+    variables = {"where": {"isDefault": True}}
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPES_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    customer_types_data = content["data"]["customerTypes"]
+    assert customer_types_data["totalCount"] == 1
+    assert customer_types_data["edges"][0]["node"]["slug"] == default_customer_type.slug
+
+
+def test_customer_types_query_sort_by_name_desc(
+    staff_api_client, customer_type, default_customer_type
+):
+    # given
+    variables = {
+        "sortBy": {
+            "field": CustomerTypeSortField.NAME.name,
+            "direction": OrderDirection.DESC.name,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(CUSTOMER_TYPES_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    customer_types_data = content["data"]["customerTypes"]
+    names = [edge["node"]["name"] for edge in customer_types_data["edges"]]
+    assert names == sorted(
+        [customer_type.name, default_customer_type.name], reverse=True
+    )

--- a/saleor/graphql/account/tests/queries/test_user_customer_type.py
+++ b/saleor/graphql/account/tests/queries/test_user_customer_type.py
@@ -1,0 +1,96 @@
+import graphene
+
+from ....tests.utils import assert_no_permission, get_graphql_content
+
+USER_CUSTOMER_TYPE_QUERY = """
+    query User($id: ID!) {
+        user(id: $id) {
+            id
+            customerType {
+                id
+                name
+                slug
+                isDefault
+            }
+        }
+    }
+"""
+
+ME_CUSTOMER_TYPE_QUERY = """
+    query Me {
+        me {
+            id
+            customerType {
+                id
+                name
+                slug
+            }
+        }
+    }
+"""
+
+
+def test_customer_type_visible_to_staff_with_manage_users(
+    staff_api_client, permission_manage_users, customer_user, customer_type
+):
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_users)
+    customer_user.customer_type = customer_type
+    customer_user.save(update_fields=["customer_type"])
+    variables = {"id": graphene.Node.to_global_id("User", customer_user.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(USER_CUSTOMER_TYPE_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    customer_type_data = content["data"]["user"]["customerType"]
+    assert customer_type_data["name"] == customer_type.name
+    assert customer_type_data["slug"] == customer_type.slug
+    assert customer_type_data["isDefault"] == customer_type.is_default
+
+
+def test_customer_type_visible_to_owner(user_api_client, customer_user, customer_type):
+    # given
+    customer_user.customer_type = customer_type
+    customer_user.save(update_fields=["customer_type"])
+
+    # when
+    response = user_api_client.post_graphql(ME_CUSTOMER_TYPE_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    customer_type_data = content["data"]["me"]["customerType"]
+    assert customer_type_data["slug"] == customer_type.slug
+
+
+def test_customer_type_not_visible_to_staff_without_permission(
+    staff_api_client, permission_manage_orders, customer_user, customer_type
+):
+    # given the customers query is reachable with MANAGE_ORDERS, but the
+    # customerType field requires MANAGE_USERS or ownership
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    customer_user.customer_type = customer_type
+    customer_user.save(update_fields=["customer_type"])
+    variables = {"id": graphene.Node.to_global_id("User", customer_user.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(USER_CUSTOMER_TYPE_QUERY, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_customer_type_falls_back_to_default_when_not_assigned(
+    user_api_client, customer_user, default_customer_type
+):
+    # given a user created before the backfill finished
+    assert customer_user.customer_type_id is None
+
+    # when
+    response = user_api_client.post_graphql(ME_CUSTOMER_TYPE_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    customer_type_data = content["data"]["me"]["customerType"]
+    assert customer_type_data["slug"] == default_customer_type.slug

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -38,6 +38,7 @@ from ..core.context import SyncWebhookControlContext, get_database_connection_na
 from ..core.descriptions import (
     ADDED_IN_319,
     ADDED_IN_322,
+    ADDED_IN_323,
     DEPRECATED_LEGACY_PAYMENTS,
     PREVIEW_FEATURE,
 )
@@ -67,10 +68,13 @@ from ..payment.types import StoredPaymentMethod
 from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import format_permissions_for_display, get_user_or_app_from_context
 from .dataloaders import (
+    DEFAULT_CUSTOMER_TYPE_LOADER_KEY,
     AccessibleChannelsByGroupIdLoader,
     AccessibleChannelsByUserIdLoader,
     AddressByIdLoader,
     CustomerEventsByUserLoader,
+    CustomerTypeByIdLoader,
+    DefaultCustomerTypeLoader,
     RestrictedChannelAccessByUserIdLoader,
     ThumbnailByUserIdSizeAndFormatLoader,
 )
@@ -316,6 +320,34 @@ class UserPermission(Permission):
         return groups
 
 
+class CustomerType(ModelObjectType[models.CustomerType]):
+    id = graphene.GlobalID(required=True, description="The ID of the customer type.")
+    name = graphene.String(required=True, description="Name of the customer type.")
+    slug = graphene.String(required=True, description="Slug of the customer type.")
+    is_default = graphene.Boolean(
+        required=True,
+        description=(
+            "Whether this is the default customer type. The default customer type "
+            "is assigned to every newly created user and cannot be deleted."
+        ),
+    )
+
+    class Meta:
+        description = (
+            "Represents a type of customer. It allows to segment users and defines "
+            "what attributes are available to users of this type." + ADDED_IN_323
+        )
+        interfaces = [relay.Node, ObjectWithMetadata]
+        model = models.CustomerType
+        doc_category = DOC_CATEGORY_USERS
+
+
+class CustomerTypeCountableConnection(CountableConnection):
+    class Meta:
+        doc_category = DOC_CATEGORY_USERS
+        node = CustomerType
+
+
 def is_newly_created_user(
     user: models.User,
 ):
@@ -462,6 +494,14 @@ class User(ModelObjectType[models.User]):
     )
     external_reference = graphene.String(
         description="External ID of this user.", required=False
+    )
+    customer_type = graphene.Field(
+        CustomerType,
+        description=(
+            "The customer type assigned to the user. Requires one of the following "
+            f"permissions: {AccountPermissions.MANAGE_USERS.name}, "
+            f"{AuthorizationFilters.OWNER.name}." + ADDED_IN_323
+        ),
     )
 
     last_login = DateTime(
@@ -857,6 +897,20 @@ class User(ModelObjectType[models.User]):
                 root.default_shipping_address_id
             )
         return None
+
+    @staticmethod
+    def resolve_customer_type(root: models.User, info: ResolveInfo):
+        requestor = get_user_or_app_from_context(info.context)
+        check_is_owner_or_has_one_of_perms(
+            requestor, root, AccountPermissions.MANAGE_USERS
+        )
+        if root.customer_type_id:
+            return CustomerTypeByIdLoader(info.context).load(root.customer_type_id)
+        # Users created before the customer type backfill finishes may still have
+        # no type assigned - present them as having the default one.
+        return DefaultCustomerTypeLoader(info.context).load(
+            DEFAULT_CUSTOMER_TYPE_LOADER_KEY
+        )
 
 
 class UserCountableConnection(CountableConnection):

--- a/saleor/graphql/core/doc_category.py
+++ b/saleor/graphql/core/doc_category.py
@@ -21,6 +21,7 @@ DOC_CATEGORY_WEBHOOKS = "Webhooks"
 # Map models to category names in doc directive.
 DOC_CATEGORY_MAP = {
     "account.Address": DOC_CATEGORY_USERS,
+    "account.CustomerType": DOC_CATEGORY_USERS,
     "account.CustomerEvent": DOC_CATEGORY_USERS,
     "account.Group": DOC_CATEGORY_USERS,
     "account.StaffNotificationRecipient": DOC_CATEGORY_USERS,

--- a/saleor/graphql/core/enums.py
+++ b/saleor/graphql/core/enums.py
@@ -233,6 +233,21 @@ CustomerBulkUpdateErrorCode: Final[graphene.Enum] = graphene.Enum.from_enum(
 )
 CustomerBulkUpdateErrorCode.doc_category = DOC_CATEGORY_USERS
 
+CustomerTypeCreateErrorCode: Final[graphene.Enum] = graphene.Enum.from_enum(
+    account_error_codes.CustomerTypeCreateErrorCode
+)
+CustomerTypeCreateErrorCode.doc_category = DOC_CATEGORY_USERS
+
+CustomerTypeUpdateErrorCode: Final[graphene.Enum] = graphene.Enum.from_enum(
+    account_error_codes.CustomerTypeUpdateErrorCode
+)
+CustomerTypeUpdateErrorCode.doc_category = DOC_CATEGORY_USERS
+
+CustomerTypeDeleteErrorCode: Final[graphene.Enum] = graphene.Enum.from_enum(
+    account_error_codes.CustomerTypeDeleteErrorCode
+)
+CustomerTypeDeleteErrorCode.doc_category = DOC_CATEGORY_USERS
+
 ExternalNotificationTriggerErrorCode: Final[graphene.Enum] = graphene.Enum.from_enum(
     external_notifications_error_codes.ExternalNotificationErrorCodes
 )

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -75,6 +75,8 @@ COST_MAP = {
         "collection": {"complexity": 1},
         "collections": {"complexity": 1, "multipliers": ["first", "last"]},
         "customers": {"complexity": 1, "multipliers": ["first", "last"]},
+        "customerType": {"complexity": 1},
+        "customerTypes": {"complexity": 1, "multipliers": ["first", "last"]},
         "draftOrders": {"complexity": 1, "multipliers": ["first", "last"]},
         "exportFile": {"complexity": 1},
         "exportFiles": {"complexity": 1, "multipliers": ["first", "last"]},
@@ -424,6 +426,7 @@ COST_MAP = {
     "User": {
         "avatar": {"complexity": 1},
         "checkout": {"complexity": 1},
+        "customerType": {"complexity": 1},
         "editableGroups": {"complexity": 1},
         "events": {"complexity": 1},
         "giftCards": {"complexity": 1, "multipliers": ["first", "last"]},

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1584,6 +1584,52 @@ type Query {
   ): UserCountableConnection @doc(category: "Users")
 
   """
+  Look up a customer type by ID.
+  
+  Added in Saleor 3.23.
+  
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP, MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES, MANAGE_USERS.
+  """
+  customerType(
+    """ID of the customer type."""
+    id: ID!
+  ): CustomerType @doc(category: "Users")
+
+  """
+  List of the customer types.
+  
+  Added in Saleor 3.23.
+  
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP, MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES, MANAGE_USERS.
+  """
+  customerTypes(
+    """Where filtering options for customer types."""
+    where: CustomerTypeWhereInput
+
+    """Search customer types by name or slug."""
+    search: String
+
+    """Sort customer types."""
+    sortBy: CustomerTypeSortingInput
+
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): CustomerTypeCountableConnection @doc(category: "Users")
+
+  """
   List of permission groups.
   
   Requires one of the following permissions: MANAGE_STAFF.
@@ -1997,6 +2043,27 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """A customer account metadata is updated."""
   CUSTOMER_METADATA_UPDATED
+
+  """
+  A new customer type is created.
+  
+  Added in Saleor 3.23.
+  """
+  CUSTOMER_TYPE_CREATED
+
+  """
+  A customer type is updated.
+  
+  Added in Saleor 3.23.
+  """
+  CUSTOMER_TYPE_UPDATED
+
+  """
+  A customer type is deleted.
+  
+  Added in Saleor 3.23.
+  """
+  CUSTOMER_TYPE_DELETED
 
   """A new collection is created."""
   COLLECTION_CREATED
@@ -2601,6 +2668,27 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """A customer account metadata is updated."""
   CUSTOMER_METADATA_UPDATED
+
+  """
+  A new customer type is created.
+  
+  Added in Saleor 3.23.
+  """
+  CUSTOMER_TYPE_CREATED
+
+  """
+  A customer type is updated.
+  
+  Added in Saleor 3.23.
+  """
+  CUSTOMER_TYPE_UPDATED
+
+  """
+  A customer type is deleted.
+  
+  Added in Saleor 3.23.
+  """
+  CUSTOMER_TYPE_DELETED
 
   """A new collection is created."""
   COLLECTION_CREATED
@@ -3449,6 +3537,13 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """External ID of this user."""
   externalReference: String
+
+  """
+  The customer type assigned to the user. Requires one of the following permissions: MANAGE_USERS, OWNER.
+  
+  Added in Saleor 3.23.
+  """
+  customerType: CustomerType
 
   """The date when the user last time log in to the system."""
   lastLogin: DateTime
@@ -14044,6 +14139,57 @@ type PaymentSource @doc(category: "Payments") {
   metadata: [MetadataItem!]!
 }
 
+"""
+Represents a type of customer. It allows to segment users and defines what attributes are available to users of this type.
+
+Added in Saleor 3.23.
+"""
+type CustomerType implements Node & ObjectWithMetadata @doc(category: "Users") {
+  """The ID of the customer type."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """Name of the customer type."""
+  name: String!
+
+  """Slug of the customer type."""
+  slug: String!
+
+  """
+  Whether this is the default customer type. The default customer type is assigned to every newly created user and cannot be deleted.
+  """
+  isDefault: Boolean!
+}
+
 """Represents the app's brand data."""
 type AppBrand @doc(category: "Apps") {
   """App's logos details."""
@@ -14310,6 +14456,9 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   CUSTOMER_UPDATED
   CUSTOMER_DELETED
   CUSTOMER_METADATA_UPDATED
+  CUSTOMER_TYPE_CREATED
+  CUSTOMER_TYPE_UPDATED
+  CUSTOMER_TYPE_DELETED
   COLLECTION_CREATED
   COLLECTION_UPDATED
   COLLECTION_DELETED
@@ -17584,6 +17733,60 @@ enum UserSortField @doc(category: "Users") {
   Sort users by rank. Note: This option is available only with the `search` filter.
   """
   RANK
+}
+
+type CustomerTypeCountableConnection @doc(category: "Users") {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+  edges: [CustomerTypeCountableEdge!]!
+
+  """A total count of items in the collection."""
+  totalCount: Int
+}
+
+type CustomerTypeCountableEdge @doc(category: "Users") {
+  """The item at the end of the edge."""
+  node: CustomerType!
+
+  """A cursor for use in pagination."""
+  cursor: String!
+}
+
+input CustomerTypeWhereInput @doc(category: "Users") {
+  """Filter by metadata fields."""
+  metadata: MetadataFilterInput
+  ids: [ID!]
+
+  """Filter by customer type name."""
+  name: StringFilterInput
+
+  """Filter by customer type slug."""
+  slug: StringFilterInput
+
+  """Filter by whether the customer type is the default one."""
+  isDefault: Boolean
+
+  """List of conditions that must be met."""
+  AND: [CustomerTypeWhereInput!]
+
+  """A list of conditions of which at least one must be met."""
+  OR: [CustomerTypeWhereInput!]
+}
+
+input CustomerTypeSortingInput @doc(category: "Users") {
+  """Specifies the direction in which to sort customer types."""
+  direction: OrderDirection!
+
+  """Sort customer types by the selected field."""
+  field: CustomerTypeSortField!
+}
+
+enum CustomerTypeSortField @doc(category: "Users") {
+  """Sort customer types by name."""
+  NAME
+
+  """Sort customer types by slug."""
+  SLUG
 }
 
 type GroupCountableConnection @doc(category: "Users") {
@@ -22328,6 +22531,54 @@ type Mutation {
     """Policies of error handling. DEFAULT: REJECT_EVERYTHING"""
     errorPolicy: ErrorPolicyEnum
   ): CustomerBulkUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_UPDATED, CUSTOMER_METADATA_UPDATED], syncEvents: [])
+
+  """
+  Creates a new customer type.
+  
+  Added in Saleor 3.23. 
+  
+  Requires one of the following permissions: MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES.
+  
+  Triggers the following webhook events:
+  - CUSTOMER_TYPE_CREATED (async): A new customer type was created.
+  """
+  customerTypeCreate(
+    """Fields required to create a customer type."""
+    input: CustomerTypeCreateInput!
+  ): CustomerTypeCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_TYPE_CREATED], syncEvents: [])
+
+  """
+  Updates a customer type.
+  
+  Added in Saleor 3.23. 
+  
+  Requires one of the following permissions: MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES.
+  
+  Triggers the following webhook events:
+  - CUSTOMER_TYPE_UPDATED (async): A customer type was updated.
+  """
+  customerTypeUpdate(
+    """ID of the customer type to update."""
+    id: ID!
+
+    """Fields required to update a customer type."""
+    input: CustomerTypeUpdateInput!
+  ): CustomerTypeUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_TYPE_UPDATED], syncEvents: [])
+
+  """
+  Deletes a customer type. Users of the deleted customer type are reassigned to the default customer type.
+  
+  Added in Saleor 3.23. 
+  
+  Requires one of the following permissions: MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES.
+  
+  Triggers the following webhook events:
+  - CUSTOMER_TYPE_DELETED (async): A customer type was deleted.
+  """
+  customerTypeDelete(
+    """ID of the customer type to delete."""
+    id: ID!
+  ): CustomerTypeDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_TYPE_DELETED], syncEvents: [])
 
   """
   Creates a new staff user. Apps are not allowed to perform this mutation. 
@@ -33862,6 +34113,144 @@ input CustomerBulkUpdateInput @doc(category: "Users") {
 }
 
 """
+Creates a new customer type.
+
+Added in Saleor 3.23. 
+
+Requires one of the following permissions: MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES.
+
+Triggers the following webhook events:
+- CUSTOMER_TYPE_CREATED (async): A new customer type was created.
+"""
+type CustomerTypeCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_TYPE_CREATED], syncEvents: []) {
+  errors: [CustomerTypeCreateError!]!
+  customerType: CustomerType
+}
+
+type CustomerTypeCreateError @doc(category: "Users") {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: CustomerTypeCreateErrorCode!
+}
+
+enum CustomerTypeCreateErrorCode @doc(category: "Users") {
+  GRAPHQL_ERROR
+  INVALID
+  NOT_FOUND
+  REQUIRED
+  UNIQUE
+}
+
+input CustomerTypeCreateInput @doc(category: "Users") {
+  """Name of the customer type."""
+  name: String
+
+  """
+  Slug of the customer type. If not provided, it will be generated from the name.
+  """
+  slug: String
+
+  """
+  Determines if the customer type should become the default one, assigned to every newly created user. Passing `true` clears the flag on the current default customer type - exactly one default customer type always exists.
+  """
+  isDefault: Boolean
+}
+
+"""
+Updates a customer type.
+
+Added in Saleor 3.23. 
+
+Requires one of the following permissions: MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES.
+
+Triggers the following webhook events:
+- CUSTOMER_TYPE_UPDATED (async): A customer type was updated.
+"""
+type CustomerTypeUpdate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_TYPE_UPDATED], syncEvents: []) {
+  errors: [CustomerTypeUpdateError!]!
+  customerType: CustomerType
+}
+
+type CustomerTypeUpdateError @doc(category: "Users") {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: CustomerTypeUpdateErrorCode!
+}
+
+enum CustomerTypeUpdateErrorCode @doc(category: "Users") {
+  CANNOT_UNSET_DEFAULT
+  GRAPHQL_ERROR
+  INVALID
+  NOT_FOUND
+  REQUIRED
+  UNIQUE
+}
+
+input CustomerTypeUpdateInput @doc(category: "Users") {
+  """Name of the customer type."""
+  name: String
+
+  """
+  Slug of the customer type. If not provided, it will be generated from the name.
+  """
+  slug: String
+
+  """
+  Determines if the customer type should become the default one, assigned to every newly created user. Passing `true` clears the flag on the current default customer type - exactly one default customer type always exists.
+  """
+  isDefault: Boolean
+}
+
+"""
+Deletes a customer type. Users of the deleted customer type are reassigned to the default customer type.
+
+Added in Saleor 3.23. 
+
+Requires one of the following permissions: MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES.
+
+Triggers the following webhook events:
+- CUSTOMER_TYPE_DELETED (async): A customer type was deleted.
+"""
+type CustomerTypeDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_TYPE_DELETED], syncEvents: []) {
+  errors: [CustomerTypeDeleteError!]!
+  customerType: CustomerType
+}
+
+type CustomerTypeDeleteError @doc(category: "Users") {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: CustomerTypeDeleteErrorCode!
+}
+
+enum CustomerTypeDeleteErrorCode @doc(category: "Users") {
+  CANNOT_DELETE_DEFAULT
+  GRAPHQL_ERROR
+  INVALID
+  NOT_FOUND
+}
+
+"""
 Creates a new staff user. Apps are not allowed to perform this mutation. 
 
 Requires one of the following permissions: MANAGE_STAFF.
@@ -36776,6 +37165,72 @@ type CustomerMetadataUpdated implements Event @doc(category: "Users") {
 
   """The user the event relates to."""
   user: User
+}
+
+"""
+Event sent when new customer type is created.
+
+Added in Saleor 3.23.
+"""
+type CustomerTypeCreated implements Event @doc(category: "Users") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The customer type the event relates to."""
+  customerType: CustomerType
+}
+
+"""
+Event sent when customer type is updated.
+
+Added in Saleor 3.23.
+"""
+type CustomerTypeUpdated implements Event @doc(category: "Users") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The customer type the event relates to."""
+  customerType: CustomerType
+}
+
+"""
+Event sent when customer type is deleted.
+
+Added in Saleor 3.23.
+"""
+type CustomerTypeDeleted implements Event @doc(category: "Users") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The customer type the event relates to."""
+  customerType: CustomerType
 }
 
 """Event sent when new collection is created."""

--- a/saleor/graphql/tests/queries/fragments.py
+++ b/saleor/graphql/tests/queries/fragments.py
@@ -350,6 +350,16 @@ fragment PageTypeDetails on PageType{
 """
 
 
+CUSTOMER_TYPE_DETAILS = """
+fragment CustomerTypeDetails on CustomerType{
+  id
+  name
+  slug
+  isDefault
+}
+"""
+
+
 PERMISSION_GROUP_DETAILS = """
 fragment PermissionGroupDetails on Group{
   name

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -3,6 +3,7 @@ import graphene
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..core.descriptions import (
     ADDED_IN_318,
+    ADDED_IN_323,
     DEFAULT_DEPRECATION_REASON,
     DEPRECATED_LEGACY_PAYMENTS,
 )
@@ -88,6 +89,12 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.CUSTOMER_UPDATED: "A customer account is updated.",
     WebhookEventAsyncType.CUSTOMER_DELETED: "A customer account is deleted.",
     WebhookEventAsyncType.CUSTOMER_METADATA_UPDATED: "A customer account metadata is updated.",
+    WebhookEventAsyncType.CUSTOMER_TYPE_CREATED: "A new customer type is created."
+    + ADDED_IN_323,
+    WebhookEventAsyncType.CUSTOMER_TYPE_UPDATED: "A customer type is updated."
+    + ADDED_IN_323,
+    WebhookEventAsyncType.CUSTOMER_TYPE_DELETED: "A customer type is deleted."
+    + ADDED_IN_323,
     WebhookEventAsyncType.GIFT_CARD_CREATED: "A new gift card created.",
     WebhookEventAsyncType.GIFT_CARD_UPDATED: "A gift card is updated.",
     WebhookEventAsyncType.GIFT_CARD_DELETED: "A gift card is deleted.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1616,6 +1616,42 @@ class CustomerDeleted(SubscriptionObjectType, UserBase):
         description = "Event sent when customer user is deleted." + ADDED_IN_323
 
 
+class CustomerTypeBase(AbstractType):
+    customer_type = graphene.Field(
+        "saleor.graphql.account.types.CustomerType",
+        description="The customer type the event relates to.",
+    )
+
+    @staticmethod
+    def resolve_customer_type(root, _info: ResolveInfo):
+        _, customer_type = root
+        return customer_type
+
+
+class CustomerTypeCreated(SubscriptionObjectType, CustomerTypeBase):
+    class Meta:
+        root_type = "CustomerType"
+        enable_dry_run = True
+        interfaces = (Event,)
+        description = "Event sent when new customer type is created." + ADDED_IN_323
+
+
+class CustomerTypeUpdated(SubscriptionObjectType, CustomerTypeBase):
+    class Meta:
+        root_type = "CustomerType"
+        enable_dry_run = True
+        interfaces = (Event,)
+        description = "Event sent when customer type is updated." + ADDED_IN_323
+
+
+class CustomerTypeDeleted(SubscriptionObjectType, CustomerTypeBase):
+    class Meta:
+        root_type = "CustomerType"
+        enable_dry_run = True
+        interfaces = (Event,)
+        description = "Event sent when customer type is deleted." + ADDED_IN_323
+
+
 class CollectionBase(AbstractType):
     collection = graphene.Field(
         "saleor.graphql.product.types.collections.Collection",
@@ -3290,6 +3326,9 @@ ASYNC_WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.CUSTOMER_UPDATED: CustomerUpdated,
     WebhookEventAsyncType.CUSTOMER_DELETED: CustomerDeleted,
     WebhookEventAsyncType.CUSTOMER_METADATA_UPDATED: CustomerMetadataUpdated,
+    WebhookEventAsyncType.CUSTOMER_TYPE_CREATED: CustomerTypeCreated,
+    WebhookEventAsyncType.CUSTOMER_TYPE_UPDATED: CustomerTypeUpdated,
+    WebhookEventAsyncType.CUSTOMER_TYPE_DELETED: CustomerTypeDeleted,
     WebhookEventAsyncType.COLLECTION_CREATED: CollectionCreated,
     WebhookEventAsyncType.COLLECTION_UPDATED: CollectionUpdated,
     WebhookEventAsyncType.COLLECTION_DELETED: CollectionDeleted,

--- a/saleor/permission/tests/fixtures/permission.py
+++ b/saleor/permission/tests/fixtures/permission.py
@@ -84,6 +84,11 @@ def permission_manage_users():
 
 
 @pytest.fixture
+def permission_manage_customer_types_and_attributes():
+    return Permission.objects.get(codename="manage_customer_types_and_attributes")
+
+
+@pytest.fixture
 def permission_impersonate_user():
     return Permission.objects.get(codename="impersonate_user")
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -34,7 +34,7 @@ from ..thumbnail.models import Thumbnail
 from .models import PluginConfiguration
 
 if TYPE_CHECKING:
-    from ..account.models import Address, Group, User
+    from ..account.models import Address, CustomerType, Group, User
     from ..app.models import App
     from ..attribute.models import Attribute, AttributeValue
     from ..channel.models import Channel
@@ -629,6 +629,24 @@ class BasePlugin:
     # Note: This method is deprecated and will be removed in a future release.
     # Webhook-related functionality will be moved from the plugin to core modules.
     customer_metadata_updated: Callable[["User", Any, None], Any]
+
+    # Trigger when customer type is created.
+    #
+    # Overwrite this method if you need to trigger specific logic after a customer
+    # type is created.
+    customer_type_created: Callable[["CustomerType", Any], Any]
+
+    # Trigger when customer type is updated.
+    #
+    # Overwrite this method if you need to trigger specific logic after a customer
+    # type is updated.
+    customer_type_updated: Callable[["CustomerType", Any], Any]
+
+    # Trigger when customer type is deleted.
+    #
+    # Overwrite this method if you need to trigger specific logic after a customer
+    # type is deleted.
+    customer_type_deleted: Callable[["CustomerType", Any, None], Any]
 
     # Handle authentication request.
     #

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -53,7 +53,7 @@ from .base_plugin import ExternalAccessTokens
 from .models import PluginConfiguration
 
 if TYPE_CHECKING:
-    from ..account.models import Address, Group, User
+    from ..account.models import Address, CustomerType, Group, User
     from ..app.models import App
     from ..attribute.models import Attribute, AttributeValue
     from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
@@ -710,6 +710,28 @@ class PluginsManager(PaymentInterface):
             "customer_metadata_updated",
             default_value,
             customer,
+            webhooks=webhooks,
+            channel_slug=None,
+        )
+
+    def customer_type_created(self, customer_type: "CustomerType"):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "customer_type_created", default_value, customer_type, channel_slug=None
+        )
+
+    def customer_type_updated(self, customer_type: "CustomerType"):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "customer_type_updated", default_value, customer_type, channel_slug=None
+        )
+
+    def customer_type_deleted(self, customer_type: "CustomerType", webhooks=None):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "customer_type_deleted",
+            default_value,
+            customer_type,
             webhooks=webhooks,
             channel_slug=None,
         )

--- a/saleor/plugins/openid_connect/tests/test_utils.py
+++ b/saleor/plugins/openid_connect/tests/test_utils.py
@@ -1251,3 +1251,25 @@ def test_update_user_details_nothing_changed(
     assert customer_user.first_name == first_name
     assert updated is False
     update_user_search_vector_mock.assert_not_called()
+
+
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_get_or_create_user_from_payload_assigns_default_customer_type(
+    mocked_cache_get, mocked_cache_set, default_customer_type
+):
+    # given
+    oauth_url = "https://saleor.io/oauth"
+    sub_id = "oauth|1234"
+    customer_email = "email.customer@example.com"
+    mocked_cache_get.side_effect = lambda cache_key: None
+
+    # when
+    user_from_payload, created, _ = get_or_create_user_from_payload(
+        payload={"sub": sub_id, "email": customer_email},
+        oauth_url=oauth_url,
+    )
+
+    # then
+    assert created is True
+    assert user_from_payload.customer_type == default_customer_type

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -18,7 +18,11 @@ from jwt import PyJWTError
 
 from ...account.models import Group, User
 from ...account.search import update_user_search_vector
-from ...account.utils import get_user_groups_permissions, send_user_event
+from ...account.utils import (
+    get_default_customer_type,
+    get_user_groups_permissions,
+    send_user_event,
+)
 from ...core.http_client import HTTPClient
 from ...core.jwt import (
     JWT_ACCESS_TYPE,
@@ -465,6 +469,7 @@ def get_or_create_user_from_payload(
             **get_kwargs
         )
     except User.DoesNotExist:
+        defaults_create["customer_type"] = get_default_customer_type()
         user, created = User.objects.get_or_create(
             email=user_email,
             defaults=defaults_create,
@@ -475,6 +480,7 @@ def get_or_create_user_from_payload(
 
     except User.MultipleObjectsReturned:
         logger.warning("Multiple users returned for single OIDC sub ID")
+        defaults_create["customer_type"] = get_default_customer_type()
         user, created = User.objects.get_or_create(
             email=user_email,
             defaults=defaults_create,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -128,7 +128,7 @@ from ...webhook.utils import (
 from ..base_plugin import BasePlugin
 
 if TYPE_CHECKING:
-    from ...account.models import Address, Group, User
+    from ...account.models import Address, CustomerType, Group, User
     from ...attribute.models import Attribute, AttributeValue
     from ...core.utils.translations import Translation
     from ...csv.models import ExportFile
@@ -1708,6 +1708,52 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         self._trigger_metadata_updated_event(
             WebhookEventAsyncType.CUSTOMER_METADATA_UPDATED, customer, webhooks=webhooks
+        )
+        return previous_value
+
+    def _trigger_customer_type_event(self, event_type, customer_type, webhooks=None):
+        if webhooks := self._get_webhooks_for_event(event_type, webhooks):
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("CustomerType", customer_type.id),
+                    "name": customer_type.name,
+                    "slug": customer_type.slug,
+                    "meta": self._generate_meta(),
+                }
+            )
+            self.trigger_webhooks_async(
+                payload, event_type, webhooks, customer_type, self.requestor
+            )
+
+    def customer_type_created(
+        self, customer_type: "CustomerType", previous_value: None
+    ) -> None:
+        if not self.active:
+            return previous_value
+        self._trigger_customer_type_event(
+            WebhookEventAsyncType.CUSTOMER_TYPE_CREATED, customer_type
+        )
+        return previous_value
+
+    def customer_type_updated(
+        self, customer_type: "CustomerType", previous_value: None
+    ) -> None:
+        if not self.active:
+            return previous_value
+        self._trigger_customer_type_event(
+            WebhookEventAsyncType.CUSTOMER_TYPE_UPDATED, customer_type
+        )
+        return previous_value
+
+    def customer_type_deleted(
+        self, customer_type: "CustomerType", previous_value: None, webhooks=None
+    ) -> None:
+        if not self.active:
+            return previous_value
+        self._trigger_customer_type_event(
+            WebhookEventAsyncType.CUSTOMER_TYPE_DELETED,
+            customer_type,
+            webhooks=webhooks,
         )
         return previous_value
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1223,6 +1223,9 @@ def async_subscription_webhooks_with_root_objects(
     subscription_page_type_created_webhook,
     subscription_page_type_updated_webhook,
     subscription_page_type_deleted_webhook,
+    subscription_customer_type_created_webhook,
+    subscription_customer_type_updated_webhook,
+    subscription_customer_type_deleted_webhook,
     subscription_permission_group_created_webhook,
     subscription_permission_group_updated_webhook,
     subscription_permission_group_deleted_webhook,
@@ -1258,6 +1261,7 @@ def async_subscription_webhooks_with_root_objects(
     fulfillment,
     stock,
     customer_user,
+    customer_type,
     collection,
     checkout,
     page,
@@ -1518,6 +1522,18 @@ def async_subscription_webhooks_with_root_objects(
         events.PAGE_TYPE_CREATED: [subscription_page_type_created_webhook, page_type],
         events.PAGE_TYPE_UPDATED: [subscription_page_type_updated_webhook, page_type],
         events.PAGE_TYPE_DELETED: [subscription_page_type_deleted_webhook, page_type],
+        events.CUSTOMER_TYPE_CREATED: [
+            subscription_customer_type_created_webhook,
+            customer_type,
+        ],
+        events.CUSTOMER_TYPE_UPDATED: [
+            subscription_customer_type_updated_webhook,
+            customer_type,
+        ],
+        events.CUSTOMER_TYPE_DELETED: [
+            subscription_customer_type_deleted_webhook,
+            customer_type,
+        ],
         events.PERMISSION_GROUP_CREATED: [
             subscription_permission_group_created_webhook,
             permission_group_manage_users,

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -6,6 +6,7 @@ from ..permission.enums import (
     BasePermissionEnum,
     ChannelPermissions,
     CheckoutPermissions,
+    CustomerTypePermissions,
     DiscountPermissions,
     GiftcardPermissions,
     MenuPermissions,
@@ -118,6 +119,10 @@ class WebhookEventAsyncType:
     CUSTOMER_UPDATED = "customer_updated"
     CUSTOMER_DELETED = "customer_deleted"
     CUSTOMER_METADATA_UPDATED = "customer_metadata_updated"
+
+    CUSTOMER_TYPE_CREATED = "customer_type_created"
+    CUSTOMER_TYPE_UPDATED = "customer_type_updated"
+    CUSTOMER_TYPE_DELETED = "customer_type_deleted"
 
     COLLECTION_CREATED = "collection_created"
     COLLECTION_UPDATED = "collection_updated"
@@ -550,6 +555,24 @@ class WebhookEventAsyncType:
         CUSTOMER_METADATA_UPDATED: {
             "name": "Customer metadata updated",
             "permission": AccountPermissions.MANAGE_USERS,
+        },
+        CUSTOMER_TYPE_CREATED: {
+            "name": "Customer type created",
+            "permission": (
+                CustomerTypePermissions.MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES
+            ),
+        },
+        CUSTOMER_TYPE_UPDATED: {
+            "name": "Customer type updated",
+            "permission": (
+                CustomerTypePermissions.MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES
+            ),
+        },
+        CUSTOMER_TYPE_DELETED: {
+            "name": "Customer type deleted",
+            "permission": (
+                CustomerTypePermissions.MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES
+            ),
         },
         COLLECTION_CREATED: {
             "name": "Collection created",

--- a/saleor/webhook/tests/fixtures/subscription_webhooks.py
+++ b/saleor/webhook/tests/fixtures/subscription_webhooks.py
@@ -880,6 +880,27 @@ def subscription_page_type_deleted_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_customer_type_created_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.CUSTOMER_TYPE_CREATED, WebhookEventAsyncType.CUSTOMER_TYPE_CREATED
+    )
+
+
+@pytest.fixture
+def subscription_customer_type_updated_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.CUSTOMER_TYPE_UPDATED, WebhookEventAsyncType.CUSTOMER_TYPE_UPDATED
+    )
+
+
+@pytest.fixture
+def subscription_customer_type_deleted_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.CUSTOMER_TYPE_DELETED, WebhookEventAsyncType.CUSTOMER_TYPE_DELETED
+    )
+
+
+@pytest.fixture
 def subscription_permission_group_created_webhook(subscription_webhook):
     return subscription_webhook(
         queries.PERMISSION_GROUP_CREATED,

--- a/saleor/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/webhook/tests/subscription_webhooks/payloads.py
@@ -304,6 +304,22 @@ def generate_page_type_payload(page_type, app):
     }
 
 
+def generate_customer_type_payload(customer_type, app):
+    customer_type_id = graphene.Node.to_global_id("CustomerType", customer_type.pk)
+    return {
+        "recipient": {
+            "id": graphene.Node.to_global_id("App", app.pk),
+            "name": app.name,
+        },
+        "customerType": {
+            "id": customer_type_id,
+            "name": customer_type.name,
+            "slug": customer_type.slug,
+            "isDefault": customer_type.is_default,
+        },
+    }
+
+
 def generate_permission_group_payload(group, app):
     return {
         "recipient": {

--- a/saleor/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -2283,6 +2283,63 @@ PAGE_TYPE_DELETED = (
 """
 )
 
+CUSTOMER_TYPE_CREATED = (
+    fragments.CUSTOMER_TYPE_DETAILS
+    + fragments.RECIPIENT_APP_DETAILS
+    + """
+    subscription{
+      event{
+        recipient{
+          ...Recipient
+        }
+        ...on CustomerTypeCreated{
+          customerType{
+            ...CustomerTypeDetails
+          }
+        }
+      }
+    }
+"""
+)
+
+CUSTOMER_TYPE_UPDATED = (
+    fragments.CUSTOMER_TYPE_DETAILS
+    + fragments.RECIPIENT_APP_DETAILS
+    + """
+    subscription{
+      event{
+        recipient{
+          ...Recipient
+        }
+        ...on CustomerTypeUpdated{
+          customerType{
+            ...CustomerTypeDetails
+          }
+        }
+      }
+    }
+"""
+)
+
+CUSTOMER_TYPE_DELETED = (
+    fragments.CUSTOMER_TYPE_DETAILS
+    + fragments.RECIPIENT_APP_DETAILS
+    + """
+    subscription{
+      event{
+        recipient{
+          ...Recipient
+        }
+        ...on CustomerTypeDeleted{
+          customerType{
+            ...CustomerTypeDetails
+          }
+        }
+      }
+    }
+"""
+)
+
 PERMISSION_GROUP_CREATED = (
     fragments.PERMISSION_GROUP_DETAILS
     + fragments.RECIPIENT_APP_DETAILS

--- a/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -34,6 +34,7 @@ from .payloads import (
     generate_category_payload,
     generate_collection_payload,
     generate_customer_payload,
+    generate_customer_type_payload,
     generate_export_payload,
     generate_fulfillment_payload,
     generate_gift_card_payload,
@@ -2572,6 +2573,73 @@ def test_page_type_deleted(page_type, subscription_page_type_deleted_webhook):
 
     # then
     assert deliveries[0].payload.get_payload() == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_customer_type_created(
+    customer_type, subscription_customer_type_created_webhook
+):
+    # given
+    webhooks = [subscription_customer_type_created_webhook]
+    event_type = WebhookEventAsyncType.CUSTOMER_TYPE_CREATED
+    expected_payload = generate_customer_type_payload(
+        customer_type, subscription_customer_type_created_webhook.app
+    )
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, customer_type, webhooks
+    )
+
+    # then
+    assert json.loads(deliveries[0].payload.get_payload()) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_customer_type_updated(
+    customer_type, subscription_customer_type_updated_webhook
+):
+    # given
+    webhooks = [subscription_customer_type_updated_webhook]
+    event_type = WebhookEventAsyncType.CUSTOMER_TYPE_UPDATED
+    expected_payload = generate_customer_type_payload(
+        customer_type, subscription_customer_type_updated_webhook.app
+    )
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, customer_type, webhooks
+    )
+
+    # then
+    assert json.loads(deliveries[0].payload.get_payload()) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_customer_type_deleted(
+    customer_type, subscription_customer_type_deleted_webhook
+):
+    # given
+    customer_type_id = customer_type.id
+    customer_type.delete()
+    customer_type.id = customer_type_id
+
+    webhooks = [subscription_customer_type_deleted_webhook]
+    event_type = WebhookEventAsyncType.CUSTOMER_TYPE_DELETED
+    expected_payload = generate_customer_type_payload(
+        customer_type, subscription_customer_type_deleted_webhook.app
+    )
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, customer_type, webhooks
+    )
+
+    # then
+    assert json.loads(deliveries[0].payload.get_payload()) == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
 


### PR DESCRIPTION
Adds GraphQL code for managing Customer Types:
- `customerType` and `customerTypes` queries with filtering, readable by authenticated staff user or an app,
- `customerTypeCreate`,`customerTypeUpdate`, `customerTypeDelete` mutations, require `MANAGE_CUSTOMER_TYPES_AND_ATTRIBUTES` permission, only one customer type can be default,
- `User.customerType` field, readable by the owner (user) or staff/app with `MANAGE_USERS` permission),
- default customer type gets assigned to newly created user,
- new async webhook events `CUSTOMER_TYPE_CREATED/UPDATED/DELETED`