### PR TITLE
tests: add missing test for old_id when fetching orders

### DIFF
--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -1856,6 +1856,40 @@ def test_query_order_fields_order_with_old_id_staff_with_perm(
     assert content["data"]["order"]["userEmail"] == order.user_email
 
 
+def test_query_order_fields_order_with_old_id_and_anonymous_request(
+    order, app_api_client, permission_manage_orders
+):
+    # given
+    order.user = None
+    order.use_old_id = True
+    order.save(update_fields=["use_old_id", "user_id"])
+
+    variables = {"id": graphene.Node.to_global_id("Order", order.id)}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_ORDER_FIELDS_BY_ID,
+        variables,
+        permissions=(permission_manage_orders,),
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["order"]
+    assert (
+        content["data"]["order"]["billingAddress"]["streetAddress1"]
+        == order.billing_address.street_address_1[0] + "........"
+    )
+    assert (
+        content["data"]["order"]["shippingAddress"]["streetAddress1"]
+        == order.shipping_address.street_address_1[0] + "........"
+    )
+    assert (
+        content["data"]["order"]["userEmail"] == order.user_email[0] + "...@example.com"
+    )
+
+
 def test_query_order_fields_by_old_id_app_no_perm(order, app_api_client):
     """Test that old order IDs require proper app permissions to access sensitive fields."""
     # given


### PR DESCRIPTION
Adds a test case for CVE-2026-24136 which was voluntarily temporarily omitted.

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
