### PR TITLE
Fix KeyError when order line references a nonexistent variant

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -49,7 +49,12 @@ from ..utils import (
     validate_variant_channel_listings,
 )
 from . import draft_order_cleaner
-from .utils import ShippingMethodUpdateMixin, get_variant_rule_info_map, save_addresses
+from .utils import (
+    ShippingMethodUpdateMixin,
+    get_variant_rule_info_map,
+    save_addresses,
+    validate_variants_available,
+)
 
 
 class OrderLineInput(BaseInputObjectType):
@@ -326,6 +331,9 @@ class DraftOrderCreate(
             [line.get("variant_id") for line in lines], ProductVariant, "variant_id"
         )
         variants_data = get_variant_rule_info_map(variant_pks, channel.id)
+        validate_variants_available(
+            [line.get("variant_id") for line in lines], variants_data
+        )
         variants = [data.variant for data in variants_data.values()]
         validate_product_is_published_in_channel(variants, channel)
         validate_variant_channel_listings(variants, channel)

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -42,6 +42,7 @@ from .utils import (
     VariantData,
     call_event_by_order_status,
     get_variant_rule_info_map,
+    validate_variants_available,
 )
 
 
@@ -188,6 +189,9 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         )
         variants_rule_map = get_variant_rule_info_map(
             variant_pks, order.channel_id, order.language_code
+        )
+        validate_variants_available(
+            [line["variant_id"] for line in input], variants_rule_map
         )
 
         lines_to_add = cls.validate_lines(

--- a/saleor/graphql/order/mutations/utils.py
+++ b/saleor/graphql/order/mutations/utils.py
@@ -321,6 +321,27 @@ def get_variant_rule_info_map(
     return variant_id_to_variant_and_rules_info_map
 
 
+def validate_variants_available(variant_ids, variants_data, field="lines"):
+    """Raise NOT_FOUND for requested variant ids missing from the resolved map.
+
+    ``get_variant_rule_info_map`` only returns entries for variants that exist,
+    so a missing key means the variant does not exist (e.g. it was deleted).
+    """
+    missing_ids = [
+        variant_id for variant_id in variant_ids if variant_id not in variants_data
+    ]
+    if missing_ids:
+        raise ValidationError(
+            {
+                field: ValidationError(
+                    "Could not resolve to a variant with the provided id.",
+                    code=OrderErrorCode.NOT_FOUND.value,
+                    params={"variants": missing_ids},
+                )
+            }
+        )
+
+
 def save_addresses(instance: models.Order, cleaned_input: dict) -> list[str]:
     update_fields = []
     shipping_address = cleaned_input.get("shipping_address")

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -2100,6 +2100,41 @@ def test_draft_order_create_with_negative_quantity_line(
     assert error["field"] == "quantity"
 
 
+def test_draft_order_create_with_nonexistent_variant(
+    staff_api_client,
+    permission_group_manage_orders,
+    customer_user,
+    channel_USD,
+):
+    # given a variant id that does not resolve to an existing variant
+    query = DRAFT_ORDER_CREATE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+    nonexistent_variant_id = graphene.Node.to_global_id("ProductVariant", -1)
+    variant_list = [{"variantId": nonexistent_variant_id, "quantity": 1}]
+    variables = {
+        "input": {
+            "user": user_id,
+            "channelId": channel_id,
+            "lines": variant_list,
+        }
+    }
+
+    # when the draft order is created
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then a NOT_FOUND error is returned instead of an unhandled KeyError
+    content = get_graphql_content(response)
+    errors = content["data"]["draftOrderCreate"]["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["code"] == OrderErrorCode.NOT_FOUND.name
+    assert error["field"] == "lines"
+    assert error["variants"] == [nonexistent_variant_id]
+
+
 def test_draft_order_create_with_channel_with_unpublished_product(
     staff_api_client,
     permission_group_manage_orders,

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -920,6 +920,38 @@ def test_order_lines_create_with_variant_not_assigned_to_channel(
     draft_order_update_webhook_mock.assert_not_called()
 
 
+def test_order_lines_create_with_nonexistent_variant(
+    order_with_lines,
+    staff_api_client,
+    permission_group_manage_orders,
+):
+    # given a variant id that does not resolve to an existing variant
+    query = ORDER_LINES_CREATE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = order_with_lines
+    order.status = OrderStatus.DRAFT
+    order.save(update_fields=["status"])
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    nonexistent_variant_id = graphene.Node.to_global_id("ProductVariant", -1)
+    variables = {
+        "orderId": order_id,
+        "variantId": nonexistent_variant_id,
+        "quantity": 1,
+    }
+
+    # when the order line is created
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then a NOT_FOUND error is returned instead of an unhandled KeyError
+    content = get_graphql_content(response)
+    errors = content["data"]["orderLinesCreate"]["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["code"] == OrderErrorCode.NOT_FOUND.name
+    assert error["field"] == "lines"
+    assert error["variants"] == [nonexistent_variant_id]
+
+
 @patch("saleor.warehouse.management.trigger_product_variant_out_of_stock")
 @pytest.mark.parametrize("status", [OrderStatus.DRAFT, OrderStatus.UNCONFIRMED])
 def test_order_lines_create_without_sku(


### PR DESCRIPTION
draftOrderCreate and orderLinesCreate indexed the resolved variant map by the requested global id without checking existence. When a variantId pointed to a variant that no longer exists (e.g. deleted), the lookup raised an unhandled KeyError logged as "A query failed unexpectedly".

Add a shared validate_variants_available helper that raises a proper NOT_FOUND ValidationError listing the missing variant ids, and call it in both mutations after building the variant rule map.

Fixes SALEOR-CORE-89M

PORT https://github.com/saleor/saleor/pull/19531
