### PR TITLE
ci: only run migration-tasks check when relevant paths change

### DIFF
--- a/.github/workflows/check-migration-tasks.yml
+++ b/.github/workflows/check-migration-tasks.yml
@@ -3,6 +3,10 @@ name: Check Migration Tasks Configuration
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+    paths:
+      - "**/migrations/tasks/**"
+      - "saleor/celeryconf.py"
+      - .github/workflows/check-migration-tasks.yml
 
 permissions: {}
 


### PR DESCRIPTION
Add a paths filter to the Check Migration Tasks Configuration workflow so it only triggers when a migration task file, celeryconf.py, or the workflow itself changes, instead of on every pull request.
