### PR TITLE
Add customer attribute values on customers

### DIFF
--- a/saleor/account/search.py
+++ b/saleor/account/search.py
@@ -41,6 +41,10 @@ def generate_user_search_vector_value(
     attach_addresses_data: bool = True,
     already_prefetched: bool = False,
 ) -> list[NoValidationSearchVector]:
+    # Customer attribute values are deliberately not indexed here - customers
+    # can be filtered with `where: {attributes: ...}`, but the free-text
+    # `search` does not match attribute values. Indexing them would require
+    # marking users as search-dirty on every attribute value write.
     search_vectors = [
         NoValidationSearchVector(
             Value(user.first_name),

--- a/saleor/account/tests/fixtures/customer_type.py
+++ b/saleor/account/tests/fixtures/customer_type.py
@@ -2,12 +2,31 @@ import pytest
 
 from ...models import CustomerType
 
-__all__ = ["customer_type", "default_customer_type"]
+__all__ = [
+    "customer_type",
+    "customer_type_with_attributes",
+    "default_customer_type",
+]
 
 
 @pytest.fixture
 def customer_type(db):
     return CustomerType.objects.create(name="B2B", slug="b2b")
+
+
+@pytest.fixture
+def customer_type_with_attributes(
+    customer_type,
+    loyalty_customer_attribute,
+    description_customer_attribute,
+    hidden_customer_attribute,
+):
+    customer_type.customer_attributes.add(
+        loyalty_customer_attribute,
+        description_customer_attribute,
+        hidden_customer_attribute,
+    )
+    return customer_type
 
 
 @pytest.fixture

--- a/saleor/attribute/tests/fixtures/attribute.py
+++ b/saleor/attribute/tests/fixtures/attribute.py
@@ -917,6 +917,16 @@ def segment_customer_attribute(db):
 
 
 @pytest.fixture
+def description_customer_attribute(db):
+    return Attribute.objects.create(
+        slug="description",
+        name="Description",
+        type=AttributeType.CUSTOMER_TYPE,
+        input_type=AttributeInputType.PLAIN_TEXT,
+    )
+
+
+@pytest.fixture
 def hidden_customer_attribute(db):
     return Attribute.objects.create(
         slug="internal-score",

--- a/saleor/attribute/utils.py
+++ b/saleor/attribute/utils.py
@@ -2,18 +2,20 @@ from collections import defaultdict
 
 from django.db.models import Exists, OuterRef, Q
 
+from ..account.models import User
 from ..page.models import Page
 from ..product.models import Product, ProductVariant
 from .models import (
     AssignedPageAttributeValue,
     AssignedProductAttributeValue,
+    AssignedUserAttributeValue,
     AssignedVariantAttribute,
     AssignedVariantAttributeValue,
     AttributeValue,
     AttributeVariant,
 )
 
-T_INSTANCE = Product | ProductVariant | Page
+T_INSTANCE = Product | ProductVariant | Page | User
 
 
 instance_to_function_variables_mapping = {
@@ -26,6 +28,7 @@ instance_to_function_variables_mapping = {
         "variant",
     ),
     "Page": (AssignedPageAttributeValue, "page"),
+    "User": (AssignedUserAttributeValue, "user"),
 }
 
 

--- a/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
@@ -9,6 +9,7 @@ from graphene.utils.str_converters import to_camel_case
 from ....account import models
 from ....account.events import CustomerEvents
 from ....account.search import update_user_search_vector
+from ....account.utils import get_default_customer_type
 from ....checkout import AddressType
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils import metadata_manager
@@ -18,6 +19,7 @@ from ....order.utils import match_orders_with_new_user
 from ....permission.enums import AccountPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
+from ...attribute.utils.attribute_assignment import AttributeAssignmentMixin
 from ...core.doc_category import DOC_CATEGORY_USERS
 from ...core.enums import CustomerBulkUpdateErrorCode, ErrorPolicyEnum
 from ...core.mutations import BaseMutation, DeprecatedModelMutation
@@ -37,9 +39,10 @@ from ..i18n import I18nMixin
 from ..mutations.base import (
     BILLING_ADDRESS_FIELD,
     SHIPPING_ADDRESS_FIELD,
+    BaseCustomerCreate,
     CustomerInput,
 )
-from ..types import User
+from ..types import CustomerType, User
 
 
 class CustomerBulkResult(BaseObjectType):
@@ -252,10 +255,23 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
             billing_address_data = customer_input["input"].pop(
                 BILLING_ADDRESS_FIELD, None
             )
+            customer_type_id = customer_input["input"].pop("customer_type", None)
 
             customer_input["input"] = DeprecatedModelMutation.clean_input(
                 info, None, customer_input["input"], input_cls=CustomerInput
             )
+
+            if customer_type_id:
+                try:
+                    customer_input["input"]["customer_type"] = cls.get_node_or_error(
+                        info,
+                        customer_type_id,
+                        field="customer_type",
+                        only_type=CustomerType,
+                    )
+                except ValidationError as exc:
+                    cls.format_errors(index, exc, index_error_map)
+                    base_error_count += 1
 
             new_external_ref = customer_input["input"].get("external_reference")
 
@@ -394,6 +410,7 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
             data = cleaned_input["input"]
             shipping_address_input = data.pop(SHIPPING_ADDRESS_FIELD, None)
             billing_address_input = data.pop(BILLING_ADDRESS_FIELD, None)
+            attributes_input = data.pop("attributes", None)
             metadata_list: list[MetadataInput] = data.pop("metadata", None)
             private_metadata_list: list[MetadataInput] = data.pop(
                 "private_metadata", None
@@ -413,6 +430,22 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
                     old_instance = filtered_customers[0]
                     new_instance = cls.construct_instance(deepcopy(old_instance), data)
                     new_instance.full_clean(exclude=["password"])
+
+                    cleaned_attributes = None
+                    if attributes_input:
+                        # Validate the values against the customer type the
+                        # user ends up with.
+                        customer_type = (
+                            new_instance.customer_type
+                            if new_instance.customer_type_id
+                            else get_default_customer_type()
+                        )
+                        try:
+                            cleaned_attributes = BaseCustomerCreate.clean_attributes(
+                                attributes_input, customer_type, creation=False
+                            )
+                        except ValidationError as e:
+                            raise ValidationError({"attributes": e}) from e
 
                     if shipping_address_input:
                         shipping_address = cls.update_address(
@@ -459,6 +492,7 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
                             "instance": new_instance,
                             "old_instance": old_instance,
                             "errors": index_error_map[index],
+                            "attributes": cleaned_attributes,
                             SHIPPING_ADDRESS_FIELD: shipping_address,
                             BILLING_ADDRESS_FIELD: billing_address,
                         }
@@ -550,11 +584,19 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
                 "note",
                 "language_code",
                 "external_reference",
+                "customer_type",
                 "updated_at",
                 "metadata",
                 "private_metadata",
             ],
         )
+
+        for customer_data in instances_data_with_errors_list:
+            customer = customer_data["instance"]
+            if not customer:
+                continue
+            if attributes := customer_data.get("attributes"):
+                AttributeAssignmentMixin.save(customer, attributes)
 
         for customer in customers_to_update:
             if customer in customer_instance_new_addresses_map:
@@ -578,7 +620,10 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
         return customers_to_update, old_instances
 
     @classmethod
-    def post_save_actions(cls, info, manager, instances, old_instances):
+    def post_save_actions(
+        cls, info, manager, instances, old_instances, user_pks_with_attributes=None
+    ):
+        user_pks_with_attributes = user_pks_with_attributes or set()
         customer_events = []
         app = get_app_promise(info.context).get()
         site = get_site_promise(info.context).get()
@@ -671,6 +716,10 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
                 or old_instance.default_shipping_address_id
                 != updated_instance.default_shipping_address_id
             )
+            customer_type_changed = (
+                old_instance.customer_type_id != updated_instance.customer_type_id
+            )
+            attributes_updated = updated_instance.pk in user_pks_with_attributes
             instance_modified = (
                 has_new_name
                 or has_new_email
@@ -681,6 +730,8 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
                 or note_changed
                 or language_code_changed
                 or external_reference_changed
+                or customer_type_changed
+                or attributes_updated
             )
             if instance_modified or (metadata_update and use_legacy_webhooks_emission):
                 cls.call_event(
@@ -745,6 +796,13 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
         # prepare and return data
         results = cls.get_results(instances_data_with_errors_list)
 
-        cls.post_save_actions(info, manager, updated_customers, old_instances)
+        user_pks_with_attributes = {
+            item["instance"].pk
+            for item in instances_data_with_errors_list
+            if item.get("instance") and item.get("attributes")
+        }
+        cls.post_save_actions(
+            info, manager, updated_customers, old_instances, user_pks_with_attributes
+        )
 
         return CustomerBulkUpdate(count=len(updated_customers), results=results)

--- a/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
@@ -367,7 +367,11 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
                 )
             lookup |= single_customer_lookup
 
-        customers = models.User.objects.customers().filter(lookup)
+        customers = (
+            models.User.objects.customers()
+            .filter(lookup)
+            .select_related("customer_type")
+        )
         return list(customers)
 
     @classmethod
@@ -397,6 +401,7 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
     def update_customers(cls, info, cleaned_inputs_map, index_error_map):
         instances_data_and_errors_list: list = []
         customers_list = cls.get_customers(cleaned_inputs_map)
+        default_customer_type = None
 
         for index, cleaned_input in cleaned_inputs_map.items():
             if not cleaned_input:
@@ -435,11 +440,13 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
                     if attributes_input:
                         # Validate the values against the customer type the
                         # user ends up with.
-                        customer_type = (
-                            new_instance.customer_type
-                            if new_instance.customer_type_id
-                            else get_default_customer_type()
-                        )
+                        if new_instance.customer_type_id:
+                            customer_type = new_instance.customer_type
+                        else:
+                            if default_customer_type is None:
+                                default_customer_type = get_default_customer_type()
+                            customer_type = default_customer_type
+
                         try:
                             cleaned_attributes = BaseCustomerCreate.clean_attributes(
                                 attributes_input, customer_type, creation=False

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -7,6 +7,7 @@ from ....account import events as account_events
 from ....account import models
 from ....account.error_codes import AccountErrorCode
 from ....account.search import update_user_search_vector
+from ....account.utils import get_default_customer_type
 from ....checkout import AddressType
 from ....core.exceptions import PermissionDenied
 from ....core.utils import metadata_manager
@@ -17,10 +18,12 @@ from ....graphql.utils import get_user_or_app_from_context
 from ....permission.auth_filters import AuthorizationFilters
 from ....permission.enums import AccountPermissions
 from ...account.i18n import I18nMixin
-from ...account.types import Address, AddressInput, User
+from ...account.types import Address, AddressInput, CustomerType, User
 from ...app.dataloaders import get_app_promise
+from ...attribute.types import AttributeValueInput
+from ...attribute.utils.attribute_assignment import AttributeAssignmentMixin
 from ...core import ResolveInfo, SaleorContext
-from ...core.descriptions import DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import ADDED_IN_323, DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_USERS
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import DeprecatedModelMutation, ModelDeleteMutation
@@ -220,6 +223,22 @@ class CustomerInput(UserInput, UserAddressInput):
     is_confirmed = graphene.Boolean(
         required=False, description="User account is confirmed."
     )
+    customer_type = graphene.ID(
+        required=False,
+        description=(
+            "ID of the customer type to assign to the user. If not provided "
+            "when creating a customer, the default customer type is assigned."
+            + ADDED_IN_323
+        ),
+    )
+    attributes = NonNullList(
+        AttributeValueInput,
+        required=False,
+        description=(
+            "List of attribute values to assign to the user. The attributes "
+            "must belong to the customer type the user ends up with." + ADDED_IN_323
+        ),
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_USERS
@@ -264,10 +283,34 @@ class BaseCustomerCreate(DeprecatedModelMutation, I18nMixin):
         abstract = True
 
     @classmethod
+    def clean_attributes(
+        cls,
+        attributes: list[dict],
+        customer_type: models.CustomerType,
+        creation: bool,
+    ):
+        attributes_qs = customer_type.customer_attributes.all()
+        return AttributeAssignmentMixin.clean_input(
+            attributes,
+            attributes_qs,
+            creation=creation,
+            error_class=AccountErrorCode,
+        )
+
+    @classmethod
     def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
         shipping_address_data = data.pop(SHIPPING_ADDRESS_FIELD, None)
         billing_address_data = data.pop(BILLING_ADDRESS_FIELD, None)
+        customer_type_id = data.pop("customer_type", None)
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
+
+        if customer_type_id:
+            cleaned_input["customer_type"] = cls.get_node_or_error(
+                info,
+                customer_type_id,
+                field="customer_type",
+                only_type=CustomerType,
+            )
 
         if shipping_address_data:
             shipping_address_metadata: list[MetadataInput] = shipping_address_data.pop(
@@ -337,6 +380,27 @@ class BaseCustomerCreate(DeprecatedModelMutation, I18nMixin):
         # The confirmation will take place when the user sets the password.
         if not instance.id:
             cleaned_input["is_confirmed"] = False
+
+        attributes = cleaned_input.get("attributes")
+        if attributes:
+            # The customer type from the input takes precedence over the
+            # current one, so the values are validated against the type the
+            # user ends up with.
+            # TODO: when the customer type changes, values of attributes that
+            # are not part of the new type persist in the database and are only
+            # hidden from the API. Migrating or pruning those values is left
+            # for a future iteration.
+            customer_type = cleaned_input.get("customer_type")
+            if customer_type is None and instance.customer_type_id:
+                customer_type = instance.customer_type
+            if customer_type is None:
+                customer_type = get_default_customer_type()
+            try:
+                cleaned_input["attributes"] = cls.clean_attributes(
+                    attributes, customer_type, creation=instance.pk is None
+                )
+            except ValidationError as e:
+                raise ValidationError({"attributes": e}) from e
 
         return cleaned_input
 

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -15,6 +15,7 @@ from .....permission.enums import AccountPermissions
 from .....plugins.manager import PluginsManager
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.types import User
+from ....attribute.utils.attribute_assignment import AttributeAssignmentMixin
 from ....channel.utils import clean_channel, validate_channel
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
@@ -113,6 +114,9 @@ class CustomerCreate(BaseCustomerCreate):
             instance.customer_type = get_default_customer_type()
 
         cls._save(instance)
+
+        if attributes := cleaned_input.get("attributes"):
+            AttributeAssignmentMixin.save(instance, attributes)
 
         if addresses_to_set_on_user:
             instance.addresses.set(addresses_to_set_on_user)

--- a/saleor/graphql/account/mutations/staff/customer_update.py
+++ b/saleor/graphql/account/mutations/staff/customer_update.py
@@ -15,6 +15,7 @@ from .....permission.enums import AccountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.types import User
 from ....app.dataloaders import get_app_promise
+from ....attribute.utils.attribute_assignment import AttributeAssignmentMixin
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import ModelWithExtRefMutation
@@ -171,18 +172,29 @@ class CustomerUpdate(BaseCustomerCreate, ModelWithExtRefMutation):
             )
             cls._save_m2m(info, instance, cleaned_input)
 
+            attributes_modified = False
+            if attributes := cleaned_input.get("attributes"):
+                AttributeAssignmentMixin.save(instance, attributes)
+                attributes_modified = True
+
             cls.generate_events(
                 info, instance, instance_tracker, non_metadata_modified_fields
             )
 
-        if non_metadata_modified_fields or metadata_modified_fields:
+        if (
+            non_metadata_modified_fields
+            or metadata_modified_fields
+            or attributes_modified
+        ):
             site = get_site_promise(info.context).get()
             use_legacy_webhooks_emission = (
                 site.settings.use_legacy_update_webhook_emission
             )
             manager = get_plugin_manager_promise(info.context).get()
-            if non_metadata_modified_fields or (
-                metadata_modified_fields and use_legacy_webhooks_emission
+            if (
+                non_metadata_modified_fields
+                or attributes_modified
+                or (metadata_modified_fields and use_legacy_webhooks_emission)
             ):
                 cls.call_event(manager.customer_updated, instance)
 

--- a/saleor/graphql/account/mutations/staff/utils.py
+++ b/saleor/graphql/account/mutations/staff/utils.py
@@ -7,6 +7,7 @@ CUSTOMER_UPDATE_FIELDS = {
     "external_reference",
     "is_confirmed",
     "language_code",
+    "customer_type_id",
     "metadata",
     "private_metadata",
 }

--- a/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
+++ b/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
@@ -6,6 +6,7 @@ import pytest
 from .....account import models
 from .....account.error_codes import CustomerBulkUpdateErrorCode
 from .....account.events import CustomerEvents
+from .....attribute.models import AssignedUserAttributeValue
 from .....giftcard.models import GiftCard
 from .....giftcard.search import update_gift_cards_search_vector
 from ....core.enums import ErrorPolicyEnum
@@ -1143,3 +1144,143 @@ def test_bulk_metadata_and_customer_data_update_sends_both_webhooks(
     # Verify both webhooks were sent
     assert mocked_customer_updated.call_count == 2
     assert mocked_customer_metadata_updated.call_count == 2
+
+
+CUSTOMER_BULK_UPDATE_ATTRIBUTES_MUTATION = """
+    mutation CustomerBulkUpdate($customers: [CustomerBulkUpdateInput!]!){
+        customerBulkUpdate(customers: $customers){
+            results{
+                errors {
+                    path
+                    message
+                    code
+                }
+                customer{
+                    id
+                    customerType {
+                        id
+                    }
+                }
+            }
+            count
+        }
+    }
+"""
+
+
+def test_customers_bulk_update_with_customer_type_and_attributes(
+    staff_api_client,
+    customer_users,
+    permission_manage_users,
+    customer_type_with_attributes,
+    loyalty_customer_attribute,
+    description_customer_attribute,
+    default_customer_type,
+):
+    # given
+    customer = customer_users[0]
+    assert customer.customer_type != customer_type_with_attributes
+    customer_type_id = graphene.Node.to_global_id(
+        "CustomerType", customer_type_with_attributes.pk
+    )
+    value = loyalty_customer_attribute.values.get(slug="gold")
+    description_text = "Bulk-updated customer."
+    customers_input = [
+        {
+            "id": graphene.Node.to_global_id("User", customer.pk),
+            "input": {
+                "customerType": customer_type_id,
+                "attributes": [
+                    {
+                        "id": graphene.Node.to_global_id(
+                            "Attribute", loyalty_customer_attribute.pk
+                        ),
+                        "dropdown": {
+                            "id": graphene.Node.to_global_id("AttributeValue", value.pk)
+                        },
+                    },
+                    {
+                        "id": graphene.Node.to_global_id(
+                            "Attribute", description_customer_attribute.pk
+                        ),
+                        "plainText": description_text,
+                    },
+                ],
+            },
+        }
+    ]
+    variables = {"customers": customers_input}
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_users)
+    response = staff_api_client.post_graphql(
+        CUSTOMER_BULK_UPDATE_ATTRIBUTES_MUTATION, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerBulkUpdate"]
+    assert data["count"] == 1
+    assert not data["results"][0]["errors"]
+    assert data["results"][0]["customer"]["customerType"]["id"] == customer_type_id
+    customer.refresh_from_db()
+    assert customer.customer_type == customer_type_with_attributes
+    assigned_values = AssignedUserAttributeValue.objects.filter(user=customer)
+    assert assigned_values.count() == 2
+    assert (
+        assigned_values.get(value__attribute=loyalty_customer_attribute).value == value
+    )
+    description_value = assigned_values.get(
+        value__attribute=description_customer_attribute
+    ).value
+    assert description_value.plain_text == description_text
+
+
+def test_customers_bulk_update_with_attribute_not_in_customer_type(
+    staff_api_client,
+    customer_users,
+    permission_manage_users,
+    customer_type,
+    loyalty_customer_attribute,
+    default_customer_type,
+):
+    # given: the attribute is not assigned to the customer type from the input
+    customer = customer_users[0]
+    assert not customer_type.customer_attributes.filter(
+        pk=loyalty_customer_attribute.pk
+    ).exists()
+    customers_input = [
+        {
+            "id": graphene.Node.to_global_id("User", customer.pk),
+            "input": {
+                "customerType": graphene.Node.to_global_id(
+                    "CustomerType", customer_type.pk
+                ),
+                "attributes": [
+                    {
+                        "id": graphene.Node.to_global_id(
+                            "Attribute", loyalty_customer_attribute.pk
+                        ),
+                        "dropdown": {"value": "gold"},
+                    }
+                ],
+            },
+        }
+    ]
+    variables = {"customers": customers_input}
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_users)
+    response = staff_api_client.post_graphql(
+        CUSTOMER_BULK_UPDATE_ATTRIBUTES_MUTATION, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerBulkUpdate"]
+    assert data["count"] == 0
+    errors = data["results"][0]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["path"] == "input.attributes"
+    assert errors[0]["code"] == CustomerBulkUpdateErrorCode.NOT_FOUND.name
+    assert not AssignedUserAttributeValue.objects.filter(user=customer).exists()

--- a/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
+++ b/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
@@ -1284,3 +1284,49 @@ def test_customers_bulk_update_with_attribute_not_in_customer_type(
     assert errors[0]["path"] == "input.attributes"
     assert errors[0]["code"] == CustomerBulkUpdateErrorCode.NOT_FOUND.name
     assert not AssignedUserAttributeValue.objects.filter(user=customer).exists()
+
+
+def test_customers_bulk_update_with_invalid_customer_type_id(
+    staff_api_client,
+    customer_users,
+    permission_manage_users,
+    default_customer_type,
+):
+    # given
+    customer = customer_users[0]
+    original_first_name = customer.first_name
+    new_first_name = "BulkUpdatedName"
+    assert original_first_name != new_first_name
+    invalid_customer_type_id = graphene.Node.to_global_id("PageType", 1)
+    customers_input = [
+        {
+            "id": graphene.Node.to_global_id("User", customer.pk),
+            "input": {
+                "firstName": new_first_name,
+                "customerType": invalid_customer_type_id,
+            },
+        }
+    ]
+    variables = {"customers": customers_input}
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_users)
+    response = staff_api_client.post_graphql(
+        CUSTOMER_BULK_UPDATE_ATTRIBUTES_MUTATION, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerBulkUpdate"]
+    assert data["count"] == 0
+    errors = data["results"][0]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["path"] == "input.customerType"
+    assert errors[0]["code"] == CustomerBulkUpdateErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["message"] == (
+        f"Invalid ID: {invalid_customer_type_id}. "
+        "Expected: CustomerType, received: PageType."
+    )
+    customer.refresh_from_db()
+    assert customer.first_name == original_first_name
+    assert customer.customer_type is None

--- a/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
+++ b/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
@@ -1286,6 +1286,57 @@ def test_customers_bulk_update_with_attribute_not_in_customer_type(
     assert not AssignedUserAttributeValue.objects.filter(user=customer).exists()
 
 
+@patch("saleor.plugins.manager.PluginsManager.customer_updated")
+def test_customers_bulk_update_with_only_attributes_triggers_customer_updated(
+    mocked_customer_updated,
+    staff_api_client,
+    customer_users,
+    permission_manage_users,
+    customer_type_with_attributes,
+    loyalty_customer_attribute,
+    default_customer_type,
+):
+    # given: input carrying only attributes, so no other change can
+    # trigger the customer_updated webhook
+    customer = customer_users[0]
+    customer.customer_type = customer_type_with_attributes
+    customer.save(update_fields=["customer_type"])
+    value = loyalty_customer_attribute.values.get(slug="gold")
+    customers_input = [
+        {
+            "id": graphene.Node.to_global_id("User", customer.pk),
+            "input": {
+                "attributes": [
+                    {
+                        "id": graphene.Node.to_global_id(
+                            "Attribute", loyalty_customer_attribute.pk
+                        ),
+                        "dropdown": {
+                            "id": graphene.Node.to_global_id("AttributeValue", value.pk)
+                        },
+                    }
+                ],
+            },
+        }
+    ]
+    variables = {"customers": customers_input}
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_users)
+    response = staff_api_client.post_graphql(
+        CUSTOMER_BULK_UPDATE_ATTRIBUTES_MUTATION, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerBulkUpdate"]
+    assert data["count"] == 1
+    assert not data["results"][0]["errors"]
+    assigned_values = AssignedUserAttributeValue.objects.filter(user=customer)
+    assert assigned_values.get().value == value
+    mocked_customer_updated.assert_called_once_with(customer, webhooks=ANY)
+
+
 def test_customers_bulk_update_with_invalid_customer_type_id(
     staff_api_client,
     customer_users,

--- a/saleor/graphql/account/tests/mutations/staff/test_customer_create.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_customer_create.py
@@ -1,10 +1,13 @@
 from unittest.mock import ANY, patch
 from urllib.parse import urlencode
 
+import graphene
+
 from ......account import events as account_events
 from ......account.error_codes import AccountErrorCode
 from ......account.models import Address, User
 from ......account.notifications import get_default_user_payload
+from ......attribute.models import AssignedUserAttributeValue
 from ......core.notify import NotifyEventType
 from ......core.tests.utils import get_site_context_payload
 from ......core.utils.url import prepare_url
@@ -615,3 +618,258 @@ def test_create_assigns_default_customer_type(
     assert not content["data"]["customerCreate"]["errors"]
     new_user = User.objects.get(email=email)
     assert new_user.customer_type == default_customer_type
+
+
+CUSTOMER_CREATE_WITH_ATTRIBUTES_MUTATION = """
+    mutation CreateCustomer(
+        $email: String, $customerType: ID, $attributes: [AttributeValueInput!]
+    ) {
+        customerCreate(input: {
+            email: $email,
+            customerType: $customerType,
+            attributes: $attributes
+        }) {
+            errors {
+                field
+                code
+                message
+                attributes
+            }
+            user {
+                id
+                email
+                customerType {
+                    id
+                }
+            }
+        }
+    }
+"""
+
+
+def test_create_with_customer_type_and_attributes(
+    staff_api_client,
+    permission_manage_users,
+    customer_type_with_attributes,
+    loyalty_customer_attribute,
+    description_customer_attribute,
+    default_customer_type,
+):
+    # given
+    email = "attributes@example.com"
+    value = loyalty_customer_attribute.values.get(slug="gold")
+    description_text = "A very important customer."
+    variables = {
+        "email": email,
+        "customerType": graphene.Node.to_global_id(
+            "CustomerType", customer_type_with_attributes.pk
+        ),
+        "attributes": [
+            {
+                "id": graphene.Node.to_global_id(
+                    "Attribute", loyalty_customer_attribute.pk
+                ),
+                "dropdown": {
+                    "id": graphene.Node.to_global_id("AttributeValue", value.pk)
+                },
+            },
+            {
+                "id": graphene.Node.to_global_id(
+                    "Attribute", description_customer_attribute.pk
+                ),
+                "plainText": description_text,
+            },
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_CREATE_WITH_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerCreate"]
+    assert not data["errors"]
+    new_user = User.objects.get(email=email)
+    assert new_user.customer_type == customer_type_with_attributes
+    assert data["user"]["customerType"]["id"] == graphene.Node.to_global_id(
+        "CustomerType", customer_type_with_attributes.pk
+    )
+    assigned_values = AssignedUserAttributeValue.objects.filter(user=new_user)
+    assert assigned_values.count() == 2
+    assert (
+        assigned_values.get(value__attribute=loyalty_customer_attribute).value == value
+    )
+    description_value = assigned_values.get(
+        value__attribute=description_customer_attribute
+    ).value
+    assert description_value.plain_text == description_text
+
+
+def test_create_with_attributes_of_default_customer_type(
+    staff_api_client,
+    permission_manage_users,
+    default_customer_type,
+    loyalty_customer_attribute,
+):
+    # given
+    default_customer_type.customer_attributes.add(loyalty_customer_attribute)
+    email = "default-type-attributes@example.com"
+    value = loyalty_customer_attribute.values.get(slug="silver")
+    variables = {
+        "email": email,
+        "attributes": [
+            {
+                "id": graphene.Node.to_global_id(
+                    "Attribute", loyalty_customer_attribute.pk
+                ),
+                "dropdown": {
+                    "id": graphene.Node.to_global_id("AttributeValue", value.pk)
+                },
+            }
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_CREATE_WITH_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerCreate"]
+    assert not data["errors"]
+    new_user = User.objects.get(email=email)
+    assert new_user.customer_type == default_customer_type
+    assigned_values = AssignedUserAttributeValue.objects.filter(user=new_user)
+    assert assigned_values.count() == 1
+    assert assigned_values.first().value == value
+
+
+def test_create_with_attribute_not_in_customer_type(
+    staff_api_client,
+    permission_manage_users,
+    customer_type,
+    loyalty_customer_attribute,
+    default_customer_type,
+):
+    # given: the attribute is not assigned to the given customer type
+    assert not customer_type.customer_attributes.filter(
+        pk=loyalty_customer_attribute.pk
+    ).exists()
+    email = "wrong-attribute@example.com"
+    attribute_id = graphene.Node.to_global_id(
+        "Attribute", loyalty_customer_attribute.pk
+    )
+    variables = {
+        "email": email,
+        "customerType": graphene.Node.to_global_id("CustomerType", customer_type.pk),
+        "attributes": [{"id": attribute_id, "dropdown": {"value": "gold"}}],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_CREATE_WITH_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerCreate"]
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "attributes"
+    assert error["code"] == AccountErrorCode.NOT_FOUND.name
+    assert f"Could not resolve attributes: ID: {attribute_id}." == error["message"]
+    assert not User.objects.filter(email=email).exists()
+
+
+def test_create_with_missing_required_attribute(
+    staff_api_client,
+    permission_manage_users,
+    customer_type_with_attributes,
+    loyalty_customer_attribute,
+    description_customer_attribute,
+    segment_customer_attribute,
+    default_customer_type,
+):
+    # given
+    loyalty_customer_attribute.value_required = True
+    loyalty_customer_attribute.save(update_fields=["value_required"])
+    customer_type_with_attributes.customer_attributes.add(segment_customer_attribute)
+
+    email = "missing-required@example.com"
+    variables = {
+        "email": email,
+        "customerType": graphene.Node.to_global_id(
+            "CustomerType", customer_type_with_attributes.pk
+        ),
+        "attributes": [
+            {
+                "id": graphene.Node.to_global_id(
+                    "Attribute", segment_customer_attribute.pk
+                ),
+                "dropdown": {"value": "Retail"},
+            },
+            {
+                "id": graphene.Node.to_global_id(
+                    "Attribute", description_customer_attribute.pk
+                ),
+                "plainText": "Provided, but the required attribute is not.",
+            },
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_CREATE_WITH_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerCreate"]
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "attributes"
+    assert error["code"] == AccountErrorCode.REQUIRED.name
+    assert error["attributes"] == [
+        graphene.Node.to_global_id("Attribute", loyalty_customer_attribute.pk)
+    ]
+    assert not User.objects.filter(email=email).exists()
+
+
+def test_create_with_invalid_customer_type_id(
+    staff_api_client,
+    permission_manage_users,
+    default_customer_type,
+):
+    # given: an ID of a different type passed as customerType
+    email = "invalid-type-id@example.com"
+    variables = {
+        "email": email,
+        "customerType": graphene.Node.to_global_id("PageType", 1),
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_CREATE_WITH_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerCreate"]
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "customerType"
+    assert error["code"] == AccountErrorCode.GRAPHQL_ERROR.name
+    assert not User.objects.filter(email=email).exists()

--- a/saleor/graphql/account/tests/mutations/staff/test_customer_update.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_customer_update.py
@@ -5,6 +5,7 @@ import pytest
 
 from ......account import events as account_events
 from ......account.error_codes import AccountErrorCode
+from ......attribute.models import AssignedUserAttributeValue
 from ......giftcard.models import GiftCard
 from ......giftcard.search import update_gift_cards_search_vector
 from .....tests.utils import get_graphql_content
@@ -826,3 +827,214 @@ def test_customer_confirm_assign_gift_cards_and_orders(
 
     order.refresh_from_db()
     assert order.user == customer_user
+
+
+CUSTOMER_UPDATE_ATTRIBUTES_MUTATION = """
+    mutation UpdateCustomer(
+        $id: ID!, $customerType: ID, $attributes: [AttributeValueInput!]
+    ) {
+        customerUpdate(id: $id, input: {
+            customerType: $customerType,
+            attributes: $attributes
+        }) {
+            errors {
+                field
+                code
+                message
+            }
+            user {
+                id
+                customerType {
+                    id
+                }
+            }
+        }
+    }
+"""
+
+
+@patch("saleor.plugins.manager.PluginsManager.customer_updated")
+def test_update_with_attributes_assigns_values(
+    mocked_customer_updated,
+    staff_api_client,
+    permission_manage_users,
+    customer_user,
+    customer_type_with_attributes,
+    loyalty_customer_attribute,
+    description_customer_attribute,
+    default_customer_type,
+):
+    # given
+    customer_user.customer_type = customer_type_with_attributes
+    customer_user.save(update_fields=["customer_type"])
+    value = loyalty_customer_attribute.values.get(slug="gold")
+    description_text = "Long-time customer."
+    variables = {
+        "id": graphene.Node.to_global_id("User", customer_user.id),
+        "attributes": [
+            {
+                "id": graphene.Node.to_global_id(
+                    "Attribute", loyalty_customer_attribute.pk
+                ),
+                "dropdown": {
+                    "id": graphene.Node.to_global_id("AttributeValue", value.pk)
+                },
+            },
+            {
+                "id": graphene.Node.to_global_id(
+                    "Attribute", description_customer_attribute.pk
+                ),
+                "plainText": description_text,
+            },
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_UPDATE_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerUpdate"]
+    assert not data["errors"]
+    assigned_values = AssignedUserAttributeValue.objects.filter(user=customer_user)
+    assert assigned_values.count() == 2
+    assert (
+        assigned_values.get(value__attribute=loyalty_customer_attribute).value == value
+    )
+    description_value = assigned_values.get(
+        value__attribute=description_customer_attribute
+    ).value
+    assert description_value.plain_text == description_text
+    mocked_customer_updated.assert_called_once_with(customer_user)
+
+
+@patch("saleor.plugins.manager.PluginsManager.customer_updated")
+def test_update_changes_customer_type(
+    mocked_customer_updated,
+    staff_api_client,
+    permission_manage_users,
+    customer_user,
+    customer_type,
+    default_customer_type,
+):
+    # given
+    customer_user.customer_type = default_customer_type
+    customer_user.save(update_fields=["customer_type"])
+    customer_type_id = graphene.Node.to_global_id("CustomerType", customer_type.pk)
+    variables = {
+        "id": graphene.Node.to_global_id("User", customer_user.id),
+        "customerType": customer_type_id,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_UPDATE_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerUpdate"]
+    assert not data["errors"]
+    assert data["user"]["customerType"]["id"] == customer_type_id
+    customer_user.refresh_from_db()
+    assert customer_user.customer_type == customer_type
+    mocked_customer_updated.assert_called_once_with(customer_user)
+
+
+def test_update_attributes_validated_against_new_customer_type(
+    staff_api_client,
+    permission_manage_users,
+    customer_user,
+    customer_type,
+    customer_type_with_attributes,
+    loyalty_customer_attribute,
+    description_customer_attribute,
+    default_customer_type,
+):
+    # given: the user's current type has the attributes, but the new type
+    # from the input does not
+    customer_user.customer_type = customer_type_with_attributes
+    customer_user.save(update_fields=["customer_type"])
+    new_customer_type = default_customer_type
+    assert not new_customer_type.customer_attributes.filter(
+        pk__in=[loyalty_customer_attribute.pk, description_customer_attribute.pk]
+    ).exists()
+    attribute_id = graphene.Node.to_global_id(
+        "Attribute", loyalty_customer_attribute.pk
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("User", customer_user.id),
+        "customerType": graphene.Node.to_global_id(
+            "CustomerType", new_customer_type.pk
+        ),
+        "attributes": [
+            {"id": attribute_id, "dropdown": {"value": "gold"}},
+            {
+                "id": graphene.Node.to_global_id(
+                    "Attribute", description_customer_attribute.pk
+                ),
+                "plainText": "A very important customer.",
+            },
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_UPDATE_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["customerUpdate"]
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "attributes"
+    assert error["code"] == AccountErrorCode.NOT_FOUND.name
+    customer_user.refresh_from_db()
+    assert customer_user.customer_type == customer_type_with_attributes
+
+
+def test_update_customer_type_change_keeps_attribute_values(
+    staff_api_client,
+    permission_manage_users,
+    customer_user,
+    customer_type,
+    customer_type_with_attributes,
+    loyalty_customer_attribute,
+    default_customer_type,
+):
+    # given: the user has a value assigned for an attribute of the current type
+    customer_user.customer_type = customer_type_with_attributes
+    customer_user.save(update_fields=["customer_type"])
+    value = loyalty_customer_attribute.values.get(slug="gold")
+    AssignedUserAttributeValue.objects.create(user=customer_user, value=value)
+
+    # when: the type changes to one without that attribute
+    variables = {
+        "id": graphene.Node.to_global_id("User", customer_user.id),
+        "customerType": graphene.Node.to_global_id(
+            "CustomerType", default_customer_type.pk
+        ),
+    }
+    response = staff_api_client.post_graphql(
+        CUSTOMER_UPDATE_ATTRIBUTES_MUTATION,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then: the value persists in the database
+    content = get_graphql_content(response)
+    assert not content["data"]["customerUpdate"]["errors"]
+    customer_user.refresh_from_db()
+    assert customer_user.customer_type == default_customer_type
+    assigned_values = AssignedUserAttributeValue.objects.filter(user=customer_user)
+    assert assigned_values.count() == 1
+    assert assigned_values.first().value == value

--- a/saleor/graphql/account/tests/queries/test_user_assigned_attributes.py
+++ b/saleor/graphql/account/tests/queries/test_user_assigned_attributes.py
@@ -1,0 +1,262 @@
+import graphene
+
+from .....attribute.models import AssignedUserAttributeValue
+from ....tests.utils import assert_no_permission, get_graphql_content
+
+USER_ASSIGNED_ATTRIBUTES_QUERY = """
+    query User($id: ID!) {
+        user(id: $id) {
+            assignedAttributes {
+                attribute {
+                    slug
+                }
+                ... on AssignedSingleChoiceAttribute {
+                    value {
+                        slug
+                    }
+                }
+            }
+        }
+    }
+"""
+
+ME_ASSIGNED_ATTRIBUTES_QUERY = """
+    query Me {
+        me {
+            assignedAttributes {
+                attribute {
+                    slug
+                }
+                ... on AssignedSingleChoiceAttribute {
+                    value {
+                        slug
+                    }
+                }
+            }
+        }
+    }
+"""
+
+USER_ASSIGNED_ATTRIBUTE_BY_SLUG_QUERY = """
+    query User($id: ID!, $slug: String!) {
+        user(id: $id) {
+            assignedAttribute(slug: $slug) {
+                attribute {
+                    slug
+                }
+                ... on AssignedSingleChoiceAttribute {
+                    value {
+                        slug
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def test_assigned_attributes_by_staff_with_manage_users(
+    staff_api_client,
+    permission_manage_users,
+    customer_user,
+    customer_type_with_attributes,
+    loyalty_customer_attribute,
+    description_customer_attribute,
+    hidden_customer_attribute,
+):
+    # given
+    customer_user.customer_type = customer_type_with_attributes
+    customer_user.save(update_fields=["customer_type"])
+    value = loyalty_customer_attribute.values.get(slug="gold")
+    AssignedUserAttributeValue.objects.create(user=customer_user, value=value)
+    variables = {"id": graphene.Node.to_global_id("User", customer_user.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        USER_ASSIGNED_ATTRIBUTES_QUERY,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assigned_attributes = content["data"]["user"]["assignedAttributes"]
+    slugs = {entry["attribute"]["slug"] for entry in assigned_attributes}
+    assert slugs == {
+        loyalty_customer_attribute.slug,
+        description_customer_attribute.slug,
+        hidden_customer_attribute.slug,
+    }
+    loyalty_entry = next(
+        entry
+        for entry in assigned_attributes
+        if entry["attribute"]["slug"] == loyalty_customer_attribute.slug
+    )
+    assert loyalty_entry["value"]["slug"] == value.slug
+
+
+def test_assigned_attributes_by_owner_hides_storefront_invisible(
+    user_api_client,
+    customer_type_with_attributes,
+    loyalty_customer_attribute,
+    description_customer_attribute,
+    hidden_customer_attribute,
+):
+    # given
+    user = user_api_client.user
+    user.customer_type = customer_type_with_attributes
+    user.save(update_fields=["customer_type"])
+    value = loyalty_customer_attribute.values.get(slug="silver")
+    AssignedUserAttributeValue.objects.create(user=user, value=value)
+
+    # when
+    response = user_api_client.post_graphql(ME_ASSIGNED_ATTRIBUTES_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    assigned_attributes = content["data"]["me"]["assignedAttributes"]
+    slugs = {entry["attribute"]["slug"] for entry in assigned_attributes}
+    assert slugs == {
+        loyalty_customer_attribute.slug,
+        description_customer_attribute.slug,
+    }
+    loyalty_entry = next(
+        entry
+        for entry in assigned_attributes
+        if entry["attribute"]["slug"] == loyalty_customer_attribute.slug
+    )
+    assert loyalty_entry["value"]["slug"] == value.slug
+
+
+def test_assigned_attributes_by_staff_without_manage_users(
+    staff_api_client,
+    permission_manage_staff,
+    admin_user,
+):
+    # given: a staff user queries another user without MANAGE_USERS
+    variables = {"id": graphene.Node.to_global_id("User", admin_user.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        USER_ASSIGNED_ATTRIBUTES_QUERY,
+        variables,
+        permissions=[permission_manage_staff],
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_assigned_attributes_fall_back_to_default_customer_type(
+    staff_api_client,
+    permission_manage_users,
+    customer_user,
+    default_customer_type,
+    segment_customer_attribute,
+):
+    # given: the user has no customer type assigned yet
+    default_customer_type.customer_attributes.add(segment_customer_attribute)
+    assert customer_user.customer_type_id is None
+    variables = {"id": graphene.Node.to_global_id("User", customer_user.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        USER_ASSIGNED_ATTRIBUTES_QUERY,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assigned_attributes = content["data"]["user"]["assignedAttributes"]
+    slugs = {entry["attribute"]["slug"] for entry in assigned_attributes}
+    assert slugs == {segment_customer_attribute.slug}
+
+
+def test_assigned_attribute_by_slug_by_staff(
+    staff_api_client,
+    permission_manage_users,
+    customer_user,
+    customer_type_with_attributes,
+    loyalty_customer_attribute,
+):
+    # given
+    customer_user.customer_type = customer_type_with_attributes
+    customer_user.save(update_fields=["customer_type"])
+    value = loyalty_customer_attribute.values.get(slug="gold")
+    AssignedUserAttributeValue.objects.create(user=customer_user, value=value)
+    variables = {
+        "id": graphene.Node.to_global_id("User", customer_user.pk),
+        "slug": loyalty_customer_attribute.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        USER_ASSIGNED_ATTRIBUTE_BY_SLUG_QUERY,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assigned_attribute = content["data"]["user"]["assignedAttribute"]
+    assert assigned_attribute["attribute"]["slug"] == loyalty_customer_attribute.slug
+    assert assigned_attribute["value"]["slug"] == value.slug
+
+
+def test_assigned_attribute_by_slug_hidden_attribute_by_staff(
+    staff_api_client,
+    permission_manage_users,
+    customer_user,
+    customer_type_with_attributes,
+    hidden_customer_attribute,
+):
+    # given
+    customer_user.customer_type = customer_type_with_attributes
+    customer_user.save(update_fields=["customer_type"])
+    variables = {
+        "id": graphene.Node.to_global_id("User", customer_user.pk),
+        "slug": hidden_customer_attribute.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        USER_ASSIGNED_ATTRIBUTE_BY_SLUG_QUERY,
+        variables,
+        permissions=[permission_manage_users],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assigned_attribute = content["data"]["user"]["assignedAttribute"]
+    assert assigned_attribute["attribute"]["slug"] == hidden_customer_attribute.slug
+
+
+def test_assigned_attribute_by_slug_hidden_attribute_by_owner(
+    user_api_client,
+    customer_type_with_attributes,
+    hidden_customer_attribute,
+):
+    # given
+    user = user_api_client.user
+    user.customer_type = customer_type_with_attributes
+    user.save(update_fields=["customer_type"])
+    query = """
+        query Me($slug: String!) {
+            me {
+                assignedAttribute(slug: $slug) {
+                    attribute {
+                        slug
+                    }
+                }
+            }
+        }
+    """
+    variables = {"slug": hidden_customer_attribute.slug}
+
+    # when
+    response = user_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["me"]["assignedAttribute"] is None

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -31,7 +31,12 @@ from ..account.utils import check_is_owner_or_has_one_of_perms
 from ..app.dataloaders import AppByIdLoader, get_app_promise
 from ..app.types import App
 from ..attribute.filters import AttributeWhereInput, filter_attribute_search
-from ..attribute.types import Attribute, AttributeCountableConnection
+from ..attribute.types import (
+    Attribute,
+    AttributeCountableConnection,
+    ObjectWithAttributes,
+)
+from ..attribute.utils.shared import AssignedAttributeData
 from ..channel.dataloaders.by_self import ChannelBySlugLoader
 from ..channel.types import Channel
 from ..checkout.dataloaders import CheckoutByUserAndChannelLoader, CheckoutByUserLoader
@@ -43,6 +48,7 @@ from ..core.connection import (
     create_connection_slice_for_sync_webhook_control_context,
     filter_connection_queryset,
 )
+from ..core.const import DEFAULT_NESTED_LIST_LIMIT
 from ..core.context import (
     ChannelContext,
     ChannelQsContext,
@@ -60,7 +66,7 @@ from ..core.doc_category import DOC_CATEGORY_USERS
 from ..core.enums import LanguageCodeEnum
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import ConnectionField, FilterConnectionField, PermissionsField
-from ..core.scalars import UUID, DateTime
+from ..core.scalars import UUID, DateTime, PositiveInt
 from ..core.tracing import traced_resolver
 from ..core.types import (
     BaseInputObjectType,
@@ -86,6 +92,7 @@ from .dataloaders import (
     AccessibleChannelsByGroupIdLoader,
     AccessibleChannelsByUserIdLoader,
     AddressByIdLoader,
+    BaseCustomerAttributesByCustomerTypeIdLoader,
     CustomerAttributesAllByCustomerTypeIdLoader,
     CustomerAttributesVisibleInStorefrontByCustomerTypeIdLoader,
     CustomerEventsByUserLoader,
@@ -579,6 +586,40 @@ class User(ModelObjectType[models.User]):
             f"{AuthorizationFilters.OWNER.name}." + ADDED_IN_323
         ),
     )
+    assigned_attribute = graphene.Field(
+        "saleor.graphql.attribute.types.AssignedAttribute",
+        slug=graphene.Argument(
+            graphene.String,
+            description="Slug of the attribute",
+            required=True,
+        ),
+        description=(
+            "Get a single attribute assigned to the user by attribute slug. "
+            "The attribute is looked up among the attributes of the user's "
+            "customer type. Requires one of the following permissions: "
+            f"{AccountPermissions.MANAGE_USERS.name}, "
+            f"{AuthorizationFilters.OWNER.name}. The owner can access only "
+            "attributes that are visible in the storefront." + ADDED_IN_323
+        ),
+    )
+    assigned_attributes = NonNullList(
+        "saleor.graphql.attribute.types.AssignedAttribute",
+        required=True,
+        description=(
+            "List of attributes assigned to the user through the user's "
+            "customer type. Requires one of the following permissions: "
+            f"{AccountPermissions.MANAGE_USERS.name}, "
+            f"{AuthorizationFilters.OWNER.name}. The owner can access only "
+            "attributes that are visible in the storefront." + ADDED_IN_323
+        ),
+        limit=PositiveInt(
+            description=(
+                "Maximum number of attributes to return. "
+                f"Default is {DEFAULT_NESTED_LIST_LIMIT}."
+            ),
+            default_value=DEFAULT_NESTED_LIST_LIMIT,
+        ),
+    )
 
     last_login = DateTime(
         description="The date when the user last time log in to the system."
@@ -606,7 +647,7 @@ class User(ModelObjectType[models.User]):
 
     class Meta:
         description = "Represents user data."
-        interfaces = [relay.Node, ObjectWithMetadata]
+        interfaces = [relay.Node, ObjectWithMetadata, ObjectWithAttributes]
         model = get_user_model()
         doc_category = DOC_CATEGORY_USERS
 
@@ -986,6 +1027,82 @@ class User(ModelObjectType[models.User]):
         # no type assigned - present them as having the default one.
         return DefaultCustomerTypeLoader(info.context).load(
             DEFAULT_CUSTOMER_TYPE_LOADER_KEY
+        )
+
+    @staticmethod
+    def _load_customer_type_attributes(root: models.User, info: ResolveInfo, loader):
+        """Load the attributes of the user's customer type.
+
+        Users created before the customer type backfill finishes may still have
+        no type assigned - fall back to the default type's attributes.
+        """
+        if root.customer_type_id:
+            return loader.load(root.customer_type_id)
+        return (
+            DefaultCustomerTypeLoader(info.context)
+            .load(DEFAULT_CUSTOMER_TYPE_LOADER_KEY)
+            .then(lambda customer_type: loader.load(customer_type.pk))
+        )
+
+    @classmethod
+    def resolve_assigned_attributes(
+        cls,
+        root: models.User,
+        info: ResolveInfo,
+        limit: int = DEFAULT_NESTED_LIST_LIMIT,
+    ):
+        requestor = get_user_or_app_from_context(info.context)
+        check_is_owner_or_has_one_of_perms(
+            requestor, root, AccountPermissions.MANAGE_USERS
+        )
+
+        def with_attributes(attributes: list[attribute_models.Attribute]):
+            return [
+                AssignedAttributeData(
+                    attribute=attribute, channel_slug=None, user_id=root.pk
+                )
+                for attribute in attributes[:limit]
+            ]
+
+        loader: BaseCustomerAttributesByCustomerTypeIdLoader
+        if one_of_permissions_or_auth_filter_required(
+            info.context, [AccountPermissions.MANAGE_USERS]
+        ):
+            loader = CustomerAttributesAllByCustomerTypeIdLoader(info.context)
+        else:
+            loader = CustomerAttributesVisibleInStorefrontByCustomerTypeIdLoader(
+                info.context
+            )
+        return cls._load_customer_type_attributes(root, info, loader).then(
+            with_attributes
+        )
+
+    @classmethod
+    def resolve_assigned_attribute(
+        cls, root: models.User, info: ResolveInfo, slug: str
+    ):
+        requestor = get_user_or_app_from_context(info.context)
+        check_is_owner_or_has_one_of_perms(
+            requestor, root, AccountPermissions.MANAGE_USERS
+        )
+        has_manage_users = one_of_permissions_or_auth_filter_required(
+            info.context, [AccountPermissions.MANAGE_USERS]
+        )
+
+        def with_attributes(attributes: list[attribute_models.Attribute]):
+            for attribute in attributes:
+                if attribute.slug != slug:
+                    continue
+                if not has_manage_users and not attribute.visible_in_storefront:
+                    return None
+                return AssignedAttributeData(
+                    attribute=attribute, channel_slug=None, user_id=root.pk
+                )
+            return None
+
+        loader = CustomerAttributesAllByCustomerTypeIdLoader(info.context)
+        return cls._load_customer_type_attributes(root, info, loader).then(
+            with_attributes
         )
 
 

--- a/saleor/graphql/attribute/dataloaders/assigned_attributes.py
+++ b/saleor/graphql/attribute/dataloaders/assigned_attributes.py
@@ -7,6 +7,7 @@ from django.db.models.query import QuerySet
 from promise import Promise
 
 from ....attribute.models import Attribute, AttributeValue
+from ....attribute.models.customer import AssignedUserAttributeValue
 from ....attribute.models.page import AssignedPageAttributeValue, AttributePage
 from ....attribute.models.product import AssignedProductAttributeValue, AttributeProduct
 from ....attribute.models.product_variant import (
@@ -30,6 +31,7 @@ type PRODUCT_ID = int
 type PRODUCT_TYPE_ID = int
 type PAGE_ID = int
 type VARIANT_ID = int
+type USER_ID = int
 type ATTRIBUTE_ID = int
 type ATTRIBUTE_SLUG = str
 type LIMIT = int | None
@@ -645,6 +647,73 @@ class AttributeValuesByPageIdAndAttributeIdAndLimitLoader(
                     if not attr_val:
                         continue
                     response_data[(page_id, attribute_id, limit)].append(attr_val)
+            return [response_data.get(key, []) for key in keys]
+
+        return (
+            AttributeValueByIdLoader(self.context)
+            .load_many(attribute_value_ids_to_fetch)
+            .then(with_attribute_values)
+        )
+
+
+class AttributeValuesByUserIdAndAttributeIdAndLimitLoader(
+    DataLoader[tuple[USER_ID, ATTRIBUTE_ID, LIMIT], list[AttributeValue]]
+):
+    context_key = "attribute_values_by_user_and_attribute"
+
+    def batch_load(self, keys: Iterable[tuple[USER_ID, ATTRIBUTE_ID, LIMIT]]):
+        limit_map = defaultdict(list)
+        for user_id, attribute_id, limit in keys:
+            limit_map[limit].append((user_id, attribute_id))
+
+        attribute_value_id_to_fetch_map: dict[
+            tuple[USER_ID, ATTRIBUTE_ID, LIMIT], list[int]
+        ] = defaultdict(list)
+
+        for limit, values in limit_map.items():
+            user_ids = [val[0] for val in values]
+            attribute_ids = [val[1] for val in values]
+
+            assigned_attribute_values = AssignedUserAttributeValue.objects.using(
+                self.database_connection_name
+            ).annotate(attribute_id=F("value__attribute_id"))
+            if limit is not None:
+                assigned_attribute_values = assigned_attribute_values.annotate(
+                    row_num=Window(
+                        expression=RowNumber(),
+                        partition_by=[F("attribute_id"), F("user_id")],
+                        order_by=["sort_order", "pk"],
+                    )
+                ).filter(row_num__lte=limit)
+            assigned_attribute_values = assigned_attribute_values.filter(
+                attribute_id__in=attribute_ids,
+                user_id__in=user_ids,
+            ).values_list("user_id", "value_id", "attribute_id")
+
+            for user_id, value_id, attribute_id in assigned_attribute_values:
+                attribute_value_id_to_fetch_map[(user_id, attribute_id, limit)].append(
+                    value_id
+                )
+
+        attribute_value_ids_to_fetch = set()
+        for id_list in attribute_value_id_to_fetch_map.values():
+            attribute_value_ids_to_fetch.update(id_list)
+
+        def with_attribute_values(attribute_values: list[AttributeValue]):
+            attribute_value_map = {av.id: av for av in attribute_values}
+            response_data: defaultdict[
+                tuple[USER_ID, ATTRIBUTE_ID, LIMIT], list[AttributeValue]
+            ] = defaultdict(list)
+            for (
+                user_id,
+                attribute_id,
+                limit,
+            ), value_ids in attribute_value_id_to_fetch_map.items():
+                for value_id in value_ids:
+                    attr_val = attribute_value_map.get(value_id)
+                    if not attr_val:
+                        continue
+                    response_data[(user_id, attribute_id, limit)].append(attr_val)
             return [response_data.get(key, []) for key in keys]
 
         return (

--- a/saleor/graphql/attribute/tests/test_utils.py
+++ b/saleor/graphql/attribute/tests/test_utils.py
@@ -10,6 +10,7 @@ from graphql import GraphQLError
 from ....attribute import AttributeInputType
 from ....attribute.models import AttributeValue
 from ....attribute.utils import associate_attribute_values_to_instance
+from ....page.error_codes import PageErrorCode
 from ....product.error_codes import ProductErrorCode
 from ..enums import AttributeValueBulkActionEnum
 from ..shared_filters import validate_attribute_value_input
@@ -55,7 +56,6 @@ def test_clean_input_for_product(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -87,7 +87,6 @@ def test_clean_attribute_input_for_product_no_values_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -132,7 +131,6 @@ def test_clean_attribute_input_for_product_too_many_values_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -176,7 +174,6 @@ def test_clean_attribute_input_for_product_empty_values_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -214,7 +211,6 @@ def test_clean_attribute_input_for_product_lack_of_required_attribute(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=True,
         )
 
@@ -258,7 +254,6 @@ def test_clean_attribute_input_for_product_creation_multiple_errors(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -307,7 +302,7 @@ def test_clean_attribute_input_for_page(
     AttributeAssignmentMixin.clean_input(
         input_data,
         page_type.page_attributes.all(),
-        is_page_attributes=True,
+        error_class=PageErrorCode,
         creation=creation,
     )
 
@@ -339,7 +334,7 @@ def test_clean_attribute_input_for_page_no_values_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             page_type.page_attributes.all(),
-            is_page_attributes=True,
+            error_class=PageErrorCode,
             creation=creation,
         )
 
@@ -384,7 +379,7 @@ def test_clean_attribute_input_for_page_too_many_values_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             page_type.page_attributes.all(),
-            is_page_attributes=True,
+            error_class=PageErrorCode,
             creation=creation,
         )
 
@@ -428,7 +423,7 @@ def test_clean_attribute_input_for_page_empty_values_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             page_type.page_attributes.all(),
-            is_page_attributes=True,
+            error_class=PageErrorCode,
             creation=creation,
         )
 
@@ -466,7 +461,7 @@ def test_clean_attribute_input_for_page_lack_of_required_attribute(
     # when
     with pytest.raises(ValidationError) as exc_info:
         AttributeAssignmentMixin.clean_input(
-            input_data, page_attributes, is_page_attributes=True, creation=True
+            input_data, page_attributes, error_class=PageErrorCode, creation=True
         )
 
     # then
@@ -507,7 +502,7 @@ def test_clean_attribute_input_for_page_multiple_errors(
         AttributeAssignmentMixin.clean_input(
             input_data,
             page_type.page_attributes.all(),
-            is_page_attributes=True,
+            error_class=PageErrorCode,
             creation=True,
         )
 
@@ -556,7 +551,6 @@ def test_clean_variant_attribute_input(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.variant_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -588,7 +582,6 @@ def test_clean_variant_attribute_input_no_values_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.variant_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -633,7 +626,6 @@ def test_clean_variant_attribute_duplicated_values_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.variant_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -676,7 +668,6 @@ def test_clean_variant_attribute_input_empty_values_given(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.variant_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -710,7 +701,6 @@ def test_clean_variant_attribute_too_many_values_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.variant_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -752,7 +742,6 @@ def test_clean_variant_attribute_empty_values_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.variant_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -796,7 +785,6 @@ def test_clean_variant_attribute_input_multiple_errors(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.variant_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -846,7 +834,6 @@ def test_clean_attributes_with_file_input_type_for_product(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -879,7 +866,6 @@ def test_clean_attributes_with_file_input_type_for_product_no_file_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -920,7 +906,6 @@ def test_clean_not_required_attrs_with_file_input_type_for_product_no_file_given
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -954,7 +939,6 @@ def test_clean_attributes_with_file_input_type_for_product_empty_file_value(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -989,7 +973,6 @@ def test_clean_numeric_attributes_input_for_product(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -1017,7 +1000,6 @@ def test_clean_numeric_attributes_input_for_product_not_numeric_value_given(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1052,7 +1034,6 @@ def test_validate_numeric_attributes_input_for_product_blank_value(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1086,7 +1067,6 @@ def test_validate_numeric_attributes_input_none_as_values(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1121,7 +1101,6 @@ def test_validate_numeric_attributes_input_for_product_more_than_one_value_given
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1168,7 +1147,6 @@ def test_validate_selectable_attributes_by_value(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -1207,7 +1185,6 @@ def test_validate_selectable_attributes_by_id(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -1241,7 +1218,6 @@ def test_clean_selectable_attributes_pass_null_value(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -1272,7 +1248,6 @@ def test_clean_selectable_attribute_by_id_and_value(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1311,7 +1286,6 @@ def test_clean_selectable_attribute_by_external_reference(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -1342,7 +1316,6 @@ def test_clean_selectable_attribute_by_id_and_external_reference(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1381,7 +1354,6 @@ def test_clean_selectable_attribute_by_value_and_external_reference(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -1412,7 +1384,6 @@ def test_clean_multiselect_attribute_by_id_and_value(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1452,7 +1423,6 @@ def test_clean_multiselect_attribute_duplicated_values(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1492,7 +1462,6 @@ def test_clean_multiselect_attribute_duplicated_ids(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1532,7 +1501,6 @@ def test_clean_multiselect_attribute_duplicated_external_refs(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1569,7 +1537,6 @@ def test_clean_selectable_attribute_max_length_exceeded(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1606,7 +1573,6 @@ def test_clean_selectable_attribute_value_required(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1640,7 +1606,6 @@ def test_validate_numeric_attributes(creation, value, numeric_attribute, product
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -1668,7 +1633,6 @@ def test_validate_numeric_attributes_invalid_number(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1699,7 +1663,6 @@ def test_clean_numeric_attributes_pass_null_value(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -1725,7 +1688,6 @@ def test_clean_numeric_attributes_value_required(
         AttributeAssignmentMixin.clean_input(
             input_data,
             product_type.product_attributes.all(),
-            is_page_attributes=False,
             creation=creation,
         )
 
@@ -1776,7 +1738,6 @@ def test_validate_rich_text_attributes_input_for_product_only_embed_block(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 
@@ -1818,7 +1779,6 @@ def test_clean_rich_text_attributes_input_for_product_only_image_block(
     AttributeAssignmentMixin.clean_input(
         input_data,
         product_type.product_attributes.all(),
-        is_page_attributes=False,
         creation=creation,
     )
 

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -63,6 +63,7 @@ from ..translations.types import AttributeTranslation, AttributeValueTranslation
 from .dataloaders.assigned_attributes import (
     AttributeValuesByPageIdAndAttributeIdAndLimitLoader,
     AttributeValuesByProductIdAndAttributeIdAndLimitLoader,
+    AttributeValuesByUserIdAndAttributeIdAndLimitLoader,
     AttributeValuesByVariantIdAndAttributeIdAndLimitLoader,
 )
 from .dataloaders.attributes import (
@@ -713,6 +714,10 @@ def get_attribute_values(
     if root.page_id:
         return AttributeValuesByPageIdAndAttributeIdAndLimitLoader(info.context).load(
             (root.page_id, root.attribute.id, limit)
+        )
+    if root.user_id:
+        return AttributeValuesByUserIdAndAttributeIdAndLimitLoader(info.context).load(
+            (root.user_id, root.attribute.id, limit)
         )
     return Promise.resolve([])
 

--- a/saleor/graphql/attribute/utils/attribute_assignment.py
+++ b/saleor/graphql/attribute/utils/attribute_assignment.py
@@ -12,7 +12,6 @@ from ....attribute import models as attribute_models
 from ....attribute.models import AttributeValue
 from ....attribute.utils import associate_attribute_values_to_instance
 from ....page import models as page_models
-from ....page.error_codes import PageErrorCode
 from ....product import models as product_models
 from ....product.error_codes import ProductErrorCode
 from ...core.utils import from_global_id_or_error
@@ -125,13 +124,9 @@ class AttributeAssignmentMixin:
         raw_input: list[dict],
         attributes_qs: "QuerySet",
         creation: bool = True,
-        is_page_attributes: bool = False,
-        error_class=None,
+        error_class=ProductErrorCode,
     ) -> T_INPUT_MAP:
         """Resolve, validate, and prepare attribute input."""
-        if error_class is None:
-            error_class = PageErrorCode if is_page_attributes else ProductErrorCode
-
         id_to_values_input_map, ext_ref_to_values_input_map = (
             cls._prepare_attribute_input_maps(raw_input, error_class)
         )

--- a/saleor/graphql/attribute/utils/attribute_assignment.py
+++ b/saleor/graphql/attribute/utils/attribute_assignment.py
@@ -126,9 +126,11 @@ class AttributeAssignmentMixin:
         attributes_qs: "QuerySet",
         creation: bool = True,
         is_page_attributes: bool = False,
+        error_class=None,
     ) -> T_INPUT_MAP:
         """Resolve, validate, and prepare attribute input."""
-        error_class = PageErrorCode if is_page_attributes else ProductErrorCode
+        if error_class is None:
+            error_class = PageErrorCode if is_page_attributes else ProductErrorCode
 
         id_to_values_input_map, ext_ref_to_values_input_map = (
             cls._prepare_attribute_input_maps(raw_input, error_class)
@@ -233,7 +235,9 @@ class AttributeAssignmentMixin:
         )
 
         if creation:
-            cls._validate_required_attributes(attributes_qs, cleaned_input, errors)
+            cls._validate_required_attributes(
+                attributes_qs, cleaned_input, errors, error_class
+            )
 
         if errors:
             raise ValidationError(errors)
@@ -278,6 +282,7 @@ class AttributeAssignmentMixin:
         attributes_qs: "QuerySet[attribute_models.Attribute]",
         cleaned_input: T_INPUT_MAP,
         errors: list[ValidationError],
+        error_class,
     ):
         """Validate that all required attributes are provided."""
         supplied_pks = {attr.pk for attr, _ in cleaned_input}
@@ -291,7 +296,7 @@ class AttributeAssignmentMixin:
             ]
             error = ValidationError(
                 "All attributes flagged as having a value required must be supplied.",
-                code=ProductErrorCode.REQUIRED.value,
+                code=error_class.REQUIRED.value,
                 params={"attributes": missing_ids},
             )
             errors.append(error)

--- a/saleor/graphql/attribute/utils/shared.py
+++ b/saleor/graphql/attribute/utils/shared.py
@@ -7,6 +7,7 @@ import orjson
 from django.db.models import Model
 from django.db.models.expressions import Exists, OuterRef
 
+from ....account import models as account_models
 from ....attribute import AttributeEntityType, AttributeInputType
 from ....attribute import models as attribute_models
 from ....page import models as page_models
@@ -16,7 +17,12 @@ from ..enums import AttributeValueBulkActionEnum
 if TYPE_CHECKING:
     from ....attribute.models import Attribute
 
-T_INSTANCE = product_models.Product | product_models.ProductVariant | page_models.Page
+T_INSTANCE = (
+    product_models.Product
+    | product_models.ProductVariant
+    | page_models.Page
+    | account_models.User
+)
 T_ERROR_DICT = dict[tuple[str, str], list]
 T_REFERENCE = (
     product_models.Product
@@ -34,6 +40,7 @@ class AssignedAttributeData:
     product_id: int | None = None
     page_id: int | None = None
     variant_id: int | None = None
+    user_id: int | None = None
 
 
 @dataclass
@@ -96,6 +103,8 @@ def get_assignment_model_and_fk(instance: T_INSTANCE):
         return attribute_models.AssignedPageAttributeValue, "page_id"
     if isinstance(instance, product_models.Product):
         return attribute_models.AssignedProductAttributeValue, "product_id"
+    if isinstance(instance, account_models.User):
+        return attribute_models.AssignedUserAttributeValue, "user_id"
     raise NotImplementedError(
         f"Assignment for {type(instance).__name__} not implemented."
     )

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -26,7 +26,7 @@ from ...core.doc_category import (
     DOC_CATEGORY_WEBHOOKS,
 )
 from ...core.scalars import DateTime, Decimal
-from ..descriptions import ADDED_IN_318
+from ..descriptions import ADDED_IN_318, ADDED_IN_323
 from ..enums import (
     AccountErrorCode,
     AppErrorCode,
@@ -187,6 +187,11 @@ class AccountError(Error):
     code = AccountErrorCode(description="The error code.", required=True)
     address_type = AddressTypeEnum(
         description="A type of address that causes the error.", required=False
+    )
+    attributes = NonNullList(
+        graphene.ID,
+        description="List of attributes IDs which causes the error." + ADDED_IN_323,
+        required=False,
     )
 
     class Meta:

--- a/saleor/graphql/page/mutations/page_create.py
+++ b/saleor/graphql/page/mutations/page_create.py
@@ -73,7 +73,7 @@ class PageCreate(DeprecatedModelMutation):
         attributes_qs = page_type.page_attributes
         attributes_qs = cast(QuerySet, attributes_qs)
         cleaned_attributes = AttributeAssignmentMixin.clean_input(
-            attributes, attributes_qs, is_page_attributes=True
+            attributes, attributes_qs, error_class=PageErrorCode
         )
         return cleaned_attributes
 

--- a/saleor/graphql/page/mutations/page_update.py
+++ b/saleor/graphql/page/mutations/page_update.py
@@ -6,6 +6,7 @@ from django.db.models import Exists, OuterRef, QuerySet
 from ....attribute import models as attribute_models
 from ....core.utils.update_mutation_manager import InstanceTracker
 from ....page import models
+from ....page.error_codes import PageErrorCode
 from ....permission.enums import PagePermissions
 from ....product.models import Product
 from ....product.utils.search_helpers import (
@@ -41,7 +42,7 @@ class PageUpdate(PageCreate):
         attributes_qs = page_type.page_attributes
         attributes_qs = cast(QuerySet, attributes_qs)
         cleaned_attributes = AttributeAssignmentMixin.clean_input(
-            attributes, attributes_qs, creation=False, is_page_attributes=True
+            attributes, attributes_qs, creation=False, error_class=PageErrorCode
         )
         return cleaned_attributes
 

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -428,6 +428,8 @@ COST_MAP = {
         "countries": {"complexity": 1},
     },
     "User": {
+        "assignedAttribute": {"complexity": 1},
+        "assignedAttributes": {"complexity": 1, "multipliers": ["limit"]},
         "avatar": {"complexity": 1},
         "checkout": {"complexity": 1},
         "customerType": {"complexity": 1},

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3331,7 +3331,7 @@ enum AppProblemDismissedByEnum @doc(category: "Apps") {
 }
 
 """Represents user data."""
-type User implements Node & ObjectWithMetadata @doc(category: "Users") {
+type User implements Node & ObjectWithMetadata & ObjectWithAttributes @doc(category: "Users") {
   """The ID of the user."""
   id: ID!
 
@@ -3364,6 +3364,26 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
   """
   metafields(keys: [String!]): Metadata
+
+  """
+  Get a single attribute assigned to the user by attribute slug. The attribute is looked up among the attributes of the user's customer type. Requires one of the following permissions: MANAGE_USERS, OWNER. The owner can access only attributes that are visible in the storefront.
+  
+  Added in Saleor 3.23.
+  """
+  assignedAttribute(
+    """Slug of the attribute"""
+    slug: String!
+  ): AssignedAttribute
+
+  """
+  List of attributes assigned to the user through the user's customer type. Requires one of the following permissions: MANAGE_USERS, OWNER. The owner can access only attributes that are visible in the storefront.
+  
+  Added in Saleor 3.23.
+  """
+  assignedAttributes(
+    """Maximum number of attributes to return. Default is 100."""
+    limit: PositiveInt = 100
+  ): [AssignedAttribute!]!
 
   """The email address of the user."""
   email: String!
@@ -3563,9 +3583,48 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   ): [StoredPaymentMethod!]
 }
 
-"""Represents user address data."""
-type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
-  """The ID of the address."""
+"""
+An object with attributes.
+
+Added in Saleor 3.22.
+"""
+interface ObjectWithAttributes @doc(category: "Attributes") {
+  """
+  Get a single attribute attached to the object by attribute slug.
+  
+  Added in Saleor 3.22.
+  """
+  assignedAttribute(
+    """Slug of the attribute"""
+    slug: String!
+  ): AssignedAttribute @doc(category: "Attributes")
+
+  """
+  List of attributes assigned to the object.
+  
+  Added in Saleor 3.22.
+  """
+  assignedAttributes(
+    """Maximum number of attributes to return. Default is 100."""
+    limit: PositiveInt = 100
+  ): [AssignedAttribute!]!
+}
+
+"""
+Represents an attribute assigned to an object.
+
+Added in Saleor 3.22.
+"""
+interface AssignedAttribute @doc(category: "Attributes") {
+  """Attribute assigned to an object."""
+  attribute: Attribute!
+}
+
+"""
+Custom attribute of a product. Attributes can be assigned to products and variants at the product type level.
+"""
+type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes") {
+  """The ID of the attribute."""
   id: ID!
 
   """List of private metadata items. Requires staff permissions to access."""
@@ -3598,504 +3657,60 @@ type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
   """
   metafields(keys: [String!]): Metadata
 
-  """The given name of the address."""
-  firstName: String!
+  """The input type to use for entering attribute values in the dashboard."""
+  inputType: AttributeInputTypeEnum
 
-  """The family name of the address."""
-  lastName: String!
-
-  """Company or organization name."""
-  companyName: String!
-
-  """The first line of the address."""
-  streetAddress1: String!
-
-  """The second line of the address."""
-  streetAddress2: String!
-
-  """The city of the address."""
-  city: String!
-
-  """The district of the address."""
-  cityArea: String!
-
-  """The postal code of the address."""
-  postalCode: String!
-
-  """The country of the address."""
-  country: CountryDisplay!
-
-  """The country area of the address."""
-  countryArea: String!
-
-  """The phone number assigned the address."""
-  phone: String
-
-  """Address is user's default shipping address."""
-  isDefaultShippingAddress: Boolean
-
-  """Address is user's default billing address."""
-  isDefaultBillingAddress: Boolean
-}
-
-type CountryDisplay {
-  """Country code."""
-  code: String!
-
-  """Country name."""
-  country: String!
-
-  """Country tax."""
-  vat: VAT @deprecated(reason: "Always returns `null`. Use `TaxClassCountryRate` type to manage tax rates per country.")
-}
-
-"""Represents a VAT rate for a country."""
-type VAT @doc(category: "Taxes") {
-  """Country code."""
-  countryCode: String!
-
-  """Standard VAT rate in percent."""
-  standardRate: Float
-
-  """Country's VAT rate exceptions for specific types of goods."""
-  reducedRates: [ReducedRate!]!
-}
-
-"""Represents a reduced VAT rate for a particular type of goods."""
-type ReducedRate @doc(category: "Taxes") {
-  """Reduced VAT rate in percent."""
-  rate: Float!
-
-  """A type of goods."""
-  rateType: String!
-}
-
-"""Checkout object."""
-type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
-  """The ID of the checkout."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
+  """The entity type which can be used as a reference."""
+  entityType: AttributeEntityTypeEnum
 
   """
-  A single key from private metadata. Requires staff permissions to access.
+  The reference types (product or page type) that are used to narrow down the choices of reference objects.
   
-  Tip: Use GraphQL aliases to fetch multiple keys.
+  Added in Saleor 3.22.
   """
-  privateMetafield(key: String!): String
+  referenceTypes(
+    """
+    Maximum number of objects to return. Value must be greater than 0. Default is 100.
+    """
+    limit: PositiveInt = 100
+  ): [ReferenceType!]
 
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """The date and time when the checkout was created."""
-  created: DateTime!
-
-  """Time of last modification of the given checkout."""
-  updatedAt: DateTime!
-  lastChange: DateTime! @deprecated(reason: "Use `updatedAt` instead.")
-
-  """
-  The user assigned to the checkout. Requires one of the following permissions: MANAGE_USERS, HANDLE_PAYMENTS, OWNER.
-  """
-  user: User
-
-  """The channel for which checkout was created."""
-  channel: Channel!
-
-  """The billing address of the checkout."""
-  billingAddress: Address
-
-  """The shipping address of the checkout."""
-  shippingAddress: Address
-
-  """
-  The customer note for the checkout. 
-  
-  Added in Saleor 3.21.
-  """
-  customerNote: String!
-
-  """The note for the checkout."""
-  note: String! @deprecated(reason: "Use `customerNote` instead.")
-
-  """
-  The total discount applied to the checkout. Note: Only discount created via voucher are included in this field.
-  """
-  discount: Money
-
-  """The name of voucher assigned to the checkout."""
-  discountName: String
-
-  """
-  Translation of the discountName field in the language set in Checkout.languageCode field.Note: this field is set automatically when Checkout.languageCode is defined; otherwise it's null
-  """
-  translatedDiscountName: String
-
-  """
-  The voucher assigned to the checkout.
-  
-  Added in Saleor 3.18.
-  
-  Requires one of the following permissions: MANAGE_DISCOUNTS.
-  """
-  voucher: Voucher
-
-  """The code of voucher assigned to the checkout."""
-  voucherCode: String
-
-  """
-  Shipping methods that can be used with this checkout.
-  
-  Triggers the following webhook events:
-  - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
-  - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
-  """
-  availableShippingMethods: [ShippingMethod!]! @webhookEventsInfo(asyncEvents: [], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT, CHECKOUT_FILTER_SHIPPING_METHODS]) @deprecated(reason: "Use `shippingMethods` instead.")
-
-  """
-  Shipping methods that can be used with this checkout.
-  
-  Triggers the following webhook events:
-  - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
-  - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
-  """
-  shippingMethods: [ShippingMethod!]! @webhookEventsInfo(asyncEvents: [], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT, CHECKOUT_FILTER_SHIPPING_METHODS])
-
-  """Collection points that can be used for this order."""
-  availableCollectionPoints: [Warehouse!]!
-
-  """
-  List of available payment gateways.
-  
-  Triggers the following webhook events:
-  - PAYMENT_LIST_GATEWAYS (sync): Fetch payment gateways available for checkout.
-  """
-  availablePaymentGateways: [PaymentGateway!]! @webhookEventsInfo(asyncEvents: [], syncEvents: [PAYMENT_LIST_GATEWAYS]) @deprecated(reason: "The legacy Payments API is deprecated and will be removed. Use the Transactions API instead.")
-
-  """Email of a customer."""
-  email: String
-
-  """List of gift cards associated with this checkout."""
-  giftCards: [GiftCard!]!
-
-  """Returns True, if checkout requires shipping."""
-  isShippingRequired: Boolean!
-
-  """The number of items purchased."""
-  quantity: Int!
-
-  """
-  Date when oldest stock reservation for this checkout expires or null if no stock is reserved.
-  """
-  stockReservationExpires: DateTime
-
-  """
-  A list of checkout lines, each containing information about an item in the checkout.
-  """
-  lines: [CheckoutLine!]!
-
-  """
-  The price of the shipping, with all the taxes included. Set to 0 when no delivery method is selected.
-  
-  Triggers the following webhook events:
-  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
-  """
-  shippingPrice: TaxedMoney! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
-
-  """
-  The delivery method selected for this checkout.
-  
-  Added in Saleor 3.23.
-  """
-  delivery: Delivery
-
-  """
-  The shipping method related with checkout.
-  
-  Triggers the following webhook events:
-  - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
-  - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
-  """
-  shippingMethod: ShippingMethod @webhookEventsInfo(asyncEvents: [], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT, CHECKOUT_FILTER_SHIPPING_METHODS]) @deprecated(reason: "Use `delivery` instead.")
-
-  """
-  The delivery method selected for this checkout.
-  
-  Triggers the following webhook events:
-  - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
-  - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
-  """
-  deliveryMethod: DeliveryMethod @webhookEventsInfo(asyncEvents: [], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT, CHECKOUT_FILTER_SHIPPING_METHODS]) @deprecated(reason: "Use `delivery` instead.")
-
-  """
-  The price of the checkout before shipping, with taxes included.
-  
-  Triggers the following webhook events:
-  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
-  """
-  subtotalPrice: TaxedMoney! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
-
-  """Returns True if checkout has to be exempt from taxes."""
-  taxExemption: Boolean!
-
-  """The checkout's token."""
-  token: UUID!
-
-  """
-  The sum of the checkout line prices, with all the taxes,shipping costs, and discounts included.
-  
-  Triggers the following webhook events:
-  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
-  """
-  totalPrice: TaxedMoney! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
-
-  """
-  The difference between the paid and the checkout total amount.
-  
-  Triggers the following webhook events:
-  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
-  """
-  totalBalance: Money! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
-
-  """Checkout language code."""
-  languageCode: LanguageCodeEnum!
-
-  """
-  List of transactions for the checkout. Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
-  """
-  transactions: [TransactionItem!]
-
-  """Determines whether displayed prices should include taxes."""
-  displayGrossPrices: Boolean!
-
-  """
-  The authorize status of the checkout.
-  
-  Triggers the following webhook events:
-  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
-  """
-  authorizeStatus: CheckoutAuthorizeStatusEnum! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
-
-  """
-  The charge status of the checkout.
-  
-  Triggers the following webhook events:
-  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
-  """
-  chargeStatus: CheckoutChargeStatusEnum! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
-
-  """
-  List of user's stored payment methods that can be used in this checkout session. It uses the channel that the checkout was created in. When `amount` is not provided, `checkout.total` will be used as a default value.
-  """
-  storedPaymentMethods(
-    """Amount that will be used to fetch stored payment methods."""
-    amount: PositiveDecimal
-  ): [StoredPaymentMethod!]
-
-  """List of problems with the checkout."""
-  problems: [CheckoutProblem!]
-}
-
-"""Represents channel."""
-type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
-  """The ID of the channel."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """Slug of the channel."""
-  slug: String!
-
-  """
-  Name of the channel.
-  
-  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
-  """
+  """Name of an attribute displayed in the interface."""
   name: String!
 
-  """
-  Whether the channel is active.
-  
-  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
-  """
-  isActive: Boolean!
-
-  """
-  A currency that is assigned to the channel.
-  
-  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
-  """
-  currencyCode: String!
-
-  """
-  Whether a channel has associated orders.
-  
-  Requires one of the following permissions: MANAGE_CHANNELS.
-  """
-  hasOrders: Boolean!
-
-  """
-  Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
-  
-  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
-  """
-  defaultCountry: CountryDisplay!
-
-  """
-  List of warehouses assigned to this channel.
-  
-  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
-  """
-  warehouses: [Warehouse!]!
-
-  """List of shippable countries for the channel."""
-  countries: [CountryDisplay!]
-
-  """Shipping methods that are available for the channel."""
-  availableShippingMethodsPerCountry(countries: [CountryCode!]): [ShippingMethodsPerCountry!]
-
-  """
-  Define the stock setting for this channel.
-  
-  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
-  """
-  stockSettings: StockSettings!
-
-  """
-  Channel-specific order settings.
-  
-  Requires one of the following permissions: MANAGE_CHANNELS, MANAGE_ORDERS.
-  """
-  orderSettings: OrderSettings!
-
-  """
-  Channel-specific checkout settings.
-  
-  Requires one of the following permissions: MANAGE_CHANNELS, MANAGE_CHECKOUTS.
-  """
-  checkoutSettings: CheckoutSettings!
-
-  """
-  Channel-specific payment settings.
-  
-  Requires one of the following permissions: MANAGE_CHANNELS, HANDLE_PAYMENTS.
-  """
-  paymentSettings: PaymentSettings!
-
-  """
-  Channel specific tax configuration.
-  
-  Added in Saleor 3.20.
-  
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
-  """
-  taxConfiguration: TaxConfiguration!
-}
-
-"""Represents warehouse."""
-type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
-  """The ID of the warehouse."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """Warehouse name."""
-  name: String!
-
-  """Warehouse slug."""
+  """Internal representation of an attribute name."""
   slug: String!
 
-  """Warehouse email."""
-  email: String!
+  """The attribute type."""
+  type: AttributeTypeEnum!
 
-  """Determine if the warehouse is private."""
-  isPrivate: Boolean!
+  """The unit of attribute values."""
+  unit: MeasurementUnitsEnum
 
-  """Address of the warehouse."""
-  address: Address!
+  """
+  A list of predefined attribute choices available for selection. Available only for attributes with predefined choices.
+  """
+  choices(
+    """Sort attribute choices."""
+    sortBy: AttributeChoicesSortingInput
 
-  """Warehouse company name."""
-  companyName: String! @deprecated(reason: "Use `Address.companyName` instead.")
+    """Filtering options for attribute choices."""
+    filter: AttributeValueFilterInput @deprecated(reason: "Use `where` filter instead.")
 
-  """Click and collect options: local, all or disabled."""
-  clickAndCollectOption: WarehouseClickAndCollectOptionEnum!
+    """
+    Where filtering options for attribute choices.
+    
+    Added in Saleor 3.22.
+    """
+    where: AttributeValueWhereInput
 
-  """Shipping zones supported by the warehouse."""
-  shippingZones(
+    """
+    Search attribute choices.
+    
+    Added in Saleor 3.22.
+    """
+    search: String
+
     """Return the elements in the list that come before the specified cursor."""
     before: String
 
@@ -4111,16 +3726,51 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
     Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
     """
     last: Int
-  ): ShippingZoneCountableConnection!
+  ): AttributeValueCountableConnection
 
   """
-  Stocks that belong to this warehouse.
-  
-  Added in Saleor 3.20.
-  
-  Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
+  Whether the attribute requires values to be passed or not. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
-  stocks(
+  valueRequired: Boolean!
+
+  """
+  Whether the attribute should be visible or not in storefront. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  """
+  visibleInStorefront: Boolean!
+
+  """
+  Whether the attribute can be filtered in storefront. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  """
+  filterableInStorefront: Boolean! @deprecated
+
+  """
+  Whether the attribute can be filtered in dashboard. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  """
+  filterableInDashboard: Boolean!
+
+  """
+  Whether the attribute can be displayed in the admin product list. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  """
+  availableInGrid: Boolean! @deprecated
+
+  """
+  The position of the attribute in the storefront navigation (0 by default). Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  """
+  storefrontSearchPosition: Int! @deprecated
+
+  """Returns translated attribute fields for the given language code."""
+  translation(
+    """A language code to return the translation for attribute."""
+    languageCode: LanguageCodeEnum!
+  ): AttributeTranslation
+
+  """Flag indicating that attribute has predefined choices."""
+  withChoices: Boolean!
+
+  """
+  A list of product types that use this attribute as a product attribute.
+  """
+  productTypes(
     """Return the elements in the list that come before the specified cursor."""
     before: String
 
@@ -4136,22 +3786,231 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
     Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
     """
     last: Int
-  ): StockCountableConnection
+  ): ProductTypeCountableConnection!
 
-  """External ID of this warehouse."""
+  """
+  A list of product types that use this attribute as a product variant attribute.
+  """
+  productVariantTypes(
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): ProductTypeCountableConnection!
+
+  """External ID of this attribute."""
   externalReference: String
 }
 
-enum WarehouseClickAndCollectOptionEnum @doc(category: "Products") {
-  DISABLED
-  LOCAL
-  ALL
+enum AttributeInputTypeEnum @doc(category: "Attributes") {
+  DROPDOWN
+  MULTISELECT
+  FILE
+  REFERENCE
+  SINGLE_REFERENCE
+  NUMERIC
+  RICH_TEXT
+  PLAIN_TEXT
+  SWATCH
+  BOOLEAN
+  DATE
+  DATE_TIME
 }
 
-type ShippingZoneCountableConnection @doc(category: "Shipping") {
+enum AttributeEntityTypeEnum @doc(category: "Attributes") {
+  PAGE
+  PRODUCT
+  PRODUCT_VARIANT
+  CATEGORY
+  COLLECTION
+}
+
+"""
+The reference types (product or page type) that are used to narrow down the choices of reference objects.
+ProductType applicable for reference attribute with `PRODUCT` or `PRODUCT_VARIANT` entity type.
+PageType applicable for reference attribute with `PAGE` entity type.
+"""
+union ReferenceType = ProductType | PageType
+
+"""
+Represents a type of product. It defines what attributes are available to products of this type.
+"""
+type ProductType implements Node & ObjectWithMetadata @doc(category: "Products") {
+  """The ID of the product type."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """Name of the product type."""
+  name: String!
+
+  """Slug of the product type."""
+  slug: String!
+
+  """Whether the product type has variants."""
+  hasVariants: Boolean! @deprecated(reason: "This is a leftover from the past Simple/Configurable product distinction. Products can have multiple variants regardless of this setting. ")
+
+  """Whether shipping is required for this product type."""
+  isShippingRequired: Boolean!
+
+  """
+  Whether the product type is digital - doesn't have any effect, it's present for backward-compatibility.
+  """
+  isDigital: Boolean! @deprecated(reason: "Will be removed in v3.24.0, use metadata or attributes instead.")
+
+  """Weight of the product type."""
+  weight: Weight
+
+  """The product type kind."""
+  kind: ProductTypeKindEnum!
+
+  """List of products of this type."""
+  products(
+    """Slug of a channel for which the data should be returned."""
+    channel: String
+
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): ProductCountableConnection @deprecated(reason: "Use the top-level `products` query with the `productTypes` filter.")
+
+  """A type of tax. Assigned by enabled tax gateway"""
+  taxType: TaxType @deprecated(reason: "Use `taxClass` field instead.")
+
+  """
+  Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
+  
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  """
+  taxClass: TaxClass
+
+  """Variant attributes of that product type."""
+  variantAttributes(
+    """Define scope of returned attributes."""
+    variantSelection: VariantAttributeScope
+  ): [Attribute!] @deprecated(reason: "Use `assignedVariantAttributes` instead.")
+
+  """
+  Variant attributes of that product type with attached variant selection.
+  """
+  assignedVariantAttributes(
+    """Define scope of returned attributes."""
+    variantSelection: VariantAttributeScope
+  ): [AssignedVariantAttribute!]
+
+  """Product attributes of that product type."""
+  productAttributes: [Attribute!]
+
+  """
+  List of attributes which can be assigned to this product type.
+  
+  Requires one of the following permissions: MANAGE_PRODUCTS.
+  """
+  availableAttributes(
+    """Filtering options for attributes of this product type."""
+    filter: AttributeFilterInput @deprecated(reason: "Use `where` filter instead.")
+
+    """Where filtering options for attributes of this product type."""
+    where: AttributeWhereInput
+
+    """Search attributes."""
+    search: String
+
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): AttributeCountableConnection
+}
+
+"""Represents weight value in a specific weight unit."""
+type Weight {
+  """Weight unit."""
+  unit: WeightUnitsEnum!
+
+  """Weight value. Returns a value with maximal three decimal places"""
+  value: Float!
+}
+
+enum WeightUnitsEnum {
+  G
+  LB
+  OZ
+  KG
+  TONNE
+}
+
+enum ProductTypeKindEnum @doc(category: "Products") {
+  NORMAL
+  GIFT_CARD
+}
+
+type ProductCountableConnection @doc(category: "Products") {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
-  edges: [ShippingZoneCountableEdge!]!
+  edges: [ProductCountableEdge!]!
 
   """A total count of items in the collection."""
   totalCount: Int
@@ -4174,19 +4033,17 @@ type PageInfo {
   endCursor: String
 }
 
-type ShippingZoneCountableEdge @doc(category: "Shipping") {
+type ProductCountableEdge @doc(category: "Products") {
   """The item at the end of the edge."""
-  node: ShippingZone!
+  node: Product!
 
   """A cursor for use in pagination."""
   cursor: String!
 }
 
-"""
-Represents a shipping zone in the shop. Zones are the concept used only for grouping shipping methods in the dashboard, and are never exposed to the customers directly.
-"""
-type ShippingZone implements Node & ObjectWithMetadata @doc(category: "Shipping") {
-  """The ID of shipping zone."""
+"""Represents an individual item for sale in the storefront."""
+type Product implements Node & ObjectWithMetadata & ObjectWithAttributes @doc(category: "Products") {
+  """The ID of the product."""
   id: ID!
 
   """List of private metadata items. Requires staff permissions to access."""
@@ -4219,139 +4076,348 @@ type ShippingZone implements Node & ObjectWithMetadata @doc(category: "Shipping"
   """
   metafields(keys: [String!]): Metadata
 
-  """Shipping zone name."""
-  name: String!
-
-  """Indicates if the shipping zone is default one."""
-  default: Boolean!
-
-  """Lowest and highest prices for the shipping."""
-  priceRange: MoneyRange
-
-  """List of countries available for the method."""
-  countries: [CountryDisplay!]!
-
   """
-  List of shipping methods available for orders shipped to countries within this shipping zone.
-  """
-  shippingMethods: [ShippingMethodType!]
-
-  """List of warehouses for shipping zone."""
-  warehouses: [Warehouse!]!
-
-  """List of channels for shipping zone."""
-  channels: [Channel!]!
-
-  """Description of a shipping zone."""
-  description: String
-}
-
-"""Represents a range of amounts of money."""
-type MoneyRange {
-  """Lower bound of a price range."""
-  start: Money
-
-  """Upper bound of a price range."""
-  stop: Money
-}
-
-"""Represents amount of money in specific currency."""
-type Money {
-  """Currency code."""
-  currency: String!
-
-  """Amount of money."""
-  amount: Float!
-
-  """
-  Amount of money represented as an integer in the smallest currency unit.
-  """
-  fractionalAmount: Int!
-
-  """Number of digits after the decimal point in the currency."""
-  fractionDigits: Int!
-}
-
-"""
-Shipping method are the methods you'll use to get customer's orders to them. They are directly exposed to the customers.
-"""
-type ShippingMethodType implements Node & ObjectWithMetadata @doc(category: "Shipping") {
-  """Shipping method ID."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
+  Get a single attribute attached to product by attribute slug.
   
-  Tip: Use GraphQL aliases to fetch multiple keys.
+  Added in Saleor 3.22.
   """
-  privateMetafield(key: String!): String
+  assignedAttribute(
+    """Slug of the attribute"""
+    slug: String!
+  ): AssignedAttribute
 
   """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
+  List of attributes assigned to this product.
   
-  Tip: Use GraphQL aliases to fetch multiple keys.
+  Added in Saleor 3.22.
   """
-  metafield(key: String!): String
+  assignedAttributes(
+    """Maximum number of attributes to return. Default is 100."""
+    limit: PositiveInt = 100
+  ): [AssignedAttribute!]!
 
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  metafields(keys: [String!]): Metadata
+  """SEO title of the product."""
+  seoTitle: String
 
-  """Shipping method name."""
+  """SEO description of the product."""
+  seoDescription: String
+
+  """SEO description of the product."""
   name: String!
 
   """
-  Shipping method description.
+  Description of the product.
   
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
-  """Type of the shipping method."""
-  type: ShippingMethodTypeEnum
+  """Type of the product."""
+  productType: ProductType!
 
-  """Returns translated shipping method fields for the given language code."""
+  """Slug of the product."""
+  slug: String!
+  category: Category
+
+  """The date and time when the product was created."""
+  created: DateTime!
+
+  """The date and time when the product was last updated."""
+  updatedAt: DateTime!
+  chargeTaxes: Boolean! @deprecated(reason: "Use `Channel.taxConfiguration` field to determine whether tax collection is enabled.")
+
+  """Weight of the product."""
+  weight: Weight
+
+  """Default variant of the product."""
+  defaultVariant: ProductVariant
+
+  """Rating of the product."""
+  rating: Float
+
+  """
+  Channel given to retrieve this product. Also used by federation gateway to resolve this object in a federated query.
+  """
+  channel: String
+
+  """
+  Description of the product.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  descriptionJson: JSONString @deprecated(reason: "Use the `description` field instead.")
+
+  """Thumbnail of the product."""
+  thumbnail(
+    """
+    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
+    """
+    size: Int
+
+    """
+    The format of the image. When not provided, format of the original image will be used.
+    """
+    format: ThumbnailFormatEnum = ORIGINAL
+  ): Image
+
+  """
+  Lists the storefront product's pricing, the current price and discounts, only meant for displaying.
+  """
+  pricing(
+    """
+    Destination address used to find warehouses where stock availability for this product is checked. If address is empty, uses `Shop.companyAddress` or fallbacks to server's `settings.DEFAULT_COUNTRY` configuration.
+    """
+    address: AddressInput
+  ): ProductPricingInfo
+
+  """
+  Whether the product is in stock, set as available for purchase in the given channel, and published.
+  """
+  isAvailable(
+    """
+    Destination address used to find warehouses where stock availability for this product is checked. If address is empty, uses `Shop.companyAddress` or fallbacks to server's `settings.DEFAULT_COUNTRY` configuration. When `Shop.useLegacyShippingZoneStockAvailability` is disabled, this argument is ignored — stock availability is determined by the direct warehouse-channel link instead of shipping zones.
+    """
+    address: AddressInput @deprecated
+  ): Boolean
+
+  """A type of tax. Assigned by enabled tax gateway"""
+  taxType: TaxType @deprecated(reason: "Use `taxClass` field instead.")
+
+  """Get a single attribute attached to product by attribute slug."""
+  attribute(
+    """Slug of the attribute"""
+    slug: String!
+  ): SelectedAttribute @deprecated(reason: "Use the `assignedAttribute` field instead.")
+
+  """List of attributes assigned to this product."""
+  attributes: [SelectedAttribute!]! @deprecated(reason: "Use the `assignedAttributes` field instead.")
+
+  """
+  List of availability in channels for the product.
+  
+  Requires one of the following permissions: MANAGE_PRODUCTS.
+  """
+  channelListings: [ProductChannelListing!]
+
+  """Get a single product media by ID."""
+  mediaById(
+    """ID of a product media."""
+    id: ID!
+  ): ProductMedia
+
+  """Get a single product image by ID."""
+  imageById(
+    """ID of a product image."""
+    id: ID!
+  ): ProductImage @deprecated(reason: "Use the `mediaById` field instead.")
+
+  """Get a single variant by SKU or ID."""
+  variant(
+    """ID of the variant."""
+    id: ID
+
+    """SKU of the variant."""
+    sku: String
+  ): ProductVariant @deprecated(reason: "Use top-level `variant` query.")
+
+  """
+  List of variants for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
+  """
+  variants: [ProductVariant!] @deprecated(reason: "Use `productVariants` field instead.")
+
+  """
+  List of variants for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
+  
+  Added in Saleor 3.21.
+  """
+  productVariants(
+    """Filtering options for product variant."""
+    filter: ProductVariantFilterInput @deprecated(reason: "Use `where` filter instead.")
+
+    """Where filtering options for product variants."""
+    where: ProductVariantWhereInput
+
+    """Sort products variants."""
+    sortBy: ProductVariantSortingInput
+
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): ProductVariantCountableConnection
+
+  """List of media for the product."""
+  media(
+    """Sort media."""
+    sortBy: MediaSortingInput
+  ): [ProductMedia!]
+
+  """List of images for the product."""
+  images: [ProductImage!] @deprecated(reason: "Use the `media` field instead.")
+
+  """
+  List of collections for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
+  """
+  collections: [Collection!]
+
+  """Returns translated product fields for the given language code."""
   translation(
-    """A language code to return the translation for shipping method."""
+    """A language code to return the translation for product."""
     languageCode: LanguageCodeEnum!
-  ): ShippingMethodTranslation
+  ): ProductTranslation
+
+  """Date when product is available for purchase."""
+  availableForPurchase: Date @deprecated(reason: "Use the `availableForPurchaseAt` field to fetch the available for purchase date.")
+
+  """Date when product is available for purchase."""
+  availableForPurchaseAt: DateTime
 
   """
-  List of channels available for the method.
+  Refers to a state that can be set by admins to control whether a product is available for purchase in storefronts. This does not guarantee the availability of stock. When set to `False`, this product is still visible to customers, but it cannot be purchased.
+  """
+  isAvailableForPurchase: Boolean
+
+  """
+  Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
   
-  Requires one of the following permissions: MANAGE_SHIPPING.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
-  channelListings: [ShippingMethodChannelListing!]
+  taxClass: TaxClass
 
-  """The price of the cheapest variant (including discounts)."""
-  maximumOrderPrice: Money
+  """External ID of this product."""
+  externalReference: String
+}
 
-  """The price of the cheapest variant (including discounts)."""
-  minimumOrderPrice: Money
+"""
+Positive Integer scalar implementation.
+
+Should be used in places where value must be positive (greater than 0).
+"""
+scalar PositiveInt
+
+scalar JSONString
+
+"""
+Represents a single category of products. Categories allow to organize products in a tree-hierarchies which can be used for navigation in the storefront.
+"""
+type Category implements Node & ObjectWithMetadata @doc(category: "Products") {
+  """The ID of the category."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
 
   """
-  Postal code ranges rule of exclusion or inclusion of the shipping method.
-  """
-  postalCodeRules: [ShippingMethodPostalCodeRule!]
-
-  """
-  List of excluded products for the shipping method.
+  A single key from private metadata. Requires staff permissions to access.
   
-  Requires one of the following permissions: MANAGE_SHIPPING.
+  Tip: Use GraphQL aliases to fetch multiple keys.
   """
-  excludedProducts(
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """SEO title of category."""
+  seoTitle: String
+
+  """SEO description of category."""
+  seoDescription: String
+
+  """Name of category"""
+  name: String!
+
+  """
+  Description of the category.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  description: JSONString
+
+  """Slug of the category."""
+  slug: String!
+
+  """Parent category."""
+  parent: Category
+
+  """Level of the category."""
+  level: Int!
+
+  """
+  Description of the category.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  descriptionJson: JSONString @deprecated(reason: "Use the `description` field instead.")
+
+  """The date and time when the category was last updated."""
+  updatedAt: DateTime!
+
+  """List of ancestors of the category."""
+  ancestors(
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): CategoryCountableConnection
+
+  """
+  List of products in the category. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
+  """
+  products(
+    """Filtering options for products."""
+    filter: ProductFilterInput @deprecated(reason: "Use `where` filter instead.")
+
+    """Where filtering options for products."""
+    where: ProductWhereInput
+
+    """Sort products."""
+    sortBy: ProductOrder
+
+    """Search products."""
+    search: String
+
+    """Slug of a channel for which the data should be returned."""
+    channel: String
+
     """Return the elements in the list that come before the specified cursor."""
     before: String
 
@@ -4369,53 +4435,537 @@ type ShippingMethodType implements Node & ObjectWithMetadata @doc(category: "Shi
     last: Int
   ): ProductCountableConnection
 
-  """Minimum order weight to use this shipping method."""
-  minimumOrderWeight: Weight
+  """List of children of the category."""
+  children(
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
 
-  """Maximum order weight to use this shipping method."""
-  maximumOrderWeight: Weight
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
 
-  """Maximum number of days for delivery."""
-  maximumDeliveryDays: Int
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
 
-  """Minimal number of days for delivery."""
-  minimumDeliveryDays: Int
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): CategoryCountableConnection
+
+  """Background image of the category."""
+  backgroundImage(
+    """
+    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
+    """
+    size: Int
+
+    """
+    The format of the image. When not provided, format of the original image will be used.
+    """
+    format: ThumbnailFormatEnum = ORIGINAL
+  ): Image
+
+  """Returns translated category fields for the given language code."""
+  translation(
+    """A language code to return the translation for category."""
+    languageCode: LanguageCodeEnum!
+  ): CategoryTranslation
+}
+
+type CategoryCountableConnection @doc(category: "Products") {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+  edges: [CategoryCountableEdge!]!
+
+  """A total count of items in the collection."""
+  totalCount: Int
+}
+
+type CategoryCountableEdge @doc(category: "Products") {
+  """The item at the end of the edge."""
+  node: Category!
+
+  """A cursor for use in pagination."""
+  cursor: String!
+}
+
+input ProductFilterInput @doc(category: "Products") {
+  isPublished: Boolean
+  collections: [ID!]
+  categories: [ID!]
+  hasCategory: Boolean
+  attributes: [AttributeInput!]
+
+  """Filter by variants having specific stock status."""
+  stockAvailability: StockAvailability
+  stocks: ProductStockFilterInput
+  search: String
+  metadata: [MetadataFilter!]
+
+  """Filter by the publication date."""
+  publishedFrom: DateTime
+
+  """Filter by availability for purchase."""
+  isAvailable: Boolean
+
+  """Filter by the date of availability for purchase."""
+  availableFrom: DateTime
+
+  """Filter by visibility in product listings."""
+  isVisibleInListing: Boolean
+  price: PriceRangeInput
+
+  """Filter by the lowest variant price after discounts."""
+  minimalPrice: PriceRangeInput
+
+  """Filter by when was the most recent update."""
+  updatedAt: DateTimeRangeInput
+  productTypes: [ID!]
+
+  """Filter on whether product is a gift card or not."""
+  giftCard: Boolean
+  ids: [ID!]
+  hasPreorderedVariants: Boolean
+  slugs: [String!]
+
+  """Specifies the channel by which the data should be filtered."""
+  channel: String @deprecated(reason: "Use root-level channel argument instead.")
+}
+
+input AttributeInput @doc(category: "Attributes") {
+  """Internal representation of an attribute name."""
+  slug: String
 
   """
-  Tax class assigned to this shipping method.
+  Filter by value of the attribute. Only one value input field is allowed. If provided more than one, the error will be raised. Cannot be combined with deprecated fields of `AttributeInput`.
+  """
+  value: AssignedAttributeValueInput
+
+  """
+  Slugs identifying the attributeValues associated with the Attribute. When specified, it filters the results to include only records with one of the matching values. Requires `slug` to be provided.
+  """
+  values: [String!] @deprecated(reason: "Use `value` instead.")
+
+  """
+  The range that the returned values should be in. Requires `slug` to be provided.
+  """
+  valuesRange: IntRangeInput @deprecated(reason: "Use `value` instead.")
+
+  """
+  The date/time range that the returned values should be in. Requires `slug` to be provided.
+  """
+  dateTime: DateTimeRangeInput @deprecated(reason: "Use `value` instead.")
+
+  """
+  The date range that the returned values should be in. In case of date/time attributes, the UTC midnight of the given date is used. Requires `slug` to be provided.
+  """
+  date: DateRangeInput @deprecated(reason: "Use `value` instead.")
+
+  """The boolean value of the attribute. Requires `slug` to be provided."""
+  boolean: Boolean @deprecated(reason: "Use `value` instead.")
+}
+
+input AssignedAttributeValueInput {
+  """Filter by slug assigned to AttributeValue."""
+  slug: StringFilterInput
+
+  """Filter by name assigned to AttributeValue."""
+  name: StringFilterInput
+
+  """Filter by numeric value for attributes of numeric type."""
+  numeric: DecimalFilterInput
+
+  """Filter by date value for attributes of date type."""
+  date: DateRangeInput
+
+  """Filter by date time value for attributes of date time type."""
+  dateTime: DateTimeRangeInput
+
+  """Filter by boolean value for attributes of boolean type."""
+  boolean: Boolean
+
+  """Filter by reference attribute value."""
+  reference: AssignedAttributeReferenceInput
+}
+
+"""Define the filtering options for string fields."""
+input StringFilterInput {
+  """The value equal to."""
+  eq: String
+
+  """The value included in."""
+  oneOf: [String!]
+}
+
+"""Define the filtering options for decimal fields."""
+input DecimalFilterInput {
+  """The value equal to."""
+  eq: Decimal
+
+  """The value included in."""
+  oneOf: [Decimal!]
+
+  """The value in range."""
+  range: DecimalRangeInput
+}
+
+"""
+Custom Decimal implementation.
+
+Returns Decimal as a float in the API,
+parses float to the Decimal on the way back.
+"""
+scalar Decimal
+
+input DecimalRangeInput {
+  """Decimal value greater than or equal to."""
+  gte: Decimal
+
+  """Decimal value less than or equal to."""
+  lte: Decimal
+}
+
+input DateRangeInput {
+  """Start date."""
+  gte: Date
+
+  """End date."""
+  lte: Date
+}
+
+"""
+The `Date` scalar type represents a Date
+value as specified by
+[iso8601](https://en.wikipedia.org/wiki/ISO_8601).
+"""
+scalar Date
+
+input DateTimeRangeInput {
+  """Start date."""
+  gte: DateTime
+
+  """End date."""
+  lte: DateTime
+}
+
+input AssignedAttributeReferenceInput {
+  """
+  Returns objects with a reference pointing to an object identified by the given ID.
+  """
+  referencedIds: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a page identified by the given slug.
+  """
+  pageSlugs: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a product identified by the given slug.
+  """
+  productSlugs: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a product variant identified by the given sku.
+  """
+  productVariantSkus: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a category identified by the given slug.
+  """
+  categorySlugs: ContainsFilterInput
+
+  """
+  Returns objects with a reference pointing to a collection identified by the given slug.
+  """
+  collectionSlugs: ContainsFilterInput
+}
+
+"""
+Define the filtering options for fields that can contain multiple values.
+"""
+input ContainsFilterInput {
+  """The field contains at least one of the specified values."""
+  containsAny: [String!]
+
+  """The field contains all of the specified values."""
+  containsAll: [String!]
+}
+
+input IntRangeInput {
+  """Value greater than or equal to."""
+  gte: Int
+
+  """Value less than or equal to."""
+  lte: Int
+}
+
+enum StockAvailability @doc(category: "Products") {
+  IN_STOCK
+  OUT_OF_STOCK
+}
+
+input ProductStockFilterInput @doc(category: "Products") {
+  warehouseIds: [ID!]
+  quantity: IntRangeInput
+}
+
+input MetadataFilter {
+  """Key of a metadata item."""
+  key: String!
+
+  """Value of a metadata item."""
+  value: String
+}
+
+input PriceRangeInput {
+  """Price greater than or equal to."""
+  gte: Float
+
+  """Price less than or equal to."""
+  lte: Float
+}
+
+input ProductWhereInput @doc(category: "Products") {
+  metadata: [MetadataFilter!]
+  ids: [ID!]
+
+  """Filter by product name."""
+  name: StringFilterInput
+
+  """Filter by product slug."""
+  slug: StringFilterInput
+
+  """Filter by product type."""
+  productType: GlobalIDFilterInput
+
+  """Filter by product category."""
+  category: GlobalIDFilterInput
+
+  """Filter by collection."""
+  collection: GlobalIDFilterInput
+
+  """Filter by availability for purchase."""
+  isAvailable: Boolean
+
+  """Filter by public visibility."""
+  isPublished: Boolean
+
+  """Filter by visibility on the channel."""
+  isVisibleInListing: Boolean
+
+  """Filter by the publication date."""
+  publishedFrom: DateTime
+
+  """Filter by the date of availability for purchase."""
+  availableFrom: DateTime
+
+  """Filter by product with category assigned."""
+  hasCategory: Boolean
+
+  """Filter by product variant price."""
+  price: DecimalFilterInput
+
+  """Filter by the lowest variant price after discounts."""
+  minimalPrice: DecimalFilterInput
+
+  """Filter by attributes associated with the product."""
+  attributes: [AttributeInput!]
+
+  """Filter by variants having specific stock status."""
+  stockAvailability: StockAvailability
+
+  """Filter by stock of the product variant."""
+  stocks: ProductStockFilterInput
+
+  """Filter on whether product is a gift card or not."""
+  giftCard: Boolean
+
+  """Filter by product with preordered variants."""
+  hasPreorderedVariants: Boolean
+
+  """Filter by when was the most recent update."""
+  updatedAt: DateTimeFilterInput
+
+  """List of conditions that must be met."""
+  AND: [ProductWhereInput!]
+
+  """A list of conditions of which at least one must be met."""
+  OR: [ProductWhereInput!]
+}
+
+"""Define the filtering options for foreign key fields."""
+input GlobalIDFilterInput {
+  """The value equal to."""
+  eq: ID
+
+  """The value included in."""
+  oneOf: [ID!]
+}
+
+"""Define the filtering options for date time fields."""
+input DateTimeFilterInput {
+  """The value equal to."""
+  eq: DateTime
+
+  """The value included in."""
+  oneOf: [DateTime!]
+
+  """The value in range."""
+  range: DateTimeRangeInput
+}
+
+input ProductOrder @doc(category: "Products") {
+  """Specifies the direction in which to sort products."""
+  direction: OrderDirection!
+
+  """Specifies the channel in which to sort the data."""
+  channel: String @deprecated(reason: "Use root-level channel argument instead.")
+
+  """
+  Sort product by the selected attribute's values.
+  Note: this doesn't take translations into account yet.
+  """
+  attributeId: ID
+
+  """Sort products by the selected field."""
+  field: ProductOrderField
+}
+
+enum OrderDirection {
+  """Specifies an ascending sort order."""
+  ASC
+
+  """Specifies a descending sort order."""
+  DESC
+}
+
+enum ProductOrderField @doc(category: "Products") {
+  """Sort products by name."""
+  NAME
+
+  """
+  Sort products by rank. Note: This option is available only with the `search` filter.
+  """
+  RANK
+
+  """
+  Sort products by price.
   
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  This option requires a channel filter to work as the values can vary between channels.
   """
-  taxClass: TaxClass
-}
-
-scalar JSONString
-
-enum ShippingMethodTypeEnum @doc(category: "Shipping") {
   PRICE
-  WEIGHT
+
+  """
+  Sort products by a minimal price of a product's variant.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  MINIMAL_PRICE
+
+  """Sort products by update date."""
+  LAST_MODIFIED @deprecated(reason: "Use `LAST_MODIFIED_AT` instead.")
+
+  """Sort products by update date."""
+  DATE @deprecated(reason: "Use `LAST_MODIFIED_AT` instead.")
+
+  """Sort products by type."""
+  TYPE
+
+  """
+  Sort products by publication status.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  PUBLISHED
+
+  """
+  Sort products by publication date.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  PUBLICATION_DATE @deprecated(reason: "Use `PUBLISHED_AT` instead.")
+
+  """
+  Sort products by publication date.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  PUBLISHED_AT
+
+  """Sort products by update date."""
+  LAST_MODIFIED_AT
+
+  """
+  Sort products by collection. Note: This option is available only for the `Collection.products` query.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  COLLECTION
+
+  """Sort products by rating."""
+  RATING
+
+  """Sort products by creation date."""
+  CREATED_AT
 }
 
-"""Represents shipping method translations."""
-type ShippingMethodTranslation implements Node @doc(category: "Shipping") {
-  """The ID of the shipping method translation."""
+"""Represents an image."""
+type Image {
+  """The URL of the image."""
+  url: String!
+
+  """Alt text for an image."""
+  alt: String
+}
+
+enum ThumbnailFormatEnum {
+  ORIGINAL
+  AVIF
+  WEBP
+}
+
+"""Represents category translations."""
+type CategoryTranslation implements Node @doc(category: "Products") {
+  """The ID of the category translation."""
   id: ID!
 
   """Translation language."""
   language: LanguageDisplay!
 
-  """Translated shipping method name."""
+  """Translated SEO title."""
+  seoTitle: String
+
+  """Translated SEO description."""
+  seoDescription: String
+
+  """
+  Translated category slug.
+  
+  Added in Saleor 3.21.
+  """
+  slug: String
+
+  """Translated category name."""
   name: String
 
   """
-  Translated description of the shipping method.
+  Translated description of the category.
   
   Rich text format. For reference see https://editorjs.io/
   """
   description: JSONString
 
-  """Represents the shipping method fields to translate."""
-  translatableContent: ShippingMethodTranslatableContent
+  """
+  Translated description of the category.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  descriptionJson: JSONString @deprecated(reason: "Use the `description` field instead.")
+
+  """Represents the category fields to translate."""
+  translatableContent: CategoryTranslatableContent
 }
 
 type LanguageDisplay {
@@ -6767,1983 +7317,6 @@ enum LanguageCodeEnum {
 }
 
 """
-Represents shipping method's original translatable fields and related translations.
-"""
-type ShippingMethodTranslatableContent implements Node @doc(category: "Shipping") {
-  """The ID of the shipping method translatable content."""
-  id: ID!
-
-  """The ID of the shipping method to translate."""
-  shippingMethodId: ID!
-
-  """Shipping method name to translate."""
-  name: String!
-
-  """
-  Shipping method description to translate.
-  
-  Rich text format. For reference see https://editorjs.io/
-  """
-  description: JSONString
-
-  """Returns translated shipping method fields for the given language code."""
-  translation(
-    """A language code to return the translation for shipping method."""
-    languageCode: LanguageCodeEnum!
-  ): ShippingMethodTranslation
-
-  """
-  Shipping method are the methods you'll use to get customer's orders  to them. They are directly exposed to the customers.
-  
-  Requires one of the following permissions: MANAGE_SHIPPING.
-  """
-  shippingMethod: ShippingMethodType @deprecated(reason: "Get model fields from the root level queries.")
-}
-
-"""Represents shipping method channel listing."""
-type ShippingMethodChannelListing implements Node @doc(category: "Shipping") {
-  """The ID of shipping method channel listing."""
-  id: ID!
-
-  """The channel associated with the shipping method channel listing."""
-  channel: Channel!
-
-  """Maximum order price."""
-  maximumOrderPrice: Money
-
-  """Minimum order price."""
-  minimumOrderPrice: Money
-
-  """Price of the shipping method in the associated channel."""
-  price: Money
-}
-
-"""Represents shipping method postal code rule."""
-type ShippingMethodPostalCodeRule implements Node @doc(category: "Shipping") {
-  """The ID of the object."""
-  id: ID!
-
-  """Start address range."""
-  start: String
-
-  """End address range."""
-  end: String
-
-  """Inclusion type of the postal code rule."""
-  inclusionType: PostalCodeRuleInclusionTypeEnum
-}
-
-enum PostalCodeRuleInclusionTypeEnum @doc(category: "Shipping") {
-  INCLUDE
-  EXCLUDE
-}
-
-type ProductCountableConnection @doc(category: "Products") {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-  edges: [ProductCountableEdge!]!
-
-  """A total count of items in the collection."""
-  totalCount: Int
-}
-
-type ProductCountableEdge @doc(category: "Products") {
-  """The item at the end of the edge."""
-  node: Product!
-
-  """A cursor for use in pagination."""
-  cursor: String!
-}
-
-"""Represents an individual item for sale in the storefront."""
-type Product implements Node & ObjectWithMetadata & ObjectWithAttributes @doc(category: "Products") {
-  """The ID of the product."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """
-  Get a single attribute attached to product by attribute slug.
-  
-  Added in Saleor 3.22.
-  """
-  assignedAttribute(
-    """Slug of the attribute"""
-    slug: String!
-  ): AssignedAttribute
-
-  """
-  List of attributes assigned to this product.
-  
-  Added in Saleor 3.22.
-  """
-  assignedAttributes(
-    """Maximum number of attributes to return. Default is 100."""
-    limit: PositiveInt = 100
-  ): [AssignedAttribute!]!
-
-  """SEO title of the product."""
-  seoTitle: String
-
-  """SEO description of the product."""
-  seoDescription: String
-
-  """SEO description of the product."""
-  name: String!
-
-  """
-  Description of the product.
-  
-  Rich text format. For reference see https://editorjs.io/
-  """
-  description: JSONString
-
-  """Type of the product."""
-  productType: ProductType!
-
-  """Slug of the product."""
-  slug: String!
-  category: Category
-
-  """The date and time when the product was created."""
-  created: DateTime!
-
-  """The date and time when the product was last updated."""
-  updatedAt: DateTime!
-  chargeTaxes: Boolean! @deprecated(reason: "Use `Channel.taxConfiguration` field to determine whether tax collection is enabled.")
-
-  """Weight of the product."""
-  weight: Weight
-
-  """Default variant of the product."""
-  defaultVariant: ProductVariant
-
-  """Rating of the product."""
-  rating: Float
-
-  """
-  Channel given to retrieve this product. Also used by federation gateway to resolve this object in a federated query.
-  """
-  channel: String
-
-  """
-  Description of the product.
-  
-  Rich text format. For reference see https://editorjs.io/
-  """
-  descriptionJson: JSONString @deprecated(reason: "Use the `description` field instead.")
-
-  """Thumbnail of the product."""
-  thumbnail(
-    """
-    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
-    """
-    size: Int
-
-    """
-    The format of the image. When not provided, format of the original image will be used.
-    """
-    format: ThumbnailFormatEnum = ORIGINAL
-  ): Image
-
-  """
-  Lists the storefront product's pricing, the current price and discounts, only meant for displaying.
-  """
-  pricing(
-    """
-    Destination address used to find warehouses where stock availability for this product is checked. If address is empty, uses `Shop.companyAddress` or fallbacks to server's `settings.DEFAULT_COUNTRY` configuration.
-    """
-    address: AddressInput
-  ): ProductPricingInfo
-
-  """
-  Whether the product is in stock, set as available for purchase in the given channel, and published.
-  """
-  isAvailable(
-    """
-    Destination address used to find warehouses where stock availability for this product is checked. If address is empty, uses `Shop.companyAddress` or fallbacks to server's `settings.DEFAULT_COUNTRY` configuration. When `Shop.useLegacyShippingZoneStockAvailability` is disabled, this argument is ignored — stock availability is determined by the direct warehouse-channel link instead of shipping zones.
-    """
-    address: AddressInput @deprecated
-  ): Boolean
-
-  """A type of tax. Assigned by enabled tax gateway"""
-  taxType: TaxType @deprecated(reason: "Use `taxClass` field instead.")
-
-  """Get a single attribute attached to product by attribute slug."""
-  attribute(
-    """Slug of the attribute"""
-    slug: String!
-  ): SelectedAttribute @deprecated(reason: "Use the `assignedAttribute` field instead.")
-
-  """List of attributes assigned to this product."""
-  attributes: [SelectedAttribute!]! @deprecated(reason: "Use the `assignedAttributes` field instead.")
-
-  """
-  List of availability in channels for the product.
-  
-  Requires one of the following permissions: MANAGE_PRODUCTS.
-  """
-  channelListings: [ProductChannelListing!]
-
-  """Get a single product media by ID."""
-  mediaById(
-    """ID of a product media."""
-    id: ID!
-  ): ProductMedia
-
-  """Get a single product image by ID."""
-  imageById(
-    """ID of a product image."""
-    id: ID!
-  ): ProductImage @deprecated(reason: "Use the `mediaById` field instead.")
-
-  """Get a single variant by SKU or ID."""
-  variant(
-    """ID of the variant."""
-    id: ID
-
-    """SKU of the variant."""
-    sku: String
-  ): ProductVariant @deprecated(reason: "Use top-level `variant` query.")
-
-  """
-  List of variants for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
-  """
-  variants: [ProductVariant!] @deprecated(reason: "Use `productVariants` field instead.")
-
-  """
-  List of variants for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
-  
-  Added in Saleor 3.21.
-  """
-  productVariants(
-    """Filtering options for product variant."""
-    filter: ProductVariantFilterInput @deprecated(reason: "Use `where` filter instead.")
-
-    """Where filtering options for product variants."""
-    where: ProductVariantWhereInput
-
-    """Sort products variants."""
-    sortBy: ProductVariantSortingInput
-
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """
-    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    first: Int
-
-    """
-    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    last: Int
-  ): ProductVariantCountableConnection
-
-  """List of media for the product."""
-  media(
-    """Sort media."""
-    sortBy: MediaSortingInput
-  ): [ProductMedia!]
-
-  """List of images for the product."""
-  images: [ProductImage!] @deprecated(reason: "Use the `media` field instead.")
-
-  """
-  List of collections for the product. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
-  """
-  collections: [Collection!]
-
-  """Returns translated product fields for the given language code."""
-  translation(
-    """A language code to return the translation for product."""
-    languageCode: LanguageCodeEnum!
-  ): ProductTranslation
-
-  """Date when product is available for purchase."""
-  availableForPurchase: Date @deprecated(reason: "Use the `availableForPurchaseAt` field to fetch the available for purchase date.")
-
-  """Date when product is available for purchase."""
-  availableForPurchaseAt: DateTime
-
-  """
-  Refers to a state that can be set by admins to control whether a product is available for purchase in storefronts. This does not guarantee the availability of stock. When set to `False`, this product is still visible to customers, but it cannot be purchased.
-  """
-  isAvailableForPurchase: Boolean
-
-  """
-  Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
-  
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
-  """
-  taxClass: TaxClass
-
-  """External ID of this product."""
-  externalReference: String
-}
-
-"""
-An object with attributes.
-
-Added in Saleor 3.22.
-"""
-interface ObjectWithAttributes @doc(category: "Attributes") {
-  """
-  Get a single attribute attached to the object by attribute slug.
-  
-  Added in Saleor 3.22.
-  """
-  assignedAttribute(
-    """Slug of the attribute"""
-    slug: String!
-  ): AssignedAttribute @doc(category: "Attributes")
-
-  """
-  List of attributes assigned to the object.
-  
-  Added in Saleor 3.22.
-  """
-  assignedAttributes(
-    """Maximum number of attributes to return. Default is 100."""
-    limit: PositiveInt = 100
-  ): [AssignedAttribute!]!
-}
-
-"""
-Represents an attribute assigned to an object.
-
-Added in Saleor 3.22.
-"""
-interface AssignedAttribute @doc(category: "Attributes") {
-  """Attribute assigned to an object."""
-  attribute: Attribute!
-}
-
-"""
-Custom attribute of a product. Attributes can be assigned to products and variants at the product type level.
-"""
-type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes") {
-  """The ID of the attribute."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """The input type to use for entering attribute values in the dashboard."""
-  inputType: AttributeInputTypeEnum
-
-  """The entity type which can be used as a reference."""
-  entityType: AttributeEntityTypeEnum
-
-  """
-  The reference types (product or page type) that are used to narrow down the choices of reference objects.
-  
-  Added in Saleor 3.22.
-  """
-  referenceTypes(
-    """
-    Maximum number of objects to return. Value must be greater than 0. Default is 100.
-    """
-    limit: PositiveInt = 100
-  ): [ReferenceType!]
-
-  """Name of an attribute displayed in the interface."""
-  name: String!
-
-  """Internal representation of an attribute name."""
-  slug: String!
-
-  """The attribute type."""
-  type: AttributeTypeEnum!
-
-  """The unit of attribute values."""
-  unit: MeasurementUnitsEnum
-
-  """
-  A list of predefined attribute choices available for selection. Available only for attributes with predefined choices.
-  """
-  choices(
-    """Sort attribute choices."""
-    sortBy: AttributeChoicesSortingInput
-
-    """Filtering options for attribute choices."""
-    filter: AttributeValueFilterInput @deprecated(reason: "Use `where` filter instead.")
-
-    """
-    Where filtering options for attribute choices.
-    
-    Added in Saleor 3.22.
-    """
-    where: AttributeValueWhereInput
-
-    """
-    Search attribute choices.
-    
-    Added in Saleor 3.22.
-    """
-    search: String
-
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """
-    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    first: Int
-
-    """
-    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    last: Int
-  ): AttributeValueCountableConnection
-
-  """
-  Whether the attribute requires values to be passed or not. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  """
-  valueRequired: Boolean!
-
-  """
-  Whether the attribute should be visible or not in storefront. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  """
-  visibleInStorefront: Boolean!
-
-  """
-  Whether the attribute can be filtered in storefront. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  """
-  filterableInStorefront: Boolean! @deprecated
-
-  """
-  Whether the attribute can be filtered in dashboard. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  """
-  filterableInDashboard: Boolean!
-
-  """
-  Whether the attribute can be displayed in the admin product list. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  """
-  availableInGrid: Boolean! @deprecated
-
-  """
-  The position of the attribute in the storefront navigation (0 by default). Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
-  """
-  storefrontSearchPosition: Int! @deprecated
-
-  """Returns translated attribute fields for the given language code."""
-  translation(
-    """A language code to return the translation for attribute."""
-    languageCode: LanguageCodeEnum!
-  ): AttributeTranslation
-
-  """Flag indicating that attribute has predefined choices."""
-  withChoices: Boolean!
-
-  """
-  A list of product types that use this attribute as a product attribute.
-  """
-  productTypes(
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """
-    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    first: Int
-
-    """
-    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    last: Int
-  ): ProductTypeCountableConnection!
-
-  """
-  A list of product types that use this attribute as a product variant attribute.
-  """
-  productVariantTypes(
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """
-    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    first: Int
-
-    """
-    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    last: Int
-  ): ProductTypeCountableConnection!
-
-  """External ID of this attribute."""
-  externalReference: String
-}
-
-enum AttributeInputTypeEnum @doc(category: "Attributes") {
-  DROPDOWN
-  MULTISELECT
-  FILE
-  REFERENCE
-  SINGLE_REFERENCE
-  NUMERIC
-  RICH_TEXT
-  PLAIN_TEXT
-  SWATCH
-  BOOLEAN
-  DATE
-  DATE_TIME
-}
-
-enum AttributeEntityTypeEnum @doc(category: "Attributes") {
-  PAGE
-  PRODUCT
-  PRODUCT_VARIANT
-  CATEGORY
-  COLLECTION
-}
-
-"""
-The reference types (product or page type) that are used to narrow down the choices of reference objects.
-ProductType applicable for reference attribute with `PRODUCT` or `PRODUCT_VARIANT` entity type.
-PageType applicable for reference attribute with `PAGE` entity type.
-"""
-union ReferenceType = ProductType | PageType
-
-"""
-Represents a type of product. It defines what attributes are available to products of this type.
-"""
-type ProductType implements Node & ObjectWithMetadata @doc(category: "Products") {
-  """The ID of the product type."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """Name of the product type."""
-  name: String!
-
-  """Slug of the product type."""
-  slug: String!
-
-  """Whether the product type has variants."""
-  hasVariants: Boolean! @deprecated(reason: "This is a leftover from the past Simple/Configurable product distinction. Products can have multiple variants regardless of this setting. ")
-
-  """Whether shipping is required for this product type."""
-  isShippingRequired: Boolean!
-
-  """
-  Whether the product type is digital - doesn't have any effect, it's present for backward-compatibility.
-  """
-  isDigital: Boolean! @deprecated(reason: "Will be removed in v3.24.0, use metadata or attributes instead.")
-
-  """Weight of the product type."""
-  weight: Weight
-
-  """The product type kind."""
-  kind: ProductTypeKindEnum!
-
-  """List of products of this type."""
-  products(
-    """Slug of a channel for which the data should be returned."""
-    channel: String
-
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """
-    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    first: Int
-
-    """
-    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    last: Int
-  ): ProductCountableConnection @deprecated(reason: "Use the top-level `products` query with the `productTypes` filter.")
-
-  """A type of tax. Assigned by enabled tax gateway"""
-  taxType: TaxType @deprecated(reason: "Use `taxClass` field instead.")
-
-  """
-  Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
-  
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
-  """
-  taxClass: TaxClass
-
-  """Variant attributes of that product type."""
-  variantAttributes(
-    """Define scope of returned attributes."""
-    variantSelection: VariantAttributeScope
-  ): [Attribute!] @deprecated(reason: "Use `assignedVariantAttributes` instead.")
-
-  """
-  Variant attributes of that product type with attached variant selection.
-  """
-  assignedVariantAttributes(
-    """Define scope of returned attributes."""
-    variantSelection: VariantAttributeScope
-  ): [AssignedVariantAttribute!]
-
-  """Product attributes of that product type."""
-  productAttributes: [Attribute!]
-
-  """
-  List of attributes which can be assigned to this product type.
-  
-  Requires one of the following permissions: MANAGE_PRODUCTS.
-  """
-  availableAttributes(
-    """Filtering options for attributes of this product type."""
-    filter: AttributeFilterInput @deprecated(reason: "Use `where` filter instead.")
-
-    """Where filtering options for attributes of this product type."""
-    where: AttributeWhereInput
-
-    """Search attributes."""
-    search: String
-
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """
-    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    first: Int
-
-    """
-    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    last: Int
-  ): AttributeCountableConnection
-}
-
-"""Represents weight value in a specific weight unit."""
-type Weight {
-  """Weight unit."""
-  unit: WeightUnitsEnum!
-
-  """Weight value. Returns a value with maximal three decimal places"""
-  value: Float!
-}
-
-enum WeightUnitsEnum {
-  G
-  LB
-  OZ
-  KG
-  TONNE
-}
-
-enum ProductTypeKindEnum @doc(category: "Products") {
-  NORMAL
-  GIFT_CARD
-}
-
-"""Representation of tax types fetched from tax gateway."""
-type TaxType @doc(category: "Taxes") {
-  """Description of the tax type."""
-  description: String
-
-  """External tax code used to identify given tax group."""
-  taxCode: String
-}
-
-"""
-Tax class is a named object used to define tax rates per country. Tax class can be assigned to product types, products and shipping methods to define their tax rates.
-"""
-type TaxClass implements Node & ObjectWithMetadata @doc(category: "Taxes") {
-  """The ID of the object."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """Name of the tax class."""
-  name: String!
-
-  """Country-specific tax rates for this tax class."""
-  countries: [TaxClassCountryRate!]!
-}
-
-"""
-Tax rate for a country. When tax class is null, it represents the default tax rate for that country; otherwise it's a country tax rate specific to the given tax class.
-"""
-type TaxClassCountryRate @doc(category: "Taxes") {
-  """Country in which this tax rate applies."""
-  country: CountryDisplay!
-
-  """Tax rate value."""
-  rate: Float!
-
-  """Related tax class."""
-  taxClass: TaxClass
-}
-
-enum VariantAttributeScope @doc(category: "Products") {
-  ALL
-  VARIANT_SELECTION
-  NOT_VARIANT_SELECTION
-}
-
-"""
-Represents assigned attribute to variant with variant selection attached.
-"""
-type AssignedVariantAttribute @doc(category: "Attributes") {
-  """Attribute assigned to variant."""
-  attribute: Attribute!
-
-  """
-  Determines, whether assigned attribute is allowed for variant selection. Supported variant types for variant selection are: ['dropdown', 'boolean', 'swatch', 'numeric']
-  """
-  variantSelection: Boolean!
-}
-
-type AttributeCountableConnection @doc(category: "Attributes") {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-  edges: [AttributeCountableEdge!]!
-
-  """A total count of items in the collection."""
-  totalCount: Int
-}
-
-type AttributeCountableEdge @doc(category: "Attributes") {
-  """The item at the end of the edge."""
-  node: Attribute!
-
-  """A cursor for use in pagination."""
-  cursor: String!
-}
-
-input AttributeFilterInput @doc(category: "Attributes") {
-  valueRequired: Boolean
-  isVariantOnly: Boolean
-  visibleInStorefront: Boolean
-  filterableInStorefront: Boolean
-  filterableInDashboard: Boolean
-  availableInGrid: Boolean
-  metadata: [MetadataFilter!]
-  search: String
-  ids: [ID!]
-  type: AttributeTypeEnum
-  inCollection: ID
-  inCategory: ID
-  slugs: [String!]
-
-  """Specifies the channel by which the data should be filtered."""
-  channel: String @deprecated(reason: "Use root-level channel argument instead.")
-}
-
-input MetadataFilter {
-  """Key of a metadata item."""
-  key: String!
-
-  """Value of a metadata item."""
-  value: String
-}
-
-enum AttributeTypeEnum @doc(category: "Attributes") {
-  PRODUCT_TYPE
-  PAGE_TYPE
-  CUSTOMER_TYPE
-}
-
-"""Where filtering options."""
-input AttributeWhereInput @doc(category: "Attributes") {
-  metadata: [MetadataFilter!]
-  ids: [ID!]
-  name: StringFilterInput
-  slug: StringFilterInput
-  withChoices: Boolean
-  inputType: AttributeInputTypeEnumFilterInput
-  entityType: AttributeEntityTypeEnumFilterInput
-  type: AttributeTypeEnumFilterInput
-  unit: MeasurementUnitsEnumFilterInput
-  inCollection: ID
-  inCategory: ID
-  valueRequired: Boolean
-  visibleInStorefront: Boolean
-  filterableInDashboard: Boolean
-
-  """List of conditions that must be met."""
-  AND: [AttributeWhereInput!]
-
-  """A list of conditions of which at least one must be met."""
-  OR: [AttributeWhereInput!]
-}
-
-"""Define the filtering options for string fields."""
-input StringFilterInput {
-  """The value equal to."""
-  eq: String
-
-  """The value included in."""
-  oneOf: [String!]
-}
-
-input AttributeInputTypeEnumFilterInput @doc(category: "Attributes") {
-  """The value equal to."""
-  eq: AttributeInputTypeEnum
-
-  """The value included in."""
-  oneOf: [AttributeInputTypeEnum!]
-}
-
-input AttributeEntityTypeEnumFilterInput @doc(category: "Attributes") {
-  """The value equal to."""
-  eq: AttributeEntityTypeEnum
-
-  """The value included in."""
-  oneOf: [AttributeEntityTypeEnum!]
-}
-
-input AttributeTypeEnumFilterInput @doc(category: "Attributes") {
-  """The value equal to."""
-  eq: AttributeTypeEnum
-
-  """The value included in."""
-  oneOf: [AttributeTypeEnum!]
-}
-
-input MeasurementUnitsEnumFilterInput @doc(category: "Attributes") {
-  """The value equal to."""
-  eq: MeasurementUnitsEnum
-
-  """The value included in."""
-  oneOf: [MeasurementUnitsEnum!]
-}
-
-enum MeasurementUnitsEnum {
-  MM
-  CM
-  DM
-  M
-  KM
-  FT
-  YD
-  INCH
-  SQ_MM
-  SQ_CM
-  SQ_DM
-  SQ_M
-  SQ_KM
-  SQ_FT
-  SQ_YD
-  SQ_INCH
-  CUBIC_MILLIMETER
-  CUBIC_CENTIMETER
-  CUBIC_DECIMETER
-  CUBIC_METER
-  LITER
-  CUBIC_FOOT
-  CUBIC_INCH
-  CUBIC_YARD
-  QT
-  PINT
-  FL_OZ
-  ACRE_IN
-  ACRE_FT
-  G
-  LB
-  OZ
-  KG
-  TONNE
-}
-
-"""
-Represents a type of page. It defines what attributes are available to pages of this type.
-"""
-type PageType implements Node & ObjectWithMetadata @doc(category: "Pages") {
-  """ID of the page type."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """Name of the page type."""
-  name: String!
-
-  """Slug of the page type."""
-  slug: String!
-
-  """Page attributes of that page type."""
-  attributes: [Attribute!]
-
-  """
-  Attributes that can be assigned to the page type.
-  
-  Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
-  """
-  availableAttributes(
-    """Filtering options for attributes."""
-    filter: AttributeFilterInput @deprecated(reason: "Use `where` filter instead.")
-
-    """Where filtering options for attributes."""
-    where: AttributeWhereInput
-
-    """Search attributes."""
-    search: String
-
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """
-    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    first: Int
-
-    """
-    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    last: Int
-  ): AttributeCountableConnection
-
-  """
-  Whether page type has pages assigned.
-  
-  Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
-  """
-  hasPages: Boolean
-}
-
-"""
-Positive Integer scalar implementation.
-
-Should be used in places where value must be positive (greater than 0).
-"""
-scalar PositiveInt
-
-type AttributeValueCountableConnection @doc(category: "Attributes") {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-  edges: [AttributeValueCountableEdge!]!
-
-  """A total count of items in the collection."""
-  totalCount: Int
-}
-
-type AttributeValueCountableEdge @doc(category: "Attributes") {
-  """The item at the end of the edge."""
-  node: AttributeValue!
-
-  """A cursor for use in pagination."""
-  cursor: String!
-}
-
-"""Represents a value of an attribute."""
-type AttributeValue implements Node @doc(category: "Attributes") {
-  """The ID of the attribute value."""
-  id: ID!
-
-  """Name of a value displayed in the interface."""
-  name: String
-
-  """Internal representation of a value (unique per attribute)."""
-  slug: String
-
-  """
-  Represent value of the attribute value (e.g. color values for swatch attributes).
-  """
-  value: String
-
-  """Returns translated attribute value fields for the given language code."""
-  translation(
-    """A language code to return the translation for attribute value."""
-    languageCode: LanguageCodeEnum!
-  ): AttributeValueTranslation
-
-  """The input type to use for entering attribute values in the dashboard."""
-  inputType: AttributeInputTypeEnum
-
-  """The ID of the referenced object."""
-  reference: ID
-
-  """Represents file URL and content type (if attribute value is a file)."""
-  file: File
-
-  """
-  Represents the text of the attribute value, includes formatting.
-  
-  Rich text format. For reference see https://editorjs.io/
-  """
-  richText: JSONString
-
-  """
-  Represents the text of the attribute value, plain text without formatting.
-  """
-  plainText: String
-
-  """Represents the boolean value of the attribute value."""
-  boolean: Boolean
-
-  """Represents the date value of the attribute value."""
-  date: Date
-
-  """Represents the date/time value of the attribute value."""
-  dateTime: DateTime
-
-  """External ID of this attribute value."""
-  externalReference: String
-}
-
-"""Represents attribute value translations."""
-type AttributeValueTranslation implements Node @doc(category: "Attributes") {
-  """The ID of the attribute value translation."""
-  id: ID!
-
-  """Translation language."""
-  language: LanguageDisplay!
-
-  """Translated attribute value name."""
-  name: String!
-
-  """
-  Translated rich-text attribute value.
-  
-  Rich text format. For reference see https://editorjs.io/
-  """
-  richText: JSONString
-
-  """Translated plain text attribute value ."""
-  plainText: String
-
-  """Represents the attribute value fields to translate."""
-  translatableContent: AttributeValueTranslatableContent
-}
-
-"""
-Represents attribute value's original translatable fields and related translations.
-"""
-type AttributeValueTranslatableContent implements Node @doc(category: "Attributes") {
-  """The ID of the attribute value translatable content."""
-  id: ID!
-
-  """The ID of the attribute value to translate."""
-  attributeValueId: ID!
-
-  """Name of the attribute value to translate."""
-  name: String!
-
-  """
-  Attribute value.
-  
-  Rich text format. For reference see https://editorjs.io/
-  """
-  richText: JSONString
-
-  """Attribute plain text value."""
-  plainText: String
-
-  """Returns translated attribute value fields for the given language code."""
-  translation(
-    """A language code to return the translation for attribute value."""
-    languageCode: LanguageCodeEnum!
-  ): AttributeValueTranslation
-
-  """Represents a value of an attribute."""
-  attributeValue: AttributeValue @deprecated(reason: "Get model fields from the root level queries.")
-
-  """Associated attribute that can be translated."""
-  attribute: AttributeTranslatableContent
-}
-
-"""
-Represents attribute's original translatable fields and related translations.
-"""
-type AttributeTranslatableContent implements Node @doc(category: "Attributes") {
-  """The ID of the attribute translatable content."""
-  id: ID!
-
-  """The ID of the attribute to translate."""
-  attributeId: ID!
-
-  """Name of the attribute to translate."""
-  name: String!
-
-  """Returns translated attribute fields for the given language code."""
-  translation(
-    """A language code to return the translation for attribute."""
-    languageCode: LanguageCodeEnum!
-  ): AttributeTranslation
-
-  """Custom attribute of a product."""
-  attribute: Attribute @deprecated(reason: "Get model fields from the root level queries.")
-}
-
-"""Represents attribute translations."""
-type AttributeTranslation implements Node @doc(category: "Attributes") {
-  """The ID of the attribute translation."""
-  id: ID!
-
-  """Translation language."""
-  language: LanguageDisplay!
-
-  """Translated attribute name."""
-  name: String!
-
-  """Represents the attribute fields to translate."""
-  translatableContent: AttributeTranslatableContent
-}
-
-type File {
-  """The URL of the file."""
-  url: String!
-
-  """Content type of the file."""
-  contentType: String
-}
-
-"""
-The `Date` scalar type represents a Date
-value as specified by
-[iso8601](https://en.wikipedia.org/wiki/ISO_8601).
-"""
-scalar Date
-
-input AttributeChoicesSortingInput @doc(category: "Attributes") {
-  """Specifies the direction in which to sort attribute choices."""
-  direction: OrderDirection!
-
-  """Sort attribute choices by the selected field."""
-  field: AttributeChoicesSortField!
-}
-
-enum OrderDirection {
-  """Specifies an ascending sort order."""
-  ASC
-
-  """Specifies a descending sort order."""
-  DESC
-}
-
-enum AttributeChoicesSortField @doc(category: "Attributes") {
-  """Sort attribute choice by name."""
-  NAME
-
-  """Sort attribute choice by slug."""
-  SLUG
-}
-
-input AttributeValueFilterInput @doc(category: "Attributes") {
-  search: String
-  ids: [ID!]
-  slugs: [String!]
-}
-
-"""Where filtering options for attribute values."""
-input AttributeValueWhereInput @doc(category: "Attributes") {
-  ids: [ID!]
-  name: StringFilterInput
-  slug: StringFilterInput
-
-  """List of conditions that must be met."""
-  AND: [AttributeValueWhereInput!]
-
-  """A list of conditions of which at least one must be met."""
-  OR: [AttributeValueWhereInput!]
-}
-
-type ProductTypeCountableConnection @doc(category: "Products") {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-  edges: [ProductTypeCountableEdge!]!
-
-  """A total count of items in the collection."""
-  totalCount: Int
-}
-
-type ProductTypeCountableEdge @doc(category: "Products") {
-  """The item at the end of the edge."""
-  node: ProductType!
-
-  """A cursor for use in pagination."""
-  cursor: String!
-}
-
-"""
-Represents a single category of products. Categories allow to organize products in a tree-hierarchies which can be used for navigation in the storefront.
-"""
-type Category implements Node & ObjectWithMetadata @doc(category: "Products") {
-  """The ID of the category."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """SEO title of category."""
-  seoTitle: String
-
-  """SEO description of category."""
-  seoDescription: String
-
-  """Name of category"""
-  name: String!
-
-  """
-  Description of the category.
-  
-  Rich text format. For reference see https://editorjs.io/
-  """
-  description: JSONString
-
-  """Slug of the category."""
-  slug: String!
-
-  """Parent category."""
-  parent: Category
-
-  """Level of the category."""
-  level: Int!
-
-  """
-  Description of the category.
-  
-  Rich text format. For reference see https://editorjs.io/
-  """
-  descriptionJson: JSONString @deprecated(reason: "Use the `description` field instead.")
-
-  """The date and time when the category was last updated."""
-  updatedAt: DateTime!
-
-  """List of ancestors of the category."""
-  ancestors(
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """
-    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    first: Int
-
-    """
-    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    last: Int
-  ): CategoryCountableConnection
-
-  """
-  List of products in the category. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
-  """
-  products(
-    """Filtering options for products."""
-    filter: ProductFilterInput @deprecated(reason: "Use `where` filter instead.")
-
-    """Where filtering options for products."""
-    where: ProductWhereInput
-
-    """Sort products."""
-    sortBy: ProductOrder
-
-    """Search products."""
-    search: String
-
-    """Slug of a channel for which the data should be returned."""
-    channel: String
-
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """
-    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    first: Int
-
-    """
-    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    last: Int
-  ): ProductCountableConnection
-
-  """List of children of the category."""
-  children(
-    """Return the elements in the list that come before the specified cursor."""
-    before: String
-
-    """Return the elements in the list that come after the specified cursor."""
-    after: String
-
-    """
-    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    first: Int
-
-    """
-    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
-    """
-    last: Int
-  ): CategoryCountableConnection
-
-  """Background image of the category."""
-  backgroundImage(
-    """
-    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
-    """
-    size: Int
-
-    """
-    The format of the image. When not provided, format of the original image will be used.
-    """
-    format: ThumbnailFormatEnum = ORIGINAL
-  ): Image
-
-  """Returns translated category fields for the given language code."""
-  translation(
-    """A language code to return the translation for category."""
-    languageCode: LanguageCodeEnum!
-  ): CategoryTranslation
-}
-
-type CategoryCountableConnection @doc(category: "Products") {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-  edges: [CategoryCountableEdge!]!
-
-  """A total count of items in the collection."""
-  totalCount: Int
-}
-
-type CategoryCountableEdge @doc(category: "Products") {
-  """The item at the end of the edge."""
-  node: Category!
-
-  """A cursor for use in pagination."""
-  cursor: String!
-}
-
-input ProductFilterInput @doc(category: "Products") {
-  isPublished: Boolean
-  collections: [ID!]
-  categories: [ID!]
-  hasCategory: Boolean
-  attributes: [AttributeInput!]
-
-  """Filter by variants having specific stock status."""
-  stockAvailability: StockAvailability
-  stocks: ProductStockFilterInput
-  search: String
-  metadata: [MetadataFilter!]
-
-  """Filter by the publication date."""
-  publishedFrom: DateTime
-
-  """Filter by availability for purchase."""
-  isAvailable: Boolean
-
-  """Filter by the date of availability for purchase."""
-  availableFrom: DateTime
-
-  """Filter by visibility in product listings."""
-  isVisibleInListing: Boolean
-  price: PriceRangeInput
-
-  """Filter by the lowest variant price after discounts."""
-  minimalPrice: PriceRangeInput
-
-  """Filter by when was the most recent update."""
-  updatedAt: DateTimeRangeInput
-  productTypes: [ID!]
-
-  """Filter on whether product is a gift card or not."""
-  giftCard: Boolean
-  ids: [ID!]
-  hasPreorderedVariants: Boolean
-  slugs: [String!]
-
-  """Specifies the channel by which the data should be filtered."""
-  channel: String @deprecated(reason: "Use root-level channel argument instead.")
-}
-
-input AttributeInput @doc(category: "Attributes") {
-  """Internal representation of an attribute name."""
-  slug: String
-
-  """
-  Filter by value of the attribute. Only one value input field is allowed. If provided more than one, the error will be raised. Cannot be combined with deprecated fields of `AttributeInput`.
-  """
-  value: AssignedAttributeValueInput
-
-  """
-  Slugs identifying the attributeValues associated with the Attribute. When specified, it filters the results to include only records with one of the matching values. Requires `slug` to be provided.
-  """
-  values: [String!] @deprecated(reason: "Use `value` instead.")
-
-  """
-  The range that the returned values should be in. Requires `slug` to be provided.
-  """
-  valuesRange: IntRangeInput @deprecated(reason: "Use `value` instead.")
-
-  """
-  The date/time range that the returned values should be in. Requires `slug` to be provided.
-  """
-  dateTime: DateTimeRangeInput @deprecated(reason: "Use `value` instead.")
-
-  """
-  The date range that the returned values should be in. In case of date/time attributes, the UTC midnight of the given date is used. Requires `slug` to be provided.
-  """
-  date: DateRangeInput @deprecated(reason: "Use `value` instead.")
-
-  """The boolean value of the attribute. Requires `slug` to be provided."""
-  boolean: Boolean @deprecated(reason: "Use `value` instead.")
-}
-
-input AssignedAttributeValueInput {
-  """Filter by slug assigned to AttributeValue."""
-  slug: StringFilterInput
-
-  """Filter by name assigned to AttributeValue."""
-  name: StringFilterInput
-
-  """Filter by numeric value for attributes of numeric type."""
-  numeric: DecimalFilterInput
-
-  """Filter by date value for attributes of date type."""
-  date: DateRangeInput
-
-  """Filter by date time value for attributes of date time type."""
-  dateTime: DateTimeRangeInput
-
-  """Filter by boolean value for attributes of boolean type."""
-  boolean: Boolean
-
-  """Filter by reference attribute value."""
-  reference: AssignedAttributeReferenceInput
-}
-
-"""Define the filtering options for decimal fields."""
-input DecimalFilterInput {
-  """The value equal to."""
-  eq: Decimal
-
-  """The value included in."""
-  oneOf: [Decimal!]
-
-  """The value in range."""
-  range: DecimalRangeInput
-}
-
-"""
-Custom Decimal implementation.
-
-Returns Decimal as a float in the API,
-parses float to the Decimal on the way back.
-"""
-scalar Decimal
-
-input DecimalRangeInput {
-  """Decimal value greater than or equal to."""
-  gte: Decimal
-
-  """Decimal value less than or equal to."""
-  lte: Decimal
-}
-
-input DateRangeInput {
-  """Start date."""
-  gte: Date
-
-  """End date."""
-  lte: Date
-}
-
-input DateTimeRangeInput {
-  """Start date."""
-  gte: DateTime
-
-  """End date."""
-  lte: DateTime
-}
-
-input AssignedAttributeReferenceInput {
-  """
-  Returns objects with a reference pointing to an object identified by the given ID.
-  """
-  referencedIds: ContainsFilterInput
-
-  """
-  Returns objects with a reference pointing to a page identified by the given slug.
-  """
-  pageSlugs: ContainsFilterInput
-
-  """
-  Returns objects with a reference pointing to a product identified by the given slug.
-  """
-  productSlugs: ContainsFilterInput
-
-  """
-  Returns objects with a reference pointing to a product variant identified by the given sku.
-  """
-  productVariantSkus: ContainsFilterInput
-
-  """
-  Returns objects with a reference pointing to a category identified by the given slug.
-  """
-  categorySlugs: ContainsFilterInput
-
-  """
-  Returns objects with a reference pointing to a collection identified by the given slug.
-  """
-  collectionSlugs: ContainsFilterInput
-}
-
-"""
-Define the filtering options for fields that can contain multiple values.
-"""
-input ContainsFilterInput {
-  """The field contains at least one of the specified values."""
-  containsAny: [String!]
-
-  """The field contains all of the specified values."""
-  containsAll: [String!]
-}
-
-input IntRangeInput {
-  """Value greater than or equal to."""
-  gte: Int
-
-  """Value less than or equal to."""
-  lte: Int
-}
-
-enum StockAvailability @doc(category: "Products") {
-  IN_STOCK
-  OUT_OF_STOCK
-}
-
-input ProductStockFilterInput @doc(category: "Products") {
-  warehouseIds: [ID!]
-  quantity: IntRangeInput
-}
-
-input PriceRangeInput {
-  """Price greater than or equal to."""
-  gte: Float
-
-  """Price less than or equal to."""
-  lte: Float
-}
-
-input ProductWhereInput @doc(category: "Products") {
-  metadata: [MetadataFilter!]
-  ids: [ID!]
-
-  """Filter by product name."""
-  name: StringFilterInput
-
-  """Filter by product slug."""
-  slug: StringFilterInput
-
-  """Filter by product type."""
-  productType: GlobalIDFilterInput
-
-  """Filter by product category."""
-  category: GlobalIDFilterInput
-
-  """Filter by collection."""
-  collection: GlobalIDFilterInput
-
-  """Filter by availability for purchase."""
-  isAvailable: Boolean
-
-  """Filter by public visibility."""
-  isPublished: Boolean
-
-  """Filter by visibility on the channel."""
-  isVisibleInListing: Boolean
-
-  """Filter by the publication date."""
-  publishedFrom: DateTime
-
-  """Filter by the date of availability for purchase."""
-  availableFrom: DateTime
-
-  """Filter by product with category assigned."""
-  hasCategory: Boolean
-
-  """Filter by product variant price."""
-  price: DecimalFilterInput
-
-  """Filter by the lowest variant price after discounts."""
-  minimalPrice: DecimalFilterInput
-
-  """Filter by attributes associated with the product."""
-  attributes: [AttributeInput!]
-
-  """Filter by variants having specific stock status."""
-  stockAvailability: StockAvailability
-
-  """Filter by stock of the product variant."""
-  stocks: ProductStockFilterInput
-
-  """Filter on whether product is a gift card or not."""
-  giftCard: Boolean
-
-  """Filter by product with preordered variants."""
-  hasPreorderedVariants: Boolean
-
-  """Filter by when was the most recent update."""
-  updatedAt: DateTimeFilterInput
-
-  """List of conditions that must be met."""
-  AND: [ProductWhereInput!]
-
-  """A list of conditions of which at least one must be met."""
-  OR: [ProductWhereInput!]
-}
-
-"""Define the filtering options for foreign key fields."""
-input GlobalIDFilterInput {
-  """The value equal to."""
-  eq: ID
-
-  """The value included in."""
-  oneOf: [ID!]
-}
-
-"""Define the filtering options for date time fields."""
-input DateTimeFilterInput {
-  """The value equal to."""
-  eq: DateTime
-
-  """The value included in."""
-  oneOf: [DateTime!]
-
-  """The value in range."""
-  range: DateTimeRangeInput
-}
-
-input ProductOrder @doc(category: "Products") {
-  """Specifies the direction in which to sort products."""
-  direction: OrderDirection!
-
-  """Specifies the channel in which to sort the data."""
-  channel: String @deprecated(reason: "Use root-level channel argument instead.")
-
-  """
-  Sort product by the selected attribute's values.
-  Note: this doesn't take translations into account yet.
-  """
-  attributeId: ID
-
-  """Sort products by the selected field."""
-  field: ProductOrderField
-}
-
-enum ProductOrderField @doc(category: "Products") {
-  """Sort products by name."""
-  NAME
-
-  """
-  Sort products by rank. Note: This option is available only with the `search` filter.
-  """
-  RANK
-
-  """
-  Sort products by price.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  PRICE
-
-  """
-  Sort products by a minimal price of a product's variant.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  MINIMAL_PRICE
-
-  """Sort products by update date."""
-  LAST_MODIFIED @deprecated(reason: "Use `LAST_MODIFIED_AT` instead.")
-
-  """Sort products by update date."""
-  DATE @deprecated(reason: "Use `LAST_MODIFIED_AT` instead.")
-
-  """Sort products by type."""
-  TYPE
-
-  """
-  Sort products by publication status.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  PUBLISHED
-
-  """
-  Sort products by publication date.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  PUBLICATION_DATE @deprecated(reason: "Use `PUBLISHED_AT` instead.")
-
-  """
-  Sort products by publication date.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  PUBLISHED_AT
-
-  """Sort products by update date."""
-  LAST_MODIFIED_AT
-
-  """
-  Sort products by collection. Note: This option is available only for the `Collection.products` query.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  COLLECTION
-
-  """Sort products by rating."""
-  RATING
-
-  """Sort products by creation date."""
-  CREATED_AT
-}
-
-"""Represents an image."""
-type Image {
-  """The URL of the image."""
-  url: String!
-
-  """Alt text for an image."""
-  alt: String
-}
-
-enum ThumbnailFormatEnum {
-  ORIGINAL
-  AVIF
-  WEBP
-}
-
-"""Represents category translations."""
-type CategoryTranslation implements Node @doc(category: "Products") {
-  """The ID of the category translation."""
-  id: ID!
-
-  """Translation language."""
-  language: LanguageDisplay!
-
-  """Translated SEO title."""
-  seoTitle: String
-
-  """Translated SEO description."""
-  seoDescription: String
-
-  """
-  Translated category slug.
-  
-  Added in Saleor 3.21.
-  """
-  slug: String
-
-  """Translated category name."""
-  name: String
-
-  """
-  Translated description of the category.
-  
-  Rich text format. For reference see https://editorjs.io/
-  """
-  description: JSONString
-
-  """
-  Translated description of the category.
-  
-  Rich text format. For reference see https://editorjs.io/
-  """
-  descriptionJson: JSONString @deprecated(reason: "Use the `description` field instead.")
-
-  """Represents the category fields to translate."""
-  translatableContent: CategoryTranslatableContent
-}
-
-"""
 Represents category original translatable fields and related translations.
 """
 type CategoryTranslatableContent implements Node @doc(category: "Products") {
@@ -9002,120 +7575,785 @@ type ProductVariantChannelListing implements Node @doc(category: "Products") {
   preorderThreshold: PreorderThreshold
 }
 
-"""Represents preorder variant data for channel."""
-type PreorderThreshold @doc(category: "Products") {
-  """Preorder threshold for product variant in this channel."""
-  quantity: Int
+"""Represents channel."""
+type Channel implements Node & ObjectWithMetadata @doc(category: "Channels") {
+  """The ID of the channel."""
+  id: ID!
 
-  """Number of sold product variant in this channel."""
-  soldUnits: Int!
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """Slug of the channel."""
+  slug: String!
+
+  """
+  Name of the channel.
+  
+  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
+  """
+  name: String!
+
+  """
+  Whether the channel is active.
+  
+  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
+  """
+  isActive: Boolean!
+
+  """
+  A currency that is assigned to the channel.
+  
+  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
+  """
+  currencyCode: String!
+
+  """
+  Whether a channel has associated orders.
+  
+  Requires one of the following permissions: MANAGE_CHANNELS.
+  """
+  hasOrders: Boolean!
+
+  """
+  Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
+  
+  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
+  """
+  defaultCountry: CountryDisplay!
+
+  """
+  List of warehouses assigned to this channel.
+  
+  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
+  """
+  warehouses: [Warehouse!]!
+
+  """List of shippable countries for the channel."""
+  countries: [CountryDisplay!]
+
+  """Shipping methods that are available for the channel."""
+  availableShippingMethodsPerCountry(countries: [CountryCode!]): [ShippingMethodsPerCountry!]
+
+  """
+  Define the stock setting for this channel.
+  
+  Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
+  """
+  stockSettings: StockSettings!
+
+  """
+  Channel-specific order settings.
+  
+  Requires one of the following permissions: MANAGE_CHANNELS, MANAGE_ORDERS.
+  """
+  orderSettings: OrderSettings!
+
+  """
+  Channel-specific checkout settings.
+  
+  Requires one of the following permissions: MANAGE_CHANNELS, MANAGE_CHECKOUTS.
+  """
+  checkoutSettings: CheckoutSettings!
+
+  """
+  Channel-specific payment settings.
+  
+  Requires one of the following permissions: MANAGE_CHANNELS, HANDLE_PAYMENTS.
+  """
+  paymentSettings: PaymentSettings!
+
+  """
+  Channel specific tax configuration.
+  
+  Added in Saleor 3.20.
+  
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  """
+  taxConfiguration: TaxConfiguration!
 }
 
-"""Represents availability of a variant in the storefront."""
-type VariantPricingInfo @doc(category: "Products") {
-  """Whether it is in sale or not."""
-  onSale: Boolean
+type CountryDisplay {
+  """Country code."""
+  code: String!
 
-  """The discount amount if in sale (null otherwise)."""
-  discount: TaxedMoney
+  """Country name."""
+  country: String!
+
+  """Country tax."""
+  vat: VAT @deprecated(reason: "Always returns `null`. Use `TaxClassCountryRate` type to manage tax rates per country.")
+}
+
+"""Represents a VAT rate for a country."""
+type VAT @doc(category: "Taxes") {
+  """Country code."""
+  countryCode: String!
+
+  """Standard VAT rate in percent."""
+  standardRate: Float
+
+  """Country's VAT rate exceptions for specific types of goods."""
+  reducedRates: [ReducedRate!]!
+}
+
+"""Represents a reduced VAT rate for a particular type of goods."""
+type ReducedRate @doc(category: "Taxes") {
+  """Reduced VAT rate in percent."""
+  rate: Float!
+
+  """A type of goods."""
+  rateType: String!
+}
+
+"""Represents warehouse."""
+type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
+  """The ID of the warehouse."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
 
   """
-  The discount amount compared to prior price. Null if product is not on sale or prior price was not provided in VariantChannelListing
+  A single key from private metadata. Requires staff permissions to access.
   
-  Added in Saleor 3.21.
+  Tip: Use GraphQL aliases to fetch multiple keys.
   """
-  discountPrior: TaxedMoney
-
-  """The discount amount in the local currency."""
-  discountLocalCurrency: TaxedMoney @deprecated(reason: "Always returns `null`.")
-
-  """The price, with any discount subtracted."""
-  price: TaxedMoney
-
-  """The price without any discount."""
-  priceUndiscounted: TaxedMoney
+  privateMetafield(key: String!): String
 
   """
-  The price prior to discount.
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
   
-  Added in Saleor 3.21.
+  Tip: Use GraphQL aliases to fetch multiple keys.
   """
-  pricePrior: TaxedMoney
+  metafield(key: String!): String
 
-  """The discounted price in the local currency."""
-  priceLocalCurrency: TaxedMoney @deprecated(reason: "Always returns `null`.")
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """Warehouse name."""
+  name: String!
+
+  """Warehouse slug."""
+  slug: String!
+
+  """Warehouse email."""
+  email: String!
+
+  """Determine if the warehouse is private."""
+  isPrivate: Boolean!
+
+  """Address of the warehouse."""
+  address: Address!
+
+  """Warehouse company name."""
+  companyName: String! @deprecated(reason: "Use `Address.companyName` instead.")
+
+  """Click and collect options: local, all or disabled."""
+  clickAndCollectOption: WarehouseClickAndCollectOptionEnum!
+
+  """Shipping zones supported by the warehouse."""
+  shippingZones(
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): ShippingZoneCountableConnection!
+
+  """
+  Stocks that belong to this warehouse.
+  
+  Added in Saleor 3.20.
+  
+  Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
+  """
+  stocks(
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): StockCountableConnection
+
+  """External ID of this warehouse."""
+  externalReference: String
+}
+
+"""Represents user address data."""
+type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
+  """The ID of the address."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """The given name of the address."""
+  firstName: String!
+
+  """The family name of the address."""
+  lastName: String!
+
+  """Company or organization name."""
+  companyName: String!
+
+  """The first line of the address."""
+  streetAddress1: String!
+
+  """The second line of the address."""
+  streetAddress2: String!
+
+  """The city of the address."""
+  city: String!
+
+  """The district of the address."""
+  cityArea: String!
+
+  """The postal code of the address."""
+  postalCode: String!
+
+  """The country of the address."""
+  country: CountryDisplay!
+
+  """The country area of the address."""
+  countryArea: String!
+
+  """The phone number assigned the address."""
+  phone: String
+
+  """Address is user's default shipping address."""
+  isDefaultShippingAddress: Boolean
+
+  """Address is user's default billing address."""
+  isDefaultBillingAddress: Boolean
+}
+
+enum WarehouseClickAndCollectOptionEnum @doc(category: "Products") {
+  DISABLED
+  LOCAL
+  ALL
+}
+
+type ShippingZoneCountableConnection @doc(category: "Shipping") {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+  edges: [ShippingZoneCountableEdge!]!
+
+  """A total count of items in the collection."""
+  totalCount: Int
+}
+
+type ShippingZoneCountableEdge @doc(category: "Shipping") {
+  """The item at the end of the edge."""
+  node: ShippingZone!
+
+  """A cursor for use in pagination."""
+  cursor: String!
 }
 
 """
-Represents a monetary value with taxes. In cases where taxes were not applied, net and gross values will be equal.
+Represents a shipping zone in the shop. Zones are the concept used only for grouping shipping methods in the dashboard, and are never exposed to the customers directly.
 """
-type TaxedMoney {
+type ShippingZone implements Node & ObjectWithMetadata @doc(category: "Shipping") {
+  """The ID of shipping zone."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """Shipping zone name."""
+  name: String!
+
+  """Indicates if the shipping zone is default one."""
+  default: Boolean!
+
+  """Lowest and highest prices for the shipping."""
+  priceRange: MoneyRange
+
+  """List of countries available for the method."""
+  countries: [CountryDisplay!]!
+
+  """
+  List of shipping methods available for orders shipped to countries within this shipping zone.
+  """
+  shippingMethods: [ShippingMethodType!]
+
+  """List of warehouses for shipping zone."""
+  warehouses: [Warehouse!]!
+
+  """List of channels for shipping zone."""
+  channels: [Channel!]!
+
+  """Description of a shipping zone."""
+  description: String
+}
+
+"""Represents a range of amounts of money."""
+type MoneyRange {
+  """Lower bound of a price range."""
+  start: Money
+
+  """Upper bound of a price range."""
+  stop: Money
+}
+
+"""Represents amount of money in specific currency."""
+type Money {
   """Currency code."""
   currency: String!
 
-  """Amount of money including taxes."""
-  gross: Money!
+  """Amount of money."""
+  amount: Float!
 
-  """Amount of money without taxes."""
-  net: Money!
+  """
+  Amount of money represented as an integer in the smallest currency unit.
+  """
+  fractionalAmount: Int!
 
-  """Amount of taxes."""
-  tax: Money!
+  """Number of digits after the decimal point in the currency."""
+  fractionDigits: Int!
 }
 
-input AddressInput {
-  """Given name."""
-  firstName: String
+"""
+Shipping method are the methods you'll use to get customer's orders to them. They are directly exposed to the customers.
+"""
+type ShippingMethodType implements Node & ObjectWithMetadata @doc(category: "Shipping") {
+  """Shipping method ID."""
+  id: ID!
 
-  """Family name."""
-  lastName: String
-
-  """Company or organization."""
-  companyName: String
-
-  """Address."""
-  streetAddress1: String
-
-  """Address."""
-  streetAddress2: String
-
-  """City."""
-  city: String
-
-  """District."""
-  cityArea: String
-
-  """Postal code."""
-  postalCode: String
-
-  """Country."""
-  country: CountryCode
-
-  """State or province."""
-  countryArea: String
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
 
   """
-  Phone number.
+  A single key from private metadata. Requires staff permissions to access.
   
-  Phone numbers are validated with Google's [libphonenumber](https://github.com/google/libphonenumber) library.
+  Tip: Use GraphQL aliases to fetch multiple keys.
   """
-  phone: String
+  privateMetafield(key: String!): String
 
   """
-  Address public metadata. Can be read by any API client authorized to read the object it's attached to.
-  
-  Warning: never store sensitive information, including financial data such as credit card details.
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
   """
-  metadata: [MetadataInput!]
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
 
   """
-  Determine if the address should be validated. By default, Saleor accepts only address inputs matching ruleset from [Google Address Data]{https://chromium-i18n.appspot.com/ssl-address), using [i18naddress](https://github.com/mirumee/google-i18n-address) library. Some mutations may require additional permissions to use the the field. More info about permissions can be found in relevant mutation.
+  A single key from public metadata.
   
-  Added in Saleor 3.19.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  Tip: Use GraphQL aliases to fetch multiple keys.
   """
-  skipValidation: Boolean = false
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """Shipping method name."""
+  name: String!
+
+  """
+  Shipping method description.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  description: JSONString
+
+  """Type of the shipping method."""
+  type: ShippingMethodTypeEnum
+
+  """Returns translated shipping method fields for the given language code."""
+  translation(
+    """A language code to return the translation for shipping method."""
+    languageCode: LanguageCodeEnum!
+  ): ShippingMethodTranslation
+
+  """
+  List of channels available for the method.
+  
+  Requires one of the following permissions: MANAGE_SHIPPING.
+  """
+  channelListings: [ShippingMethodChannelListing!]
+
+  """The price of the cheapest variant (including discounts)."""
+  maximumOrderPrice: Money
+
+  """The price of the cheapest variant (including discounts)."""
+  minimumOrderPrice: Money
+
+  """
+  Postal code ranges rule of exclusion or inclusion of the shipping method.
+  """
+  postalCodeRules: [ShippingMethodPostalCodeRule!]
+
+  """
+  List of excluded products for the shipping method.
+  
+  Requires one of the following permissions: MANAGE_SHIPPING.
+  """
+  excludedProducts(
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): ProductCountableConnection
+
+  """Minimum order weight to use this shipping method."""
+  minimumOrderWeight: Weight
+
+  """Maximum order weight to use this shipping method."""
+  maximumOrderWeight: Weight
+
+  """Maximum number of days for delivery."""
+  maximumDeliveryDays: Int
+
+  """Minimal number of days for delivery."""
+  minimumDeliveryDays: Int
+
+  """
+  Tax class assigned to this shipping method.
+  
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  """
+  taxClass: TaxClass
+}
+
+enum ShippingMethodTypeEnum @doc(category: "Shipping") {
+  PRICE
+  WEIGHT
+}
+
+"""Represents shipping method translations."""
+type ShippingMethodTranslation implements Node @doc(category: "Shipping") {
+  """The ID of the shipping method translation."""
+  id: ID!
+
+  """Translation language."""
+  language: LanguageDisplay!
+
+  """Translated shipping method name."""
+  name: String
+
+  """
+  Translated description of the shipping method.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  description: JSONString
+
+  """Represents the shipping method fields to translate."""
+  translatableContent: ShippingMethodTranslatableContent
+}
+
+"""
+Represents shipping method's original translatable fields and related translations.
+"""
+type ShippingMethodTranslatableContent implements Node @doc(category: "Shipping") {
+  """The ID of the shipping method translatable content."""
+  id: ID!
+
+  """The ID of the shipping method to translate."""
+  shippingMethodId: ID!
+
+  """Shipping method name to translate."""
+  name: String!
+
+  """
+  Shipping method description to translate.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  description: JSONString
+
+  """Returns translated shipping method fields for the given language code."""
+  translation(
+    """A language code to return the translation for shipping method."""
+    languageCode: LanguageCodeEnum!
+  ): ShippingMethodTranslation
+
+  """
+  Shipping method are the methods you'll use to get customer's orders  to them. They are directly exposed to the customers.
+  
+  Requires one of the following permissions: MANAGE_SHIPPING.
+  """
+  shippingMethod: ShippingMethodType @deprecated(reason: "Get model fields from the root level queries.")
+}
+
+"""Represents shipping method channel listing."""
+type ShippingMethodChannelListing implements Node @doc(category: "Shipping") {
+  """The ID of shipping method channel listing."""
+  id: ID!
+
+  """The channel associated with the shipping method channel listing."""
+  channel: Channel!
+
+  """Maximum order price."""
+  maximumOrderPrice: Money
+
+  """Minimum order price."""
+  minimumOrderPrice: Money
+
+  """Price of the shipping method in the associated channel."""
+  price: Money
+}
+
+"""Represents shipping method postal code rule."""
+type ShippingMethodPostalCodeRule implements Node @doc(category: "Shipping") {
+  """The ID of the object."""
+  id: ID!
+
+  """Start address range."""
+  start: String
+
+  """End address range."""
+  end: String
+
+  """Inclusion type of the postal code rule."""
+  inclusionType: PostalCodeRuleInclusionTypeEnum
+}
+
+enum PostalCodeRuleInclusionTypeEnum @doc(category: "Shipping") {
+  INCLUDE
+  EXCLUDE
+}
+
+"""
+Tax class is a named object used to define tax rates per country. Tax class can be assigned to product types, products and shipping methods to define their tax rates.
+"""
+type TaxClass implements Node & ObjectWithMetadata @doc(category: "Taxes") {
+  """The ID of the object."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """Name of the tax class."""
+  name: String!
+
+  """Country-specific tax rates for this tax class."""
+  countries: [TaxClassCountryRate!]!
+}
+
+"""
+Tax rate for a country. When tax class is null, it represents the default tax rate for that country; otherwise it's a country tax rate specific to the given tax class.
+"""
+type TaxClassCountryRate @doc(category: "Taxes") {
+  """Country in which this tax rate applies."""
+  country: CountryDisplay!
+
+  """Tax rate value."""
+  rate: Float!
+
+  """Related tax class."""
+  taxClass: TaxClass
+}
+
+type StockCountableConnection @doc(category: "Products") {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+  edges: [StockCountableEdge!]!
+
+  """A total count of items in the collection."""
+  totalCount: Int
+}
+
+type StockCountableEdge @doc(category: "Products") {
+  """The item at the end of the edge."""
+  node: Stock!
+
+  """A cursor for use in pagination."""
+  cursor: String!
+}
+
+"""Represents stock."""
+type Stock implements Node @doc(category: "Products") {
+  """The ID of stock."""
+  id: ID!
+
+  """The warehouse associated with the stock."""
+  warehouse: Warehouse!
+
+  """Information about the product variant."""
+  productVariant: ProductVariant!
+
+  """
+  Quantity of a product in the warehouse's possession, including the allocated stock that is waiting for shipment.
+  
+  Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
+  """
+  quantity: Int!
+
+  """
+  Quantity allocated for orders.
+  
+  Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
+  """
+  quantityAllocated: Int!
+
+  """
+  Quantity reserved for checkouts.
+  
+  Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
+  """
+  quantityReserved: Int!
+}
+
+"""List of shipping methods available for the country."""
+type ShippingMethodsPerCountry @doc(category: "Shipping") {
+  """The country code."""
+  countryCode: CountryCode!
+
+  """List of available shipping methods."""
+  shippingMethods: [ShippingMethod!]
 }
 
 """
@@ -9878,6 +9116,497 @@ enum CountryCode {
   ZW
 }
 
+"""
+Shipping methods that can be used as means of shipping for orders and checkouts.
+"""
+type ShippingMethod implements Node & ObjectWithMetadata @doc(category: "Shipping") {
+  """Unique ID of ShippingMethod available for Order."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """Type of the shipping method."""
+  type: ShippingMethodTypeEnum @deprecated
+
+  """Shipping method name."""
+  name: String!
+
+  """
+  Shipping method description.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  description: JSONString
+
+  """Maximum delivery days for this shipping method."""
+  maximumDeliveryDays: Int
+
+  """Minimum delivery days for this shipping method."""
+  minimumDeliveryDays: Int
+
+  """Maximum order weight for this shipping method."""
+  maximumOrderWeight: Weight @deprecated
+
+  """Minimum order weight for this shipping method."""
+  minimumOrderWeight: Weight @deprecated
+
+  """Returns translated shipping method fields for the given language code."""
+  translation(
+    """A language code to return the translation for shipping method."""
+    languageCode: LanguageCodeEnum!
+  ): ShippingMethodTranslation
+
+  """The price of selected shipping method."""
+  price: Money!
+
+  """Maximum order price for this shipping method."""
+  maximumOrderPrice: Money @deprecated
+
+  """Minimal order price for this shipping method."""
+  minimumOrderPrice: Money @deprecated
+
+  """Describes if this shipping method is active and can be selected."""
+  active: Boolean!
+
+  """Message connected to this shipping method."""
+  message: String
+}
+
+"""Represents the channel stock settings."""
+type StockSettings @doc(category: "Products") {
+  """
+  Allocation strategy defines the preference of warehouses for allocations and reservations.
+  """
+  allocationStrategy: AllocationStrategyEnum!
+}
+
+"""
+Determine the allocation strategy for the channel.
+
+    PRIORITIZE_SORTING_ORDER - allocate stocks according to the warehouses' order
+    within the channel
+
+    PRIORITIZE_HIGH_STOCK - allocate stock in a warehouse with the most stock
+"""
+enum AllocationStrategyEnum @doc(category: "Products") {
+  PRIORITIZE_SORTING_ORDER
+  PRIORITIZE_HIGH_STOCK
+}
+
+"""Represents the channel-specific order settings."""
+type OrderSettings {
+  """
+  When disabled, all new orders from checkout will be marked as unconfirmed. When enabled orders from checkout will become unfulfilled immediately.
+  """
+  automaticallyConfirmAllNewOrders: Boolean!
+
+  """
+  When enabled, all non-shippable gift card orders will be fulfilled automatically.
+  """
+  automaticallyFulfillNonShippableGiftCard: Boolean!
+
+  """
+  Expiration time in minutes. Default null - means do not expire any orders.
+  """
+  expireOrdersAfter: Minute
+
+  """
+  Determine what strategy will be used to mark the order as paid. Based on the chosen option, the proper object will be created and attached to the order when it's manually marked as paid.
+  `PAYMENT_FLOW` - [default option] creates the `Payment` object.
+  `TRANSACTION_FLOW` - creates the `TransactionItem` object.
+  """
+  markAsPaidStrategy: MarkAsPaidStrategyEnum!
+
+  """The time in days after expired orders will be deleted."""
+  deleteExpiredOrdersAfter: Day!
+
+  """
+  Determine if it is possible to place unpaid order by calling `checkoutComplete` mutation.
+  """
+  allowUnpaidOrders: Boolean!
+
+  """
+  Determine if voucher applied on draft order should be count toward voucher usage.
+  
+  Added in Saleor 3.18.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  includeDraftOrderInVoucherUsage: Boolean!
+
+  """
+  Time in hours after which the draft order line price will be refreshed.
+  
+  Added in Saleor 3.21.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  draftOrderLinePriceFreezePeriod: Hour
+
+  """
+  This flag only affects orders created from checkout and applies specifically to vouchers of the types: `SPECIFIC_PRODUCT` and `ENTIRE_ORDER` with `applyOncePerOrder` enabled.
+  - When legacy propagation is enabled, discounts from these vouchers are represented as `OrderDiscount` objects, attached to the order and returned in the `Order.discounts` field. Additionally, percentage-based vouchers are converted to fixed-value discounts.
+  - When legacy propagation is disabled, discounts are represented as `OrderLineDiscount` objects, attached to individual lines and returned in the `OrderLine.discounts` field. In this case, percentage-based vouchers retain their original type.
+  In future releases, `OrderLineDiscount` will become the default behavior, and this flag will be deprecated and removed.
+  
+  Added in Saleor 3.21.
+  """
+  useLegacyLineDiscountPropagation: Boolean!
+}
+
+"""
+The `Minute` scalar type represents number of minutes by integer value.
+"""
+scalar Minute
+
+"""
+Determine the mark as paid strategy for the channel.
+
+    TRANSACTION_FLOW - new orders marked as paid will receive a
+    `TransactionItem` object, that will cover the `order.total`.
+
+    PAYMENT_FLOW - new orders marked as paid will receive a
+    `Payment` object, that will cover the `order.total`.
+"""
+enum MarkAsPaidStrategyEnum @doc(category: "Channels") {
+  TRANSACTION_FLOW
+  PAYMENT_FLOW @deprecated(reason: "The legacy Payments API is deprecated and will be removed. Use the Transactions API instead.")
+}
+
+"""The `Day` scalar type represents number of days by integer value."""
+scalar Day
+
+"""The `Hour` scalar type represents number of hours by integer value."""
+scalar Hour
+
+"""Represents the channel-specific checkout settings."""
+type CheckoutSettings {
+  """
+  Default `true`. Determines if the checkout mutations should use legacy error flow. In legacy flow, all mutations can raise an exception unrelated to the requested action - (e.g. out-of-stock exception when updating checkoutShippingAddress.) If `false`, the errors will be aggregated in `checkout.problems` field. Some of the `problems` can block the finalizing checkout process. The legacy flow will be removed in Saleor 4.0. The flow with `checkout.problems` will be the default one.
+  """
+  useLegacyErrorFlow: Boolean!
+
+  """
+  Default `false`. Determines if the paid checkouts should be automatically completed. This setting applies only to checkouts where payment was processed through transactions.When enabled, the checkout will be automatically completed once the checkout `charge_status` reaches `FULL`. This occurs when the total sum of charged and authorized transaction amounts equals or exceeds the checkout's total amount.
+  
+  Added in Saleor 3.20.
+  """
+  automaticallyCompleteFullyPaidCheckouts: Boolean!
+
+  """
+  The time in minutes to wait after a checkout is fully paid before automatically completing it.
+  
+  Added in Saleor 3.22.
+  """
+  automaticCompletionDelay: Minute
+
+  """
+  The date time defines the earliest checkout creation date on which fully paid checkouts can begin to be automatically completed. 
+  
+  Added in Saleor 3.22.
+  """
+  automaticCompletionCutOffDate: DateTime
+
+  """
+  Default to `true`. Determines whether gift cards can be attached to a Checkout via `addPromoCode` mutation. Usage of this mutation with gift cards is deprecated.
+  
+  Added in Saleor 3.23.
+  """
+  allowLegacyGiftCardUse: Boolean!
+}
+
+"""Represents the channel-specific payment settings."""
+type PaymentSettings {
+  """
+  Determine the transaction flow strategy to be used. Include the selected option in the payload sent to the payment app, as a requested action for the transaction.
+  """
+  defaultTransactionFlowStrategy: TransactionFlowStrategyEnum!
+
+  """
+  Determine if the funds for expired checkouts should be released automatically.
+  
+  Added in Saleor 3.20.
+  """
+  releaseFundsForExpiredCheckouts: Boolean
+
+  """
+  The time in hours after which funds for expired checkouts will be released.
+  
+  Added in Saleor 3.20.
+  """
+  checkoutTtlBeforeReleasingFunds: Hour
+
+  """
+  Specifies the earliest date on which funds for expired checkouts can begin to be released. Expired checkouts dated before this cut-off will not have their funds released. Additionally, no funds will be released for checkouts that are more than one year old, regardless of the cut-off date.
+  
+  Added in Saleor 3.20.
+  """
+  checkoutReleaseFundsCutOffDate: DateTime
+}
+
+"""
+Determine the transaction flow strategy.
+
+    AUTHORIZATION - the processed transaction should be only authorized
+    CHARGE - the processed transaction should be charged.
+"""
+enum TransactionFlowStrategyEnum @doc(category: "Payments") {
+  AUTHORIZATION
+  CHARGE
+}
+
+"""Channel-specific tax configuration."""
+type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes") {
+  """The ID of the object."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """A channel to which the tax configuration applies to."""
+  channel: Channel!
+
+  """Determines whether taxes are charged in the given channel."""
+  chargeTaxes: Boolean!
+
+  """
+  The default strategy to use for tax calculation in the given channel. Taxes can be calculated either using user-defined flat rates or with a tax app. Empty value means that no method is selected and taxes are not calculated.
+  """
+  taxCalculationStrategy: TaxCalculationStrategy
+
+  """Determines whether displayed prices should include taxes."""
+  displayGrossPrices: Boolean!
+
+  """Determines whether prices are entered with the tax included."""
+  pricesEnteredWithTax: Boolean!
+
+  """List of country-specific exceptions in tax configuration."""
+  countries: [TaxConfigurationPerCountry!]!
+
+  """
+  The tax app `App.identifier` that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
+  
+  Added in Saleor 3.19.
+  """
+  taxAppId: String
+
+  """
+  Determines whether to use weighted tax for shipping. When set to true, the tax rate for shipping will be calculated based on the weighted average of tax rates from the order or checkout lines.
+  
+  Added in Saleor 3.21.
+  """
+  useWeightedTaxForShipping: Boolean
+}
+
+enum TaxCalculationStrategy @doc(category: "Taxes") {
+  FLAT_RATES
+  TAX_APP
+}
+
+"""Country-specific exceptions of a channel's tax configuration."""
+type TaxConfigurationPerCountry @doc(category: "Taxes") {
+  """Country in which this configuration applies."""
+  country: CountryDisplay!
+
+  """Determines whether taxes are charged in this country."""
+  chargeTaxes: Boolean!
+
+  """
+  A country-specific strategy to use for tax calculation. Taxes can be calculated either using user-defined flat rates or with a tax app. If not provided, use the value from the channel's tax configuration.
+  """
+  taxCalculationStrategy: TaxCalculationStrategy
+
+  """
+  Determines whether displayed prices should include taxes for this country.
+  """
+  displayGrossPrices: Boolean!
+
+  """
+  The tax app `App.identifier` that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
+  
+  Added in Saleor 3.19.
+  """
+  taxAppId: String
+
+  """
+  Determines whether to use weighted tax for shipping. When set to true, the tax rate for shipping will be calculated based on the weighted average of tax rates from the order or checkout lines.
+  
+  Added in Saleor 3.21.
+  """
+  useWeightedTaxForShipping: Boolean
+}
+
+"""Represents preorder variant data for channel."""
+type PreorderThreshold @doc(category: "Products") {
+  """Preorder threshold for product variant in this channel."""
+  quantity: Int
+
+  """Number of sold product variant in this channel."""
+  soldUnits: Int!
+}
+
+"""Represents availability of a variant in the storefront."""
+type VariantPricingInfo @doc(category: "Products") {
+  """Whether it is in sale or not."""
+  onSale: Boolean
+
+  """The discount amount if in sale (null otherwise)."""
+  discount: TaxedMoney
+
+  """
+  The discount amount compared to prior price. Null if product is not on sale or prior price was not provided in VariantChannelListing
+  
+  Added in Saleor 3.21.
+  """
+  discountPrior: TaxedMoney
+
+  """The discount amount in the local currency."""
+  discountLocalCurrency: TaxedMoney @deprecated(reason: "Always returns `null`.")
+
+  """The price, with any discount subtracted."""
+  price: TaxedMoney
+
+  """The price without any discount."""
+  priceUndiscounted: TaxedMoney
+
+  """
+  The price prior to discount.
+  
+  Added in Saleor 3.21.
+  """
+  pricePrior: TaxedMoney
+
+  """The discounted price in the local currency."""
+  priceLocalCurrency: TaxedMoney @deprecated(reason: "Always returns `null`.")
+}
+
+"""
+Represents a monetary value with taxes. In cases where taxes were not applied, net and gross values will be equal.
+"""
+type TaxedMoney {
+  """Currency code."""
+  currency: String!
+
+  """Amount of money including taxes."""
+  gross: Money!
+
+  """Amount of money without taxes."""
+  net: Money!
+
+  """Amount of taxes."""
+  tax: Money!
+}
+
+input AddressInput {
+  """Given name."""
+  firstName: String
+
+  """Family name."""
+  lastName: String
+
+  """Company or organization."""
+  companyName: String
+
+  """Address."""
+  streetAddress1: String
+
+  """Address."""
+  streetAddress2: String
+
+  """City."""
+  city: String
+
+  """District."""
+  cityArea: String
+
+  """Postal code."""
+  postalCode: String
+
+  """Country."""
+  country: CountryCode
+
+  """State or province."""
+  countryArea: String
+
+  """
+  Phone number.
+  
+  Phone numbers are validated with Google's [libphonenumber](https://github.com/google/libphonenumber) library.
+  """
+  phone: String
+
+  """
+  Address public metadata. Can be read by any API client authorized to read the object it's attached to.
+  
+  Warning: never store sensitive information, including financial data such as credit card details.
+  """
+  metadata: [MetadataInput!]
+
+  """
+  Determine if the address should be validated. By default, Saleor accepts only address inputs matching ruleset from [Google Address Data]{https://chromium-i18n.appspot.com/ssl-address), using [i18naddress](https://github.com/mirumee/google-i18n-address) library. Some mutations may require additional permissions to use the the field. More info about permissions can be found in relevant mutation.
+  
+  Added in Saleor 3.19.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  skipValidation: Boolean = false
+}
+
 input MetadataInput {
   """Key of a metadata item."""
   key: String!
@@ -9893,6 +9622,175 @@ type SelectedAttribute @doc(category: "Attributes") {
 
   """Values of an attribute."""
   values: [AttributeValue!]!
+}
+
+"""Represents a value of an attribute."""
+type AttributeValue implements Node @doc(category: "Attributes") {
+  """The ID of the attribute value."""
+  id: ID!
+
+  """Name of a value displayed in the interface."""
+  name: String
+
+  """Internal representation of a value (unique per attribute)."""
+  slug: String
+
+  """
+  Represent value of the attribute value (e.g. color values for swatch attributes).
+  """
+  value: String
+
+  """Returns translated attribute value fields for the given language code."""
+  translation(
+    """A language code to return the translation for attribute value."""
+    languageCode: LanguageCodeEnum!
+  ): AttributeValueTranslation
+
+  """The input type to use for entering attribute values in the dashboard."""
+  inputType: AttributeInputTypeEnum
+
+  """The ID of the referenced object."""
+  reference: ID
+
+  """Represents file URL and content type (if attribute value is a file)."""
+  file: File
+
+  """
+  Represents the text of the attribute value, includes formatting.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  richText: JSONString
+
+  """
+  Represents the text of the attribute value, plain text without formatting.
+  """
+  plainText: String
+
+  """Represents the boolean value of the attribute value."""
+  boolean: Boolean
+
+  """Represents the date value of the attribute value."""
+  date: Date
+
+  """Represents the date/time value of the attribute value."""
+  dateTime: DateTime
+
+  """External ID of this attribute value."""
+  externalReference: String
+}
+
+"""Represents attribute value translations."""
+type AttributeValueTranslation implements Node @doc(category: "Attributes") {
+  """The ID of the attribute value translation."""
+  id: ID!
+
+  """Translation language."""
+  language: LanguageDisplay!
+
+  """Translated attribute value name."""
+  name: String!
+
+  """
+  Translated rich-text attribute value.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  richText: JSONString
+
+  """Translated plain text attribute value ."""
+  plainText: String
+
+  """Represents the attribute value fields to translate."""
+  translatableContent: AttributeValueTranslatableContent
+}
+
+"""
+Represents attribute value's original translatable fields and related translations.
+"""
+type AttributeValueTranslatableContent implements Node @doc(category: "Attributes") {
+  """The ID of the attribute value translatable content."""
+  id: ID!
+
+  """The ID of the attribute value to translate."""
+  attributeValueId: ID!
+
+  """Name of the attribute value to translate."""
+  name: String!
+
+  """
+  Attribute value.
+  
+  Rich text format. For reference see https://editorjs.io/
+  """
+  richText: JSONString
+
+  """Attribute plain text value."""
+  plainText: String
+
+  """Returns translated attribute value fields for the given language code."""
+  translation(
+    """A language code to return the translation for attribute value."""
+    languageCode: LanguageCodeEnum!
+  ): AttributeValueTranslation
+
+  """Represents a value of an attribute."""
+  attributeValue: AttributeValue @deprecated(reason: "Get model fields from the root level queries.")
+
+  """Associated attribute that can be translated."""
+  attribute: AttributeTranslatableContent
+}
+
+"""
+Represents attribute's original translatable fields and related translations.
+"""
+type AttributeTranslatableContent implements Node @doc(category: "Attributes") {
+  """The ID of the attribute translatable content."""
+  id: ID!
+
+  """The ID of the attribute to translate."""
+  attributeId: ID!
+
+  """Name of the attribute to translate."""
+  name: String!
+
+  """Returns translated attribute fields for the given language code."""
+  translation(
+    """A language code to return the translation for attribute."""
+    languageCode: LanguageCodeEnum!
+  ): AttributeTranslation
+
+  """Custom attribute of a product."""
+  attribute: Attribute @deprecated(reason: "Get model fields from the root level queries.")
+}
+
+"""Represents attribute translations."""
+type AttributeTranslation implements Node @doc(category: "Attributes") {
+  """The ID of the attribute translation."""
+  id: ID!
+
+  """Translation language."""
+  language: LanguageDisplay!
+
+  """Translated attribute name."""
+  name: String!
+
+  """Represents the attribute fields to translate."""
+  translatableContent: AttributeTranslatableContent
+}
+
+type File {
+  """The URL of the file."""
+  url: String!
+
+  """Content type of the file."""
+  contentType: String
+}
+
+enum VariantAttributeScope @doc(category: "Products") {
+  ALL
+  VARIANT_SELECTION
+  NOT_VARIANT_SELECTION
 }
 
 enum ReportingPeriod {
@@ -10037,39 +9935,6 @@ type ProductVariantTranslatableContent implements Node @doc(category: "Products"
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
-"""Represents stock."""
-type Stock implements Node @doc(category: "Products") {
-  """The ID of stock."""
-  id: ID!
-
-  """The warehouse associated with the stock."""
-  warehouse: Warehouse!
-
-  """Information about the product variant."""
-  productVariant: ProductVariant!
-
-  """
-  Quantity of a product in the warehouse's possession, including the allocated stock that is waiting for shipment.
-  
-  Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
-  """
-  quantity: Int!
-
-  """
-  Quantity allocated for orders.
-  
-  Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
-  """
-  quantityAllocated: Int!
-
-  """
-  Quantity reserved for checkouts.
-  
-  Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_ORDERS.
-  """
-  quantityReserved: Int!
-}
-
 """Represents preorder settings for product variant."""
 type PreorderData @doc(category: "Products") {
   """
@@ -10137,6 +10002,15 @@ type TaxedMoneyRange {
 
   """Upper bound of a price range."""
   stop: TaxedMoney
+}
+
+"""Representation of tax types fetched from tax gateway."""
+type TaxType @doc(category: "Taxes") {
+  """Description of the tax type."""
+  description: String
+
+  """External tax code used to identify given tax group."""
+  taxCode: String
 }
 
 """Represents product channel listing."""
@@ -10615,37 +10489,159 @@ type ProductTranslatableContent implements Node @doc(category: "Products") {
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
-type StockCountableConnection @doc(category: "Products") {
+"""
+Represents assigned attribute to variant with variant selection attached.
+"""
+type AssignedVariantAttribute @doc(category: "Attributes") {
+  """Attribute assigned to variant."""
+  attribute: Attribute!
+
+  """
+  Determines, whether assigned attribute is allowed for variant selection. Supported variant types for variant selection are: ['dropdown', 'boolean', 'swatch', 'numeric']
+  """
+  variantSelection: Boolean!
+}
+
+type AttributeCountableConnection @doc(category: "Attributes") {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
-  edges: [StockCountableEdge!]!
+  edges: [AttributeCountableEdge!]!
 
   """A total count of items in the collection."""
   totalCount: Int
 }
 
-type StockCountableEdge @doc(category: "Products") {
+type AttributeCountableEdge @doc(category: "Attributes") {
   """The item at the end of the edge."""
-  node: Stock!
+  node: Attribute!
 
   """A cursor for use in pagination."""
   cursor: String!
 }
 
-"""List of shipping methods available for the country."""
-type ShippingMethodsPerCountry @doc(category: "Shipping") {
-  """The country code."""
-  countryCode: CountryCode!
+input AttributeFilterInput @doc(category: "Attributes") {
+  valueRequired: Boolean
+  isVariantOnly: Boolean
+  visibleInStorefront: Boolean
+  filterableInStorefront: Boolean
+  filterableInDashboard: Boolean
+  availableInGrid: Boolean
+  metadata: [MetadataFilter!]
+  search: String
+  ids: [ID!]
+  type: AttributeTypeEnum
+  inCollection: ID
+  inCategory: ID
+  slugs: [String!]
 
-  """List of available shipping methods."""
-  shippingMethods: [ShippingMethod!]
+  """Specifies the channel by which the data should be filtered."""
+  channel: String @deprecated(reason: "Use root-level channel argument instead.")
+}
+
+enum AttributeTypeEnum @doc(category: "Attributes") {
+  PRODUCT_TYPE
+  PAGE_TYPE
+  CUSTOMER_TYPE
+}
+
+"""Where filtering options."""
+input AttributeWhereInput @doc(category: "Attributes") {
+  metadata: [MetadataFilter!]
+  ids: [ID!]
+  name: StringFilterInput
+  slug: StringFilterInput
+  withChoices: Boolean
+  inputType: AttributeInputTypeEnumFilterInput
+  entityType: AttributeEntityTypeEnumFilterInput
+  type: AttributeTypeEnumFilterInput
+  unit: MeasurementUnitsEnumFilterInput
+  inCollection: ID
+  inCategory: ID
+  valueRequired: Boolean
+  visibleInStorefront: Boolean
+  filterableInDashboard: Boolean
+
+  """List of conditions that must be met."""
+  AND: [AttributeWhereInput!]
+
+  """A list of conditions of which at least one must be met."""
+  OR: [AttributeWhereInput!]
+}
+
+input AttributeInputTypeEnumFilterInput @doc(category: "Attributes") {
+  """The value equal to."""
+  eq: AttributeInputTypeEnum
+
+  """The value included in."""
+  oneOf: [AttributeInputTypeEnum!]
+}
+
+input AttributeEntityTypeEnumFilterInput @doc(category: "Attributes") {
+  """The value equal to."""
+  eq: AttributeEntityTypeEnum
+
+  """The value included in."""
+  oneOf: [AttributeEntityTypeEnum!]
+}
+
+input AttributeTypeEnumFilterInput @doc(category: "Attributes") {
+  """The value equal to."""
+  eq: AttributeTypeEnum
+
+  """The value included in."""
+  oneOf: [AttributeTypeEnum!]
+}
+
+input MeasurementUnitsEnumFilterInput @doc(category: "Attributes") {
+  """The value equal to."""
+  eq: MeasurementUnitsEnum
+
+  """The value included in."""
+  oneOf: [MeasurementUnitsEnum!]
+}
+
+enum MeasurementUnitsEnum {
+  MM
+  CM
+  DM
+  M
+  KM
+  FT
+  YD
+  INCH
+  SQ_MM
+  SQ_CM
+  SQ_DM
+  SQ_M
+  SQ_KM
+  SQ_FT
+  SQ_YD
+  SQ_INCH
+  CUBIC_MILLIMETER
+  CUBIC_CENTIMETER
+  CUBIC_DECIMETER
+  CUBIC_METER
+  LITER
+  CUBIC_FOOT
+  CUBIC_INCH
+  CUBIC_YARD
+  QT
+  PINT
+  FL_OZ
+  ACRE_IN
+  ACRE_FT
+  G
+  LB
+  OZ
+  KG
+  TONNE
 }
 
 """
-Shipping methods that can be used as means of shipping for orders and checkouts.
+Represents a type of page. It defines what attributes are available to pages of this type.
 """
-type ShippingMethod implements Node & ObjectWithMetadata @doc(category: "Shipping") {
-  """Unique ID of ShippingMethod available for Order."""
+type PageType implements Node & ObjectWithMetadata @doc(category: "Pages") {
+  """ID of the page type."""
   id: ID!
 
   """List of private metadata items. Requires staff permissions to access."""
@@ -10678,342 +10674,366 @@ type ShippingMethod implements Node & ObjectWithMetadata @doc(category: "Shippin
   """
   metafields(keys: [String!]): Metadata
 
-  """Type of the shipping method."""
-  type: ShippingMethodTypeEnum @deprecated
-
-  """Shipping method name."""
+  """Name of the page type."""
   name: String!
 
+  """Slug of the page type."""
+  slug: String!
+
+  """Page attributes of that page type."""
+  attributes: [Attribute!]
+
   """
-  Shipping method description.
+  Attributes that can be assigned to the page type.
   
-  Rich text format. For reference see https://editorjs.io/
+  Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
   """
-  description: JSONString
+  availableAttributes(
+    """Filtering options for attributes."""
+    filter: AttributeFilterInput @deprecated(reason: "Use `where` filter instead.")
 
-  """Maximum delivery days for this shipping method."""
-  maximumDeliveryDays: Int
+    """Where filtering options for attributes."""
+    where: AttributeWhereInput
 
-  """Minimum delivery days for this shipping method."""
-  minimumDeliveryDays: Int
+    """Search attributes."""
+    search: String
 
-  """Maximum order weight for this shipping method."""
-  maximumOrderWeight: Weight @deprecated
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
 
-  """Minimum order weight for this shipping method."""
-  minimumOrderWeight: Weight @deprecated
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
 
-  """Returns translated shipping method fields for the given language code."""
-  translation(
-    """A language code to return the translation for shipping method."""
-    languageCode: LanguageCodeEnum!
-  ): ShippingMethodTranslation
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
 
-  """The price of selected shipping method."""
-  price: Money!
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): AttributeCountableConnection
 
-  """Maximum order price for this shipping method."""
-  maximumOrderPrice: Money @deprecated
-
-  """Minimal order price for this shipping method."""
-  minimumOrderPrice: Money @deprecated
-
-  """Describes if this shipping method is active and can be selected."""
-  active: Boolean!
-
-  """Message connected to this shipping method."""
-  message: String
+  """
+  Whether page type has pages assigned.
+  
+  Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
+  """
+  hasPages: Boolean
 }
 
-"""Represents the channel stock settings."""
-type StockSettings @doc(category: "Products") {
-  """
-  Allocation strategy defines the preference of warehouses for allocations and reservations.
-  """
-  allocationStrategy: AllocationStrategyEnum!
+type AttributeValueCountableConnection @doc(category: "Attributes") {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+  edges: [AttributeValueCountableEdge!]!
+
+  """A total count of items in the collection."""
+  totalCount: Int
 }
 
-"""
-Determine the allocation strategy for the channel.
+type AttributeValueCountableEdge @doc(category: "Attributes") {
+  """The item at the end of the edge."""
+  node: AttributeValue!
 
-    PRIORITIZE_SORTING_ORDER - allocate stocks according to the warehouses' order
-    within the channel
-
-    PRIORITIZE_HIGH_STOCK - allocate stock in a warehouse with the most stock
-"""
-enum AllocationStrategyEnum @doc(category: "Products") {
-  PRIORITIZE_SORTING_ORDER
-  PRIORITIZE_HIGH_STOCK
+  """A cursor for use in pagination."""
+  cursor: String!
 }
 
-"""Represents the channel-specific order settings."""
-type OrderSettings {
-  """
-  When disabled, all new orders from checkout will be marked as unconfirmed. When enabled orders from checkout will become unfulfilled immediately.
-  """
-  automaticallyConfirmAllNewOrders: Boolean!
+input AttributeChoicesSortingInput @doc(category: "Attributes") {
+  """Specifies the direction in which to sort attribute choices."""
+  direction: OrderDirection!
+
+  """Sort attribute choices by the selected field."""
+  field: AttributeChoicesSortField!
+}
+
+enum AttributeChoicesSortField @doc(category: "Attributes") {
+  """Sort attribute choice by name."""
+  NAME
+
+  """Sort attribute choice by slug."""
+  SLUG
+}
+
+input AttributeValueFilterInput @doc(category: "Attributes") {
+  search: String
+  ids: [ID!]
+  slugs: [String!]
+}
+
+"""Where filtering options for attribute values."""
+input AttributeValueWhereInput @doc(category: "Attributes") {
+  ids: [ID!]
+  name: StringFilterInput
+  slug: StringFilterInput
+
+  """List of conditions that must be met."""
+  AND: [AttributeValueWhereInput!]
+
+  """A list of conditions of which at least one must be met."""
+  OR: [AttributeValueWhereInput!]
+}
+
+type ProductTypeCountableConnection @doc(category: "Products") {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+  edges: [ProductTypeCountableEdge!]!
+
+  """A total count of items in the collection."""
+  totalCount: Int
+}
+
+type ProductTypeCountableEdge @doc(category: "Products") {
+  """The item at the end of the edge."""
+  node: ProductType!
+
+  """A cursor for use in pagination."""
+  cursor: String!
+}
+
+"""Checkout object."""
+type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
+  """The ID of the checkout."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
 
   """
-  When enabled, all non-shippable gift card orders will be fulfilled automatically.
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
   """
-  automaticallyFulfillNonShippableGiftCard: Boolean!
+  privateMetafield(key: String!): String
 
   """
-  Expiration time in minutes. Default null - means do not expire any orders.
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
   """
-  expireOrdersAfter: Minute
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
 
   """
-  Determine what strategy will be used to mark the order as paid. Based on the chosen option, the proper object will be created and attached to the order when it's manually marked as paid.
-  `PAYMENT_FLOW` - [default option] creates the `Payment` object.
-  `TRANSACTION_FLOW` - creates the `TransactionItem` object.
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
   """
-  markAsPaidStrategy: MarkAsPaidStrategyEnum!
-
-  """The time in days after expired orders will be deleted."""
-  deleteExpiredOrdersAfter: Day!
+  metafield(key: String!): String
 
   """
-  Determine if it is possible to place unpaid order by calling `checkoutComplete` mutation.
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
   """
-  allowUnpaidOrders: Boolean!
+  metafields(keys: [String!]): Metadata
+
+  """The date and time when the checkout was created."""
+  created: DateTime!
+
+  """Time of last modification of the given checkout."""
+  updatedAt: DateTime!
+  lastChange: DateTime! @deprecated(reason: "Use `updatedAt` instead.")
 
   """
-  Determine if voucher applied on draft order should be count toward voucher usage.
+  The user assigned to the checkout. Requires one of the following permissions: MANAGE_USERS, HANDLE_PAYMENTS, OWNER.
+  """
+  user: User
+
+  """The channel for which checkout was created."""
+  channel: Channel!
+
+  """The billing address of the checkout."""
+  billingAddress: Address
+
+  """The shipping address of the checkout."""
+  shippingAddress: Address
+
+  """
+  The customer note for the checkout. 
+  
+  Added in Saleor 3.21.
+  """
+  customerNote: String!
+
+  """The note for the checkout."""
+  note: String! @deprecated(reason: "Use `customerNote` instead.")
+
+  """
+  The total discount applied to the checkout. Note: Only discount created via voucher are included in this field.
+  """
+  discount: Money
+
+  """The name of voucher assigned to the checkout."""
+  discountName: String
+
+  """
+  Translation of the discountName field in the language set in Checkout.languageCode field.Note: this field is set automatically when Checkout.languageCode is defined; otherwise it's null
+  """
+  translatedDiscountName: String
+
+  """
+  The voucher assigned to the checkout.
   
   Added in Saleor 3.18.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
-  includeDraftOrderInVoucherUsage: Boolean!
+  voucher: Voucher
+
+  """The code of voucher assigned to the checkout."""
+  voucherCode: String
 
   """
-  Time in hours after which the draft order line price will be refreshed.
+  Shipping methods that can be used with this checkout.
   
-  Added in Saleor 3.21.
+  Triggers the following webhook events:
+  - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
+  - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
+  """
+  availableShippingMethods: [ShippingMethod!]! @webhookEventsInfo(asyncEvents: [], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT, CHECKOUT_FILTER_SHIPPING_METHODS]) @deprecated(reason: "Use `shippingMethods` instead.")
+
+  """
+  Shipping methods that can be used with this checkout.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  Triggers the following webhook events:
+  - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
+  - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
   """
-  draftOrderLinePriceFreezePeriod: Hour
+  shippingMethods: [ShippingMethod!]! @webhookEventsInfo(asyncEvents: [], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT, CHECKOUT_FILTER_SHIPPING_METHODS])
+
+  """Collection points that can be used for this order."""
+  availableCollectionPoints: [Warehouse!]!
 
   """
-  This flag only affects orders created from checkout and applies specifically to vouchers of the types: `SPECIFIC_PRODUCT` and `ENTIRE_ORDER` with `applyOncePerOrder` enabled.
-  - When legacy propagation is enabled, discounts from these vouchers are represented as `OrderDiscount` objects, attached to the order and returned in the `Order.discounts` field. Additionally, percentage-based vouchers are converted to fixed-value discounts.
-  - When legacy propagation is disabled, discounts are represented as `OrderLineDiscount` objects, attached to individual lines and returned in the `OrderLine.discounts` field. In this case, percentage-based vouchers retain their original type.
-  In future releases, `OrderLineDiscount` will become the default behavior, and this flag will be deprecated and removed.
+  List of available payment gateways.
   
-  Added in Saleor 3.21.
+  Triggers the following webhook events:
+  - PAYMENT_LIST_GATEWAYS (sync): Fetch payment gateways available for checkout.
   """
-  useLegacyLineDiscountPropagation: Boolean!
-}
+  availablePaymentGateways: [PaymentGateway!]! @webhookEventsInfo(asyncEvents: [], syncEvents: [PAYMENT_LIST_GATEWAYS]) @deprecated(reason: "The legacy Payments API is deprecated and will be removed. Use the Transactions API instead.")
 
-"""
-The `Minute` scalar type represents number of minutes by integer value.
-"""
-scalar Minute
+  """Email of a customer."""
+  email: String
 
-"""
-Determine the mark as paid strategy for the channel.
+  """List of gift cards associated with this checkout."""
+  giftCards: [GiftCard!]!
 
-    TRANSACTION_FLOW - new orders marked as paid will receive a
-    `TransactionItem` object, that will cover the `order.total`.
+  """Returns True, if checkout requires shipping."""
+  isShippingRequired: Boolean!
 
-    PAYMENT_FLOW - new orders marked as paid will receive a
-    `Payment` object, that will cover the `order.total`.
-"""
-enum MarkAsPaidStrategyEnum @doc(category: "Channels") {
-  TRANSACTION_FLOW
-  PAYMENT_FLOW @deprecated(reason: "The legacy Payments API is deprecated and will be removed. Use the Transactions API instead.")
-}
-
-"""The `Day` scalar type represents number of days by integer value."""
-scalar Day
-
-"""The `Hour` scalar type represents number of hours by integer value."""
-scalar Hour
-
-"""Represents the channel-specific checkout settings."""
-type CheckoutSettings {
-  """
-  Default `true`. Determines if the checkout mutations should use legacy error flow. In legacy flow, all mutations can raise an exception unrelated to the requested action - (e.g. out-of-stock exception when updating checkoutShippingAddress.) If `false`, the errors will be aggregated in `checkout.problems` field. Some of the `problems` can block the finalizing checkout process. The legacy flow will be removed in Saleor 4.0. The flow with `checkout.problems` will be the default one.
-  """
-  useLegacyErrorFlow: Boolean!
+  """The number of items purchased."""
+  quantity: Int!
 
   """
-  Default `false`. Determines if the paid checkouts should be automatically completed. This setting applies only to checkouts where payment was processed through transactions.When enabled, the checkout will be automatically completed once the checkout `charge_status` reaches `FULL`. This occurs when the total sum of charged and authorized transaction amounts equals or exceeds the checkout's total amount.
+  Date when oldest stock reservation for this checkout expires or null if no stock is reserved.
+  """
+  stockReservationExpires: DateTime
+
+  """
+  A list of checkout lines, each containing information about an item in the checkout.
+  """
+  lines: [CheckoutLine!]!
+
+  """
+  The price of the shipping, with all the taxes included. Set to 0 when no delivery method is selected.
   
-  Added in Saleor 3.20.
+  Triggers the following webhook events:
+  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
-  automaticallyCompleteFullyPaidCheckouts: Boolean!
+  shippingPrice: TaxedMoney! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
 
   """
-  The time in minutes to wait after a checkout is fully paid before automatically completing it.
-  
-  Added in Saleor 3.22.
-  """
-  automaticCompletionDelay: Minute
-
-  """
-  The date time defines the earliest checkout creation date on which fully paid checkouts can begin to be automatically completed. 
-  
-  Added in Saleor 3.22.
-  """
-  automaticCompletionCutOffDate: DateTime
-
-  """
-  Default to `true`. Determines whether gift cards can be attached to a Checkout via `addPromoCode` mutation. Usage of this mutation with gift cards is deprecated.
+  The delivery method selected for this checkout.
   
   Added in Saleor 3.23.
   """
-  allowLegacyGiftCardUse: Boolean!
-}
-
-"""Represents the channel-specific payment settings."""
-type PaymentSettings {
-  """
-  Determine the transaction flow strategy to be used. Include the selected option in the payload sent to the payment app, as a requested action for the transaction.
-  """
-  defaultTransactionFlowStrategy: TransactionFlowStrategyEnum!
+  delivery: Delivery
 
   """
-  Determine if the funds for expired checkouts should be released automatically.
+  The shipping method related with checkout.
   
-  Added in Saleor 3.20.
+  Triggers the following webhook events:
+  - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
+  - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
   """
-  releaseFundsForExpiredCheckouts: Boolean
+  shippingMethod: ShippingMethod @webhookEventsInfo(asyncEvents: [], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT, CHECKOUT_FILTER_SHIPPING_METHODS]) @deprecated(reason: "Use `delivery` instead.")
 
   """
-  The time in hours after which funds for expired checkouts will be released.
+  The delivery method selected for this checkout.
   
-  Added in Saleor 3.20.
+  Triggers the following webhook events:
+  - SHIPPING_LIST_METHODS_FOR_CHECKOUT (sync): Optionally triggered when cached external shipping methods are invalid.
+  - CHECKOUT_FILTER_SHIPPING_METHODS (sync): Optionally triggered when cached filtered shipping methods are invalid.
   """
-  checkoutTtlBeforeReleasingFunds: Hour
+  deliveryMethod: DeliveryMethod @webhookEventsInfo(asyncEvents: [], syncEvents: [SHIPPING_LIST_METHODS_FOR_CHECKOUT, CHECKOUT_FILTER_SHIPPING_METHODS]) @deprecated(reason: "Use `delivery` instead.")
 
   """
-  Specifies the earliest date on which funds for expired checkouts can begin to be released. Expired checkouts dated before this cut-off will not have their funds released. Additionally, no funds will be released for checkouts that are more than one year old, regardless of the cut-off date.
+  The price of the checkout before shipping, with taxes included.
   
-  Added in Saleor 3.20.
+  Triggers the following webhook events:
+  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
-  checkoutReleaseFundsCutOffDate: DateTime
-}
+  subtotalPrice: TaxedMoney! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
 
-"""
-Determine the transaction flow strategy.
+  """Returns True if checkout has to be exempt from taxes."""
+  taxExemption: Boolean!
 
-    AUTHORIZATION - the processed transaction should be only authorized
-    CHARGE - the processed transaction should be charged.
-"""
-enum TransactionFlowStrategyEnum @doc(category: "Payments") {
-  AUTHORIZATION
-  CHARGE
-}
-
-"""Channel-specific tax configuration."""
-type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes") {
-  """The ID of the object."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
+  """The checkout's token."""
+  token: UUID!
 
   """
-  A single key from private metadata. Requires staff permissions to access.
+  The sum of the checkout line prices, with all the taxes,shipping costs, and discounts included.
   
-  Tip: Use GraphQL aliases to fetch multiple keys.
+  Triggers the following webhook events:
+  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
-  privateMetafield(key: String!): String
+  totalPrice: TaxedMoney! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
 
   """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
+  The difference between the paid and the checkout total amount.
   
-  Tip: Use GraphQL aliases to fetch multiple keys.
+  Triggers the following webhook events:
+  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
-  metafield(key: String!): String
+  totalBalance: Money! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
+
+  """Checkout language code."""
+  languageCode: LanguageCodeEnum!
 
   """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  List of transactions for the checkout. Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
   """
-  metafields(keys: [String!]): Metadata
-
-  """A channel to which the tax configuration applies to."""
-  channel: Channel!
-
-  """Determines whether taxes are charged in the given channel."""
-  chargeTaxes: Boolean!
-
-  """
-  The default strategy to use for tax calculation in the given channel. Taxes can be calculated either using user-defined flat rates or with a tax app. Empty value means that no method is selected and taxes are not calculated.
-  """
-  taxCalculationStrategy: TaxCalculationStrategy
+  transactions: [TransactionItem!]
 
   """Determines whether displayed prices should include taxes."""
   displayGrossPrices: Boolean!
 
-  """Determines whether prices are entered with the tax included."""
-  pricesEnteredWithTax: Boolean!
-
-  """List of country-specific exceptions in tax configuration."""
-  countries: [TaxConfigurationPerCountry!]!
-
   """
-  The tax app `App.identifier` that will be used to calculate the taxes for the given channel. Empty value for `TAX_APP` set as `taxCalculationStrategy` means that Saleor will iterate over all installed tax apps. If multiple tax apps exist with provided tax app id use the `App` with newest `created` date. Will become mandatory in 4.0 for `TAX_APP` `taxCalculationStrategy`.
+  The authorize status of the checkout.
   
-  Added in Saleor 3.19.
+  Triggers the following webhook events:
+  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
-  taxAppId: String
+  authorizeStatus: CheckoutAuthorizeStatusEnum! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
 
   """
-  Determines whether to use weighted tax for shipping. When set to true, the tax rate for shipping will be calculated based on the weighted average of tax rates from the order or checkout lines.
+  The charge status of the checkout.
   
-  Added in Saleor 3.21.
+  Triggers the following webhook events:
+  - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
-  useWeightedTaxForShipping: Boolean
-}
-
-enum TaxCalculationStrategy @doc(category: "Taxes") {
-  FLAT_RATES
-  TAX_APP
-}
-
-"""Country-specific exceptions of a channel's tax configuration."""
-type TaxConfigurationPerCountry @doc(category: "Taxes") {
-  """Country in which this configuration applies."""
-  country: CountryDisplay!
-
-  """Determines whether taxes are charged in this country."""
-  chargeTaxes: Boolean!
+  chargeStatus: CheckoutChargeStatusEnum! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
 
   """
-  A country-specific strategy to use for tax calculation. Taxes can be calculated either using user-defined flat rates or with a tax app. If not provided, use the value from the channel's tax configuration.
+  List of user's stored payment methods that can be used in this checkout session. It uses the channel that the checkout was created in. When `amount` is not provided, `checkout.total` will be used as a default value.
   """
-  taxCalculationStrategy: TaxCalculationStrategy
+  storedPaymentMethods(
+    """Amount that will be used to fetch stored payment methods."""
+    amount: PositiveDecimal
+  ): [StoredPaymentMethod!]
 
-  """
-  Determines whether displayed prices should include taxes for this country.
-  """
-  displayGrossPrices: Boolean!
-
-  """
-  The tax app `App.identifier` that will be used to calculate the taxes for the given channel and country. If not provided, use the value from the channel's tax configuration.
-  
-  Added in Saleor 3.19.
-  """
-  taxAppId: String
-
-  """
-  Determines whether to use weighted tax for shipping. When set to true, the tax rate for shipping will be calculated based on the weighted average of tax rates from the order or checkout lines.
-  
-  Added in Saleor 3.21.
-  """
-  useWeightedTaxForShipping: Boolean
+  """List of problems with the checkout."""
+  problems: [CheckoutProblem!]
 }
 
 """
@@ -33453,6 +33473,13 @@ type AccountError @doc(category: "Users") {
 
   """A type of address that causes the error."""
   addressType: AddressTypeEnum
+
+  """
+  List of attributes IDs which causes the error.
+  
+  Added in Saleor 3.23.
+  """
+  attributes: [ID!]
 }
 
 enum AccountErrorCode @doc(category: "Users") {
@@ -34033,6 +34060,20 @@ input UserCreateInput @doc(category: "Users") {
   isConfirmed: Boolean @deprecated(reason: "The user will be always set as unconfirmed. The confirmation will take place when the user sets the password.")
 
   """
+  ID of the customer type to assign to the user. If not provided when creating a customer, the default customer type is assigned.
+  
+  Added in Saleor 3.23.
+  """
+  customerType: ID
+
+  """
+  List of attribute values to assign to the user. The attributes must belong to the customer type the user ends up with.
+  
+  Added in Saleor 3.23.
+  """
+  attributes: [AttributeValueInput!]
+
+  """
   URL of a view where users should be redirected to set the password. URL in RFC 1808 format.
   """
   redirectUrl: String
@@ -34102,6 +34143,20 @@ input CustomerInput @doc(category: "Users") {
 
   """User account is confirmed."""
   isConfirmed: Boolean
+
+  """
+  ID of the customer type to assign to the user. If not provided when creating a customer, the default customer type is assigned.
+  
+  Added in Saleor 3.23.
+  """
+  customerType: ID
+
+  """
+  List of attribute values to assign to the user. The attributes must belong to the customer type the user ends up with.
+  
+  Added in Saleor 3.23.
+  """
+  attributes: [AttributeValueInput!]
 }
 
 """
@@ -34465,6 +34520,13 @@ type StaffError @doc(category: "Users") {
 
   """A type of address that causes the error."""
   addressType: AddressTypeEnum
+
+  """
+  List of attributes IDs which causes the error.
+  
+  Added in Saleor 3.23.
+  """
+  attributes: [ID!]
 
   """List of permissions which causes the error."""
   permissions: [PermissionEnum!]


### PR DESCRIPTION
- **`customerType` and `attributes` inputs** on `customerCreate`, `customerUpdate`, and `customerBulkUpdate` (MANAGE_USERS). `accountRegister`/`accountUpdate` deliberately get neither — a customer can never write their own type or values.
- **Value validation via `AttributeAssignmentMixin`** — values are validated against the customer type the user ends up with, including required-attribute enforcement. Attribute errors surface as `AccountError` with the new `attributes` ID-list field.
- **`User.assignedAttributes(limit:)` and `User.assignedAttribute(slug:)`**, with `User` implementing `ObjectWithAttributes`. Gated to the owner or MANAGE_USERS; owners see only storefront-visible attributes. Users not yet backfilled with a type fall back to the Default type's attributes.
- **Webhooks**: no new events — attribute/type changes ride the existing `CUSTOMER_UPDATED` (and values set at creation ride `CUSTOMER_CREATED`), in both single and bulk mutations.
- **Value lifecycle**: persist-and-hide on type change — values survive in the database and are hidden from the API when the new type lacks the attribute (TODO comment marks the type-change path for future value migration).

The `schema.graphql` diff is ~9k lines. `User` now references the `AssignedAttribute` cluster, so type-discovery order pulls those definitions earlier in the file. Only ~60 lines are new content.
