### PR TITLE
feat(app): add appReloadManifest mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### GraphQL API
 
+- Added `appReloadManifest` mutation that reloads an installed app from its manifest URL, re-syncing the app's fields, permissions, extensions and webhooks without reinstalling. Pass `dryRun: true` to get a preview (`currentManifest` / `incomingManifest`) of the changes without applying them.
 - Added `stockAvailability` and `stocks` filters to the `productVariants` query `where` input, allowing variants to be filtered by their stock status and stock quantity for a given channel - #17689 by @ayesha-waris
 - `lines` input on the `checkoutCreate` mutation is no longer required. When omitted, a checkout with no lines is created.
 - Removed the deprecated `availableShippingMethods` field from the `Order` type. Use `shippingMethods` instead.

--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from collections.abc import Iterable
 from io import BytesIO
 
 import requests
@@ -9,7 +10,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files import File
 from django.core.files.storage import default_storage
-from django.db import DatabaseError
+from django.db import DatabaseError, transaction
 from django.urls import reverse
 from requests import HTTPError, Response
 
@@ -26,7 +27,7 @@ from ..thumbnail.utils import get_filename_from_url
 from ..thumbnail.validators import validate_icon_image
 from ..webhook.models import Webhook, WebhookEvent
 from .error_codes import AppErrorCode
-from .manifest_validations import clean_manifest_data
+from .manifest_validations import MANIFEST_SCALAR_FIELDS, clean_manifest_data
 from .models import App, AppExtension, AppInstallation, AppToken
 from .types import DEFAULT_APP_TARGET, AppType
 
@@ -236,6 +237,67 @@ def fetch_manifest(
     return _get(max_retries)  # final attempt, explicit return to satisfy ruff RET503
 
 
+def _create_app_extension(app: App, extension_data: dict) -> AppExtension:
+    # Manifest is already "clean" so values use serialization aliases (camelCase)
+    options = extension_data.get("options", {})
+    new_tab_target = options.get("newTabTarget")
+    widget_target = options.get("widgetTarget")
+
+    # Ensure proper extraction of the method values from the options
+    http_target_method = None
+
+    if (
+        new_tab_target
+        and isinstance(new_tab_target, dict)
+        and "method" in new_tab_target
+    ):
+        http_target_method = new_tab_target["method"]
+
+    if widget_target and isinstance(widget_target, dict) and "method" in widget_target:
+        http_target_method = widget_target["method"]
+
+    extension = AppExtension.objects.create(
+        app=app,
+        label=extension_data.get("label"),
+        url=extension_data.get("url"),
+        mount=extension_data.get("mount"),
+        target=extension_data.get("target", DEFAULT_APP_TARGET),
+        http_target_method=http_target_method,
+        settings=extension_data.get("options", {}),
+        identifier=extension_data.get("identifier"),
+    )
+    extension.permissions.set(extension_data.get("permissions", []))
+    return extension
+
+
+def _create_manifest_webhooks(app: App, manifest_webhooks: list[dict]) -> list[Webhook]:
+    """Create webhooks (and their events) from cleaned manifest webhook data.
+
+    Shared by install and reload so the two paths can never build webhook rows
+    differently. The caller decides which webhooks to create (e.g. reload passes
+    only the to-create subset).
+    """
+    webhooks = Webhook.objects.bulk_create(
+        Webhook(
+            app=app,
+            name=webhook["name"],
+            is_active=webhook["isActive"],
+            target_url=webhook["targetUrl"],
+            subscription_query=webhook["query"],
+            custom_headers=webhook.get("customHeaders", None),
+        )
+        for webhook in manifest_webhooks
+    )
+    WebhookEvent.objects.bulk_create(
+        WebhookEvent(webhook=db_webhook, event_type=event_type)
+        for db_webhook, manifest_webhook in zip(
+            webhooks, manifest_webhooks, strict=True
+        )
+        for event_type in manifest_webhook["events"]
+    )
+    return webhooks
+
+
 def install_app(
     app_installation: AppInstallation, activate: bool = False
 ) -> tuple[App, AppToken | None]:
@@ -267,61 +329,9 @@ def install_app(
 
     app.permissions.set(app_installation.permissions.all())
     for extension_data in manifest_data.get("extensions", []):
-        # Manifest is already "clean" so values use serialization aliases (camelCase)
-        options = extension_data.get("options", {})
-        new_tab_target = options.get("newTabTarget")
-        widget_target = options.get("widgetTarget")
+        _create_app_extension(app, extension_data)
 
-        # Ensure proper extraction of the method values from the options
-        http_target_method = None
-
-        if (
-            new_tab_target
-            and isinstance(new_tab_target, dict)
-            and "method" in new_tab_target
-        ):
-            http_target_method = new_tab_target["method"]
-
-        if (
-            widget_target
-            and isinstance(widget_target, dict)
-            and "method" in widget_target
-        ):
-            http_target_method = widget_target["method"]
-
-        extension = AppExtension.objects.create(
-            app=app,
-            label=extension_data.get("label"),
-            url=extension_data.get("url"),
-            mount=extension_data.get("mount"),
-            target=extension_data.get("target", DEFAULT_APP_TARGET),
-            http_target_method=http_target_method,
-            settings=extension_data.get("options", {}),
-            identifier=extension_data.get("identifier"),
-        )
-        extension.permissions.set(extension_data.get("permissions", []))
-
-    webhooks = Webhook.objects.bulk_create(
-        Webhook(
-            app=app,
-            name=webhook["name"],
-            is_active=webhook["isActive"],
-            target_url=webhook["targetUrl"],
-            subscription_query=webhook["query"],
-            custom_headers=webhook.get("customHeaders", None),
-        )
-        for webhook in manifest_data.get("webhooks", [])
-    )
-
-    webhook_events = []
-    for db_webhook, manifest_webhook in zip(
-        webhooks, manifest_data.get("webhooks", []), strict=False
-    ):
-        for event_type in manifest_webhook["events"]:
-            webhook_events.append(
-                WebhookEvent(webhook=db_webhook, event_type=event_type)
-            )
-    WebhookEvent.objects.bulk_create(webhook_events)
+    _create_manifest_webhooks(app, manifest_data.get("webhooks", []))
 
     token = None
     if tokent_target_url := manifest_data.get("tokenTargetUrl"):
@@ -336,3 +346,247 @@ def install_app(
     PluginsManager(plugins=settings.PLUGINS).app_installed(app)
     fetch_brand_data_async(manifest_data, app=app)
     return app, token
+
+
+def _dedupe_manifest_webhooks(manifest_webhooks: list[dict]) -> list[dict]:
+    """Drop manifest webhooks with a duplicated name, keeping the first occurrence.
+
+    Webhooks are matched by name during a manifest reload; duplicated names in
+    a manifest are the app author's bug and are resolved deterministically.
+    """
+    seen: set[str] = set()
+    deduped = []
+    for webhook in manifest_webhooks:
+        if webhook["name"] in seen:
+            continue
+        seen.add(webhook["name"])
+        deduped.append(webhook)
+    return deduped
+
+
+def canonicalize_manifest_json(value):
+    """Recursively sort dict keys so equal data serializes to an identical string.
+
+    JSONField (jsonb) values return from Postgres in normalized — not authored —
+    key order, so two semantically-equal manifests can dump to different JSON
+    strings. Sorting keys before the value is handed to the JSONString scalar
+    keeps the manifest-reload preview diff free of phantom key-order noise.
+    """
+    if isinstance(value, dict):
+        return {key: canonicalize_manifest_json(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [canonicalize_manifest_json(item) for item in value]
+    return value
+
+
+def _serialize_webhook_for_preview(
+    name: str, target_url: str, query: str | None, events: Iterable[str], custom_headers
+) -> dict:
+    return {
+        "name": name,
+        "targetUrl": target_url,
+        "query": query or "",
+        "events": sorted(events),
+        "customHeaders": custom_headers or {},
+    }
+
+
+def _serialize_extension_for_preview(
+    identifier, label, url, mount, target, permission_names: Iterable[str], options
+) -> dict:
+    return {
+        "identifier": identifier,
+        "label": label,
+        "url": url,
+        "mount": mount,
+        "target": target,
+        "permissions": sorted(permission_names),
+        "options": options or {},
+    }
+
+
+def _serialize_app_extensions(app: App) -> list[dict]:
+    return sorted(
+        (
+            _serialize_extension_for_preview(
+                extension.identifier,
+                extension.label,
+                extension.url,
+                extension.mount,
+                extension.target,
+                get_permission_names(extension.permissions.all()),
+                extension.settings,
+            )
+            for extension in app.extensions.prefetch_related("permissions")
+        ),
+        key=lambda extension: (extension["identifier"] or "", extension["label"]),
+    )
+
+
+def _serialize_manifest_extensions(manifest_data: dict) -> list[dict]:
+    return sorted(
+        (
+            _serialize_extension_for_preview(
+                extension.get("identifier"),
+                extension.get("label"),
+                extension.get("url"),
+                extension.get("mount"),
+                extension.get("target", DEFAULT_APP_TARGET),
+                get_permission_names(extension.get("permissions", [])),
+                extension.get("options", {}),
+            )
+            for extension in manifest_data.get("extensions", [])
+        ),
+        key=lambda extension: (extension["identifier"] or "", extension["label"]),
+    )
+
+
+def _serialize_app_webhooks(app: App) -> list[dict]:
+    return sorted(
+        (
+            _serialize_webhook_for_preview(
+                webhook.name,
+                webhook.target_url,
+                webhook.subscription_query,
+                (event.event_type for event in webhook.events.all()),
+                webhook.custom_headers,
+            )
+            for webhook in app.webhooks.prefetch_related("events")
+        ),
+        key=lambda webhook: webhook["name"],
+    )
+
+
+def _serialize_manifest_webhooks(manifest_data: dict) -> list[dict]:
+    return sorted(
+        (
+            _serialize_webhook_for_preview(
+                webhook["name"],
+                webhook["targetUrl"],
+                webhook["query"],
+                webhook["events"],
+                webhook.get("customHeaders"),
+            )
+            for webhook in _dedupe_manifest_webhooks(manifest_data.get("webhooks", []))
+        ),
+        key=lambda webhook: webhook["name"],
+    )
+
+
+def serialize_app_as_manifest(app: App) -> dict:
+    """Serialize an installed app's state into the manifest shape.
+
+    Covers only the fields a manifest reload applies (scalar fields,
+    permissions, extensions, webhooks) so it can be compared against
+    ``serialize_manifest_for_preview`` output with no diff noise.
+    """
+    manifest = {
+        manifest_key: getattr(app, attr)
+        for manifest_key, attr in MANIFEST_SCALAR_FIELDS
+    }
+    manifest["id"] = app.identifier
+    manifest["permissions"] = sorted(get_permission_names(app.permissions.all()))
+    manifest["extensions"] = _serialize_app_extensions(app)
+    manifest["webhooks"] = _serialize_app_webhooks(app)
+    return manifest
+
+
+def serialize_manifest_for_preview(manifest_data: dict) -> dict:
+    """Serialize cleaned manifest data into the same shape as ``serialize_app_as_manifest``."""
+    manifest = {
+        manifest_key: manifest_data.get(manifest_key)
+        for manifest_key, _ in MANIFEST_SCALAR_FIELDS
+    }
+    manifest["id"] = manifest_data.get("id")
+    manifest["permissions"] = sorted(
+        get_permission_names(manifest_data.get("permissions", []))
+    )
+    manifest["extensions"] = _serialize_manifest_extensions(manifest_data)
+    manifest["webhooks"] = _serialize_manifest_webhooks(manifest_data)
+    return manifest
+
+
+def _resync_app_webhooks(app: App, manifest_webhooks: list[dict]):
+    """Reconcile the app's webhooks with its manifest webhooks.
+
+    Webhooks are matched by name — the only identity a manifest webhook has.
+    Matched webhooks are updated in place, keeping their ``is_active`` flag
+    (an admin's activation choice survives a reload) and ``secret_key``.
+    A webhook renamed in the manifest is therefore deleted and recreated.
+    """
+    manifest_webhooks = _dedupe_manifest_webhooks(manifest_webhooks)
+    existing_by_name: dict[str, Webhook] = {}
+    for webhook in app.webhooks.order_by("pk").prefetch_related("events"):
+        # Duplicated names among existing webhooks: the first one is matchable,
+        # the rest are deleted below as unmatched.
+        existing_by_name.setdefault(webhook.name, webhook)
+
+    matched_ids = set()
+    webhooks_to_create = []
+    for manifest_webhook in manifest_webhooks:
+        existing = existing_by_name.get(manifest_webhook["name"])
+        if existing is None:
+            webhooks_to_create.append(manifest_webhook)
+            continue
+
+        matched_ids.add(existing.pk)
+        update_fields = []
+        if existing.target_url != manifest_webhook["targetUrl"]:
+            existing.target_url = manifest_webhook["targetUrl"]
+            update_fields.append("target_url")
+        if (existing.subscription_query or "") != (manifest_webhook["query"] or ""):
+            existing.subscription_query = manifest_webhook["query"]
+            update_fields.append("subscription_query")
+        custom_headers = manifest_webhook.get("customHeaders") or {}
+        if (existing.custom_headers or {}) != custom_headers:
+            existing.custom_headers = custom_headers
+            update_fields.append("custom_headers")
+        if update_fields:
+            existing.save(update_fields=update_fields)
+
+        current_events = sorted(event.event_type for event in existing.events.all())
+        manifest_events = sorted(manifest_webhook["events"])
+        if current_events != manifest_events:
+            existing.events.all().delete()
+            WebhookEvent.objects.bulk_create(
+                WebhookEvent(webhook=existing, event_type=event_type)
+                for event_type in manifest_events
+            )
+
+    app.webhooks.exclude(pk__in=matched_ids).delete()
+
+    _create_manifest_webhooks(app, webhooks_to_create)
+
+
+def resync_app_from_manifest(app: App, manifest_data: dict) -> App:
+    """Update an installed app in place from its cleaned manifest data.
+
+    Applies the manifest's scalar fields, identifier, permissions, extensions
+    and webhooks. The app's ``is_active`` flag, tokens and existing webhooks'
+    ``is_active``/``secret_key`` are never modified.
+    """
+    with transaction.atomic():
+        # Adopting the manifest id lets an app installed before identifiers were
+        # recorded (identifier == "") converge; for an app that already has one
+        # the mutation guarantees a match, so this is a no-op write.
+        app.identifier = manifest_data["id"]
+        for manifest_key, attr in MANIFEST_SCALAR_FIELDS:
+            setattr(app, attr, manifest_data.get(manifest_key))
+        app.save(
+            update_fields=["identifier", *(attr for _, attr in MANIFEST_SCALAR_FIELDS)]
+        )
+        app.permissions.set(manifest_data.get("permissions", []))
+        # AppExtension rows have no stable per-row identity, so unchanged
+        # extensions are left untouched and only a real change triggers a
+        # wholesale rebuild — reissuing extension IDs (which dashboard mounts and
+        # URLs reference) on every reload would otherwise break open sessions.
+        if _serialize_app_extensions(app) != _serialize_manifest_extensions(
+            manifest_data
+        ):
+            app.extensions.all().delete()
+            for extension_data in manifest_data.get("extensions", []):
+                _create_app_extension(app, extension_data)
+        _resync_app_webhooks(app, manifest_data.get("webhooks", []))
+
+    fetch_brand_data_async(manifest_data, app=app)
+    return app

--- a/saleor/app/manifest_validations.py
+++ b/saleor/app/manifest_validations.py
@@ -111,7 +111,9 @@ def _ensure_app_permissions_allowed(required_permissions: list[str]) -> None:
     )
 
 
-def clean_manifest_data(manifest_data, raise_for_saleor_version=False):
+def clean_manifest_data(
+    manifest_data, raise_for_saleor_version=False, exclude_app: App | None = None
+):
     # Structural validation: required fields, field types, URL formats, brand logo.
     try:
         ManifestSchema.model_validate(manifest_data)
@@ -142,11 +144,12 @@ def clean_manifest_data(manifest_data, raise_for_saleor_version=False):
         app_permissions = []
 
     manifest_data["permissions"] = app_permissions
-    if (
-        app := App.objects.not_removed()
-        .filter(identifier=manifest_data.get("id"))
-        .first()
-    ):
+    installed_apps = App.objects.not_removed().filter(
+        identifier=manifest_data.get("id")
+    )
+    if exclude_app is not None:
+        installed_apps = installed_apps.exclude(pk=exclude_app.pk)
+    if app := installed_apps.first():
         errors["identifier"].append(
             ValidationError(
                 f"App with the same identifier is already installed: {app.name}",
@@ -163,11 +166,50 @@ def clean_manifest_data(manifest_data, raise_for_saleor_version=False):
         )
 
     if not errors:
+        _clean_field_lengths(manifest_data, errors)
         _clean_extensions(manifest_data, app_permissions, errors)
         _clean_webhooks(manifest_data, errors)
 
     if errors:
         raise ValidationError(errors)
+
+
+# Manifest scalar key -> App model attribute it is stored in. Single source of
+# truth for the manifest<->model field correspondence, shared with the reload
+# serializers/writer in installation_utils so they can never drift.
+MANIFEST_SCALAR_FIELDS: tuple[tuple[str, str], ...] = (
+    ("name", "name"),
+    ("about", "about_app"),
+    ("version", "version"),
+    ("author", "author"),
+    ("audience", "audience"),
+    ("appUrl", "app_url"),
+    ("configurationUrl", "configuration_url"),
+    ("dataPrivacy", "data_privacy"),
+    ("dataPrivacyUrl", "data_privacy_url"),
+    ("homepageUrl", "homepage_url"),
+    ("supportUrl", "support_url"),
+)
+
+
+def _clean_field_lengths(manifest_data, errors):
+    """Reject values that would overflow their App column.
+
+    Without this a too-long value raises a DataError deep in ``.save()`` (a 500
+    on reload); the limits are read from the model so they can't drift from the
+    schema. Unbounded columns (``TextField``) report ``max_length`` as ``None``
+    and are skipped.
+    """
+    for manifest_field, model_field in MANIFEST_SCALAR_FIELDS:
+        max_length = App._meta.get_field(model_field).max_length
+        value = manifest_data.get(manifest_field)
+        if max_length and value and len(value) > max_length:
+            errors[manifest_field].append(
+                ValidationError(
+                    f"Value exceeds the maximum length of {max_length} characters.",
+                    code=AppErrorCode.INVALID.value,
+                )
+            )
 
 
 def _clean_extension_permissions(extension, app_permissions, errors):

--- a/saleor/app/tests/test_manifest_resync.py
+++ b/saleor/app/tests/test_manifest_resync.py
@@ -1,0 +1,307 @@
+from ...webhook.event_types import WebhookEventAsyncType
+from ...webhook.models import Webhook, WebhookEvent
+from ..installation_utils import (
+    resync_app_from_manifest,
+    serialize_app_as_manifest,
+    serialize_manifest_for_preview,
+)
+
+SUBSCRIPTION_QUERY = "subscription { event { ... on OrderCreated { order { id } } } }"
+
+
+def _manifest_data(app, **overrides):
+    """Build manifest data in the shape produced by clean_manifest_data."""
+    manifest_data = {
+        "id": app.identifier,
+        "name": "Reloaded app",
+        "about": "About the reloaded app.",
+        "version": "2.0",
+        "author": "Saleor",
+        "audience": None,
+        "appUrl": "https://app.example/app",
+        "configurationUrl": "https://app.example/configuration",
+        "dataPrivacy": None,
+        "dataPrivacyUrl": None,
+        "homepageUrl": "https://app.example",
+        "supportUrl": "https://app.example/support",
+        "permissions": [],
+        "extensions": [],
+        "webhooks": [],
+    }
+    manifest_data.update(overrides)
+    return manifest_data
+
+
+def _manifest_webhook(**overrides):
+    webhook = {
+        "name": "order-webhook",
+        "targetUrl": "https://app.example/api/webhook",
+        "query": SUBSCRIPTION_QUERY,
+        "events": [WebhookEventAsyncType.ORDER_CREATED],
+        "isActive": True,
+    }
+    webhook.update(overrides)
+    return webhook
+
+
+def test_resync_creates_missing_webhooks(app):
+    # given
+    manifest_data = _manifest_data(app, webhooks=[_manifest_webhook()])
+
+    # when
+    resync_app_from_manifest(app, manifest_data)
+
+    # then
+    webhook = app.webhooks.get()
+    assert webhook.name == "order-webhook"
+    assert webhook.target_url == "https://app.example/api/webhook"
+    assert webhook.is_active is True
+    assert list(webhook.events.values_list("event_type", flat=True)) == [
+        WebhookEventAsyncType.ORDER_CREATED
+    ]
+
+
+def test_resync_updates_matched_webhook_and_preserves_is_active(app):
+    # given
+    existing = Webhook.objects.create(
+        app=app,
+        name="order-webhook",
+        is_active=False,
+        target_url="https://old.example/api/webhook",
+        subscription_query="subscription { event { __typename } }",
+    )
+    WebhookEvent.objects.create(
+        webhook=existing, event_type=WebhookEventAsyncType.ORDER_UPDATED
+    )
+    manifest_data = _manifest_data(app, webhooks=[_manifest_webhook()])
+
+    # when
+    resync_app_from_manifest(app, manifest_data)
+
+    # then
+    existing.refresh_from_db()
+    assert app.webhooks.count() == 1
+    assert existing.target_url == "https://app.example/api/webhook"
+    assert existing.subscription_query == SUBSCRIPTION_QUERY
+    assert existing.is_active is False
+    assert list(existing.events.values_list("event_type", flat=True)) == [
+        WebhookEventAsyncType.ORDER_CREATED
+    ]
+
+
+def test_resync_deletes_webhooks_absent_from_manifest(app):
+    # given
+    Webhook.objects.create(
+        app=app, name="legacy", target_url="https://old.example/api/legacy"
+    )
+    manifest_data = _manifest_data(app, webhooks=[_manifest_webhook()])
+
+    # when
+    resync_app_from_manifest(app, manifest_data)
+
+    # then
+    assert list(app.webhooks.values_list("name", flat=True)) == ["order-webhook"]
+
+
+def test_resync_dedupes_duplicated_manifest_webhook_names(app):
+    # given: the first occurrence of a duplicated name wins.
+    manifest_data = _manifest_data(
+        app,
+        webhooks=[
+            _manifest_webhook(targetUrl="https://app.example/api/first"),
+            _manifest_webhook(targetUrl="https://app.example/api/second"),
+        ],
+    )
+
+    # when
+    resync_app_from_manifest(app, manifest_data)
+
+    # then
+    webhook = app.webhooks.get()
+    assert webhook.target_url == "https://app.example/api/first"
+
+
+def test_resync_updates_scalar_fields_and_permissions(app, permission_manage_products):
+    # given
+    app_is_active = app.is_active
+    manifest_data = _manifest_data(app, permissions=[permission_manage_products])
+
+    # when
+    resync_app_from_manifest(app, manifest_data)
+
+    # then
+    app.refresh_from_db()
+    assert app.name == "Reloaded app"
+    assert app.about_app == "About the reloaded app."
+    assert app.version == "2.0"
+    assert app.homepage_url == "https://app.example"
+    assert app.is_active == app_is_active
+    assert [permission.codename for permission in app.permissions.all()] == [
+        "manage_products"
+    ]
+
+
+def test_serialize_matches_after_resync(app, permission_manage_products):
+    # given: once resynced, the app serializes exactly as its manifest —
+    # this is the invariant the reload preview's "no changes" state relies on.
+    manifest_data = _manifest_data(
+        app,
+        permissions=[permission_manage_products],
+        webhooks=[
+            _manifest_webhook(),
+            _manifest_webhook(
+                name="another-webhook",
+                targetUrl="https://app.example/api/another",
+                events=[
+                    WebhookEventAsyncType.ORDER_UPDATED,
+                    WebhookEventAsyncType.ORDER_CREATED,
+                ],
+            ),
+        ],
+    )
+
+    # when
+    resync_app_from_manifest(app, manifest_data)
+
+    # then
+    assert serialize_app_as_manifest(app) == serialize_manifest_for_preview(
+        manifest_data
+    )
+
+
+def test_serialize_app_as_manifest_sorts_collections(app):
+    # given
+    for name in ["zeta", "alpha"]:
+        webhook = Webhook.objects.create(
+            app=app,
+            name=name,
+            target_url=f"https://app.example/api/{name}",
+        )
+        WebhookEvent.objects.bulk_create(
+            WebhookEvent(webhook=webhook, event_type=event_type)
+            for event_type in [
+                WebhookEventAsyncType.ORDER_UPDATED,
+                WebhookEventAsyncType.ORDER_CREATED,
+            ]
+        )
+
+    # when
+    serialized = serialize_app_as_manifest(app)
+
+    # then
+    assert [webhook["name"] for webhook in serialized["webhooks"]] == [
+        "alpha",
+        "zeta",
+    ]
+    assert serialized["webhooks"][0]["events"] == sorted(
+        [
+            WebhookEventAsyncType.ORDER_UPDATED,
+            WebhookEventAsyncType.ORDER_CREATED,
+        ]
+    )
+
+
+def test_resync_converges_blank_identifier_app(app):
+    # given - an app installed before identifiers were recorded
+    app.identifier = ""
+    app.save(update_fields=["identifier"])
+    manifest_data = _manifest_data(app, id="saleor.reloaded.app")
+
+    # when
+    resync_app_from_manifest(app, manifest_data)
+
+    # then - the app adopts the manifest id, so the preview reaches "up to date"
+    app.refresh_from_db()
+    assert app.identifier == "saleor.reloaded.app"
+    assert serialize_app_as_manifest(app) == serialize_manifest_for_preview(
+        manifest_data
+    )
+
+
+def test_resync_keeps_extension_ids_when_extensions_unchanged(app):
+    # given - an app whose manifest keeps its single extension but changes a scalar
+    from ...app.models import AppExtension
+
+    extension = AppExtension.objects.create(
+        app=app,
+        label="Settings",
+        url="https://app.example/settings",
+        mount="navigation_catalog",
+        target="popup",
+        identifier="settings-ext",
+    )
+    manifest_extension = {
+        "identifier": "settings-ext",
+        "label": "Settings",
+        "url": "https://app.example/settings",
+        "mount": "navigation_catalog",
+        "target": "popup",
+        "permissions": [],
+        "options": {},
+    }
+    manifest_data = _manifest_data(
+        app, name="Renamed app", extensions=[manifest_extension]
+    )
+
+    # when
+    resync_app_from_manifest(app, manifest_data)
+
+    # then - the extension row is reused, not deleted and recreated
+    assert list(app.extensions.values_list("pk", flat=True)) == [extension.pk]
+    app.refresh_from_db()
+    assert app.name == "Renamed app"
+
+
+def test_resync_rebuilds_extensions_when_changed(app):
+    # given
+    from ...app.models import AppExtension
+
+    old = AppExtension.objects.create(
+        app=app,
+        label="Old",
+        url="https://app.example/old",
+        mount="navigation_catalog",
+        target="popup",
+        identifier="old-ext",
+    )
+    manifest_data = _manifest_data(
+        app,
+        extensions=[
+            {
+                "identifier": "new-ext",
+                "label": "New",
+                "url": "https://app.example/new",
+                "mount": "navigation_catalog",
+                "target": "popup",
+                "permissions": [],
+                "options": {},
+            }
+        ],
+    )
+
+    # when
+    resync_app_from_manifest(app, manifest_data)
+
+    # then
+    assert not AppExtension.objects.filter(pk=old.pk).exists()
+    assert list(app.extensions.values_list("identifier", flat=True)) == ["new-ext"]
+
+
+def test_serialize_matches_after_resync_with_custom_headers(app):
+    # given - custom headers whose manifest key order differs from jsonb order
+    manifest_data = _manifest_data(
+        app,
+        webhooks=[
+            _manifest_webhook(
+                customHeaders={"X-Zeta": "1", "X-Alpha": "2", "X-Mu": "3"}
+            )
+        ],
+    )
+
+    # when
+    resync_app_from_manifest(app, manifest_data)
+
+    # then - key order does not produce a phantom diff
+    assert serialize_app_as_manifest(app) == serialize_manifest_for_preview(
+        manifest_data
+    )

--- a/saleor/graphql/app/mutations/__init__.py
+++ b/saleor/graphql/app/mutations/__init__.py
@@ -8,6 +8,7 @@ from .app_install import AppInstall
 from .app_problem_create import AppProblemCreate
 from .app_problem_dismiss import AppProblemDismiss
 from .app_reenable_sync_webhooks import AppReenableSyncWebhooks
+from .app_reload_manifest import AppReloadManifest
 from .app_retry_install import AppRetryInstall
 from .app_token_create import AppTokenCreate
 from .app_token_delete import AppTokenDelete
@@ -30,4 +31,5 @@ __all__ = [
     "AppTokenVerify",
     "AppUpdate",
     "AppReenableSyncWebhooks",
+    "AppReloadManifest",
 ]

--- a/saleor/graphql/app/mutations/app_reload_manifest.py
+++ b/saleor/graphql/app/mutations/app_reload_manifest.py
@@ -1,0 +1,170 @@
+from typing import cast
+
+import graphene
+from django.core.exceptions import ValidationError
+
+from ....app import models
+from ....app.error_codes import AppErrorCode
+from ....app.installation_utils import (
+    canonicalize_manifest_json,
+    resync_app_from_manifest,
+    serialize_app_as_manifest,
+    serialize_manifest_for_preview,
+)
+from ....app.manifest_validations import clean_manifest_data
+from ....app.types import AppType
+from ....permission.enums import AppPermission
+from ....webhook.event_types import WebhookEventAsyncType
+from ...core.descriptions import ADDED_IN_324
+from ...core.doc_category import DOC_CATEGORY_APPS
+from ...core.fields import JSONString
+from ...core.mutations import BaseMutation
+from ...core.types import AppError, BaseObjectType
+from ...core.utils import WebhookEventInfo
+from ...decorators import staff_member_required
+from ...plugins.dataloaders import get_plugin_manager_promise
+from ...utils import get_user_or_app_from_context
+from ..types import App
+from ..utils import ensure_can_manage_permissions, validate_app_is_not_removed
+from .app_fetch_manifest import AppFetchManifest
+
+
+class AppManifestReloadPreview(BaseObjectType):
+    current_manifest = JSONString(
+        required=True,
+        description=(
+            "The installed app's current state, serialized in the manifest shape. "
+            "Covers only the fields a reload applies."
+        ),
+    )
+    incoming_manifest = JSONString(
+        required=True,
+        description=(
+            "The freshly fetched manifest, serialized in the same shape as "
+            "`currentManifest`."
+        ),
+    )
+
+    class Meta:
+        description = (
+            "Preview of the changes a manifest reload would apply." + ADDED_IN_324
+        )
+        doc_category = DOC_CATEGORY_APPS
+
+
+class AppReloadManifest(BaseMutation):
+    app = graphene.Field(App, description="App reloaded from its manifest.")
+    preview = graphene.Field(
+        AppManifestReloadPreview,
+        description="Current and incoming manifest, for reviewing the changes.",
+    )
+
+    class Arguments:
+        id = graphene.ID(description="ID of the app to reload.", required=True)
+        dry_run = graphene.Boolean(
+            default_value=False,
+            description=(
+                "If true, fetch and validate the manifest and return the preview "
+                "without applying any changes."
+            ),
+        )
+        expected_incoming_manifest = JSONString(
+            required=False,
+            description=(
+                "The `incomingManifest` returned by a prior dry run. When "
+                "provided on apply, the mutation refuses to apply if the manifest "
+                "fetched now differs from it — so an admin never silently applies "
+                "changes the manifest gained since the preview was reviewed."
+            ),
+        )
+
+    class Meta:
+        auto_permission_message = False
+        description = (
+            "Reload an installed app from its manifest URL: the app's fields, "
+            "permissions, extensions and webhooks are updated to match the "
+            "manifest. Webhooks are matched by name; a webhook renamed in the "
+            "manifest is deleted and recreated. The `isActive` flag of existing "
+            "webhooks and of the app itself, and app tokens, are never modified. "
+            "Requires the following permissions: AUTHENTICATED_STAFF_USER "
+            "and MANAGE_APPS." + ADDED_IN_324
+        )
+        doc_category = DOC_CATEGORY_APPS
+        permissions = (AppPermission.MANAGE_APPS,)
+        error_type_class = AppError
+        error_type_field = "app_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.APP_UPDATED,
+                description="An app was reloaded from its manifest.",
+            ),
+        ]
+
+    @classmethod
+    @staff_member_required
+    def perform_mutation(cls, _root, info, /, **data):
+        app_global_id = data["id"]
+        app = cls.get_node_or_error(info, app_global_id, only_type="App", field="id")
+        app = cast(models.App, app)
+        validate_app_is_not_removed(app, app_global_id, "id")
+        if app.type != AppType.THIRDPARTY or not app.manifest_url:
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        "The app was not installed from a manifest.",
+                        code=AppErrorCode.INVALID.value,
+                    )
+                }
+            )
+
+        manifest_data = AppFetchManifest.fetch_manifest(app.manifest_url)
+        if app.identifier and manifest_data.get("id") != app.identifier:
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        "The manifest identifier does not match the installed app.",
+                        code=AppErrorCode.INVALID.value,
+                    )
+                }
+            )
+        clean_manifest_data(
+            manifest_data, raise_for_saleor_version=True, exclude_app=app
+        )
+        requestor = get_user_or_app_from_context(info.context)
+        ensure_can_manage_permissions(
+            requestor,
+            [
+                permission.formatted_codename
+                for permission in manifest_data["permissions"]
+            ],
+        )
+
+        incoming_manifest = serialize_manifest_for_preview(manifest_data)
+
+        if data["dry_run"]:
+            # The current-state serialization walks the app's webhooks/extensions
+            # and is only needed to render the diff, so it is skipped on apply.
+            preview = AppManifestReloadPreview(
+                current_manifest=canonicalize_manifest_json(
+                    serialize_app_as_manifest(app)
+                ),
+                incoming_manifest=canonicalize_manifest_json(incoming_manifest),
+            )
+            return cls(app=app, preview=preview, errors=[])
+
+        expected = data.get("expected_incoming_manifest")
+        if expected is not None and incoming_manifest != expected:
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        "The manifest changed since the preview was generated. "
+                        "Please review the changes again before applying.",
+                        code=AppErrorCode.INVALID.value,
+                    )
+                }
+            )
+
+        resync_app_from_manifest(app, manifest_data)
+        manager = get_plugin_manager_promise(info.context).get()
+        cls.call_event(manager.app_updated, app)
+        return cls(app=app, preview=None, errors=[])

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -23,6 +23,7 @@ from .mutations import (
     AppProblemCreate,
     AppProblemDismiss,
     AppReenableSyncWebhooks,
+    AppReloadManifest,
     AppRetryInstall,
     AppTokenCreate,
     AppTokenDelete,
@@ -197,3 +198,5 @@ class AppMutations(graphene.ObjectType):
     app_problem_dismiss = AppProblemDismiss.Field()
 
     app_reenable_sync_webhooks = AppReenableSyncWebhooks.Field()
+
+    app_reload_manifest = AppReloadManifest.Field()

--- a/saleor/graphql/app/tests/mutations/test_app_reload_manifest.py
+++ b/saleor/graphql/app/tests/mutations/test_app_reload_manifest.py
@@ -1,0 +1,404 @@
+import copy
+import json
+from unittest.mock import patch
+
+import graphene
+import pytest
+import requests
+
+from .....app.error_codes import AppErrorCode
+from .....app.types import AppType
+from .....webhook.event_types import WebhookEventAsyncType
+from .....webhook.models import Webhook, WebhookEvent
+from ....tests.utils import assert_no_permission, get_graphql_content
+
+APP_RELOAD_MANIFEST_MUTATION = """
+mutation AppReloadManifest(
+  $id: ID!
+  $dryRun: Boolean
+  $expectedIncomingManifest: JSONString
+) {
+  appReloadManifest(
+    id: $id
+    dryRun: $dryRun
+    expectedIncomingManifest: $expectedIncomingManifest
+  ) {
+    app {
+      id
+      name
+    }
+    preview {
+      currentManifest
+      incomingManifest
+    }
+    errors {
+      field
+      message
+      code
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(autouse=True)
+def _third_party_app(app):
+    # The shared `app` fixture defaults to a LOCAL app; reloading a manifest
+    # only makes sense for THIRDPARTY (manifest-installed) apps.
+    app.type = AppType.THIRDPARTY
+    app.save(update_fields=["type"])
+
+
+@pytest.fixture
+def reload_manifest(app, app_manifest, app_manifest_webhook):
+    app_manifest["id"] = app.identifier
+    app_manifest["webhooks"] = [app_manifest_webhook]
+    return app_manifest
+
+
+def _reload(
+    staff_api_client,
+    app,
+    permissions,
+    dry_run=False,
+    expected_incoming_manifest=None,
+    check_no_permissions=True,
+):
+    variables = {
+        "id": graphene.Node.to_global_id("App", app.id),
+        "dryRun": dry_run,
+        "expectedIncomingManifest": expected_incoming_manifest,
+    }
+    response = staff_api_client.post_graphql(
+        APP_RELOAD_MANIFEST_MUTATION,
+        variables=variables,
+        permissions=permissions,
+        check_no_permissions=check_no_permissions,
+    )
+    content = get_graphql_content(response)
+    return content["data"]["appReloadManifest"]
+
+
+@patch("saleor.graphql.app.mutations.app_fetch_manifest.fetch_manifest")
+def test_app_reload_manifest_dry_run_applies_nothing(
+    mocked_fetch,
+    app,
+    reload_manifest,
+    staff_api_client,
+    staff_user,
+    permission_manage_apps,
+    permission_manage_products,
+    permission_manage_users,
+):
+    # given
+    mocked_fetch.return_value = reload_manifest
+    staff_user.user_permissions.add(permission_manage_products, permission_manage_users)
+    original_name = app.name
+
+    # when
+    data = _reload(staff_api_client, app, [permission_manage_apps], dry_run=True)
+
+    # then
+    assert data["errors"] == []
+    current = json.loads(data["preview"]["currentManifest"])
+    incoming = json.loads(data["preview"]["incomingManifest"])
+    assert current["name"] == original_name
+    assert incoming["name"] == reload_manifest["name"]
+    assert [webhook["name"] for webhook in incoming["webhooks"]] == ["webhook"]
+    app.refresh_from_db()
+    assert app.name == original_name
+    assert app.webhooks.exists() is False
+    assert app.permissions.exists() is False
+
+
+@patch("saleor.graphql.app.mutations.app_fetch_manifest.fetch_manifest")
+def test_app_reload_manifest_applies_changes(
+    mocked_fetch,
+    app,
+    reload_manifest,
+    staff_api_client,
+    staff_user,
+    permission_manage_apps,
+    permission_manage_products,
+    permission_manage_users,
+):
+    # given
+    mocked_fetch.return_value = reload_manifest
+    staff_user.user_permissions.add(permission_manage_products, permission_manage_users)
+    # A webhook matched by name: gets updated, keeps its is_active flag.
+    matched = Webhook.objects.create(
+        app=app,
+        name="webhook",
+        is_active=False,
+        target_url="https://old.example/api/webhook",
+        subscription_query="subscription { event { ... on OrderCreated { order { id } } } }",
+    )
+    WebhookEvent.objects.create(
+        webhook=matched, event_type=WebhookEventAsyncType.ORDER_UPDATED
+    )
+    # A webhook absent from the manifest: gets deleted.
+    unmatched = Webhook.objects.create(
+        app=app,
+        name="legacy-webhook",
+        target_url="https://old.example/api/legacy",
+    )
+
+    # when
+    data = _reload(staff_api_client, app, [permission_manage_apps])
+
+    # then
+    assert data["errors"] == []
+    app.refresh_from_db()
+    assert app.name == reload_manifest["name"]
+    assert app.homepage_url == reload_manifest["homepageUrl"]
+    permission_names = {permission.codename for permission in app.permissions.all()}
+    assert permission_names == {"manage_products", "manage_users"}
+
+    assert not Webhook.objects.filter(pk=unmatched.pk).exists()
+    matched.refresh_from_db()
+    assert matched.target_url == reload_manifest["webhooks"][0]["targetUrl"]
+    assert matched.subscription_query == reload_manifest["webhooks"][0]["query"]
+    assert matched.is_active is False  # admin's choice preserved
+    event_types = set(matched.events.values_list("event_type", flat=True))
+    assert event_types == {
+        WebhookEventAsyncType.ORDER_CREATED,
+        WebhookEventAsyncType.ORDER_FULLY_PAID,
+        WebhookEventAsyncType.CUSTOMER_CREATED,
+        WebhookEventAsyncType.FULFILLMENT_CREATED,
+    }
+
+
+@patch("saleor.graphql.app.mutations.app_fetch_manifest.fetch_manifest")
+def test_app_reload_manifest_identifier_mismatch(
+    mocked_fetch,
+    app,
+    reload_manifest,
+    staff_api_client,
+    permission_manage_apps,
+):
+    # given
+    reload_manifest["id"] = "some.other.app"
+    mocked_fetch.return_value = reload_manifest
+
+    # when
+    data = _reload(staff_api_client, app, [permission_manage_apps])
+
+    # then
+    assert data["app"] is None
+    assert data["errors"][0]["field"] == "id"
+    assert data["errors"][0]["code"] == AppErrorCode.INVALID.name
+
+
+def test_app_reload_manifest_without_manifest_url(
+    app, staff_api_client, permission_manage_apps
+):
+    # given
+    app.manifest_url = None
+    app.type = AppType.LOCAL
+    app.save(update_fields=["manifest_url", "type"])
+
+    # when
+    data = _reload(staff_api_client, app, [permission_manage_apps])
+
+    # then
+    assert data["errors"][0]["field"] == "id"
+    assert data["errors"][0]["code"] == AppErrorCode.INVALID.name
+
+
+@patch("saleor.graphql.app.mutations.app_fetch_manifest.fetch_manifest")
+def test_app_reload_manifest_fetch_timeout(
+    mocked_fetch, app, staff_api_client, permission_manage_apps
+):
+    # given
+    mocked_fetch.side_effect = requests.Timeout()
+
+    # when
+    data = _reload(staff_api_client, app, [permission_manage_apps])
+
+    # then
+    assert data["errors"][0]["code"] == AppErrorCode.MANIFEST_URL_CANT_CONNECT.name
+
+
+@patch("saleor.graphql.app.mutations.app_fetch_manifest.fetch_manifest")
+def test_app_reload_manifest_out_of_scope_permissions(
+    mocked_fetch,
+    app,
+    reload_manifest,
+    staff_api_client,
+    staff_user,
+    permission_manage_apps,
+    permission_manage_products,
+):
+    # given: staff user holds MANAGE_PRODUCTS but not MANAGE_USERS,
+    # which the manifest requests.
+    mocked_fetch.return_value = reload_manifest
+    staff_user.user_permissions.add(permission_manage_products)
+
+    # when
+    data = _reload(staff_api_client, app, [permission_manage_apps])
+
+    # then
+    assert data["app"] is None
+    assert data["errors"][0]["field"] == "permissions"
+    assert data["errors"][0]["code"] == AppErrorCode.OUT_OF_SCOPE_PERMISSION.name
+    app.refresh_from_db()
+    assert app.permissions.exists() is False
+
+
+def test_app_reload_manifest_removed_app(
+    app_marked_to_be_removed, staff_api_client, permission_manage_apps
+):
+    # when
+    data = _reload(staff_api_client, app_marked_to_be_removed, [permission_manage_apps])
+
+    # then
+    assert data["app"] is None
+    assert data["errors"][0]["field"] == "id"
+
+
+def test_app_reload_manifest_no_permission(app, staff_api_client):
+    # when
+    variables = {"id": graphene.Node.to_global_id("App", app.id), "dryRun": False}
+    response = staff_api_client.post_graphql(
+        APP_RELOAD_MANIFEST_MUTATION, variables=variables
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_app_reload_manifest_requires_staff_user(
+    app, app_api_client, permission_manage_apps
+):
+    # given: an app (non-staff requestor) holding MANAGE_APPS still cannot
+    # reload manifests.
+    app_api_client.app.permissions.add(permission_manage_apps)
+
+    # when
+    variables = {"id": graphene.Node.to_global_id("App", app.id), "dryRun": False}
+    response = app_api_client.post_graphql(
+        APP_RELOAD_MANIFEST_MUTATION, variables=variables
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+@patch("saleor.graphql.app.mutations.app_fetch_manifest.fetch_manifest")
+def test_app_reload_manifest_rejects_changed_manifest(
+    mocked_fetch,
+    app,
+    reload_manifest,
+    staff_api_client,
+    staff_user,
+    permission_manage_apps,
+    permission_manage_products,
+    permission_manage_users,
+):
+    # given - a preview was generated, then the manifest changed before apply.
+    # Each fetch returns a fresh copy, mirroring two separate GraphQL requests
+    # (clean_manifest_data mutates the dict it is given).
+    mocked_fetch.side_effect = lambda *args, **kwargs: copy.deepcopy(reload_manifest)
+    staff_user.user_permissions.add(permission_manage_products, permission_manage_users)
+    preview = _reload(staff_api_client, app, [permission_manage_apps], dry_run=True)
+    stale_incoming = preview["preview"]["incomingManifest"]
+    reload_manifest["name"] = "Changed since preview"
+
+    # when - apply passes the previously-previewed incoming manifest
+    data = _reload(
+        staff_api_client,
+        app,
+        [permission_manage_apps],
+        expected_incoming_manifest=stale_incoming,
+        check_no_permissions=False,
+    )
+
+    # then - the mutation refuses to apply the unreviewed change
+    assert data["app"] is None
+    assert data["errors"][0]["field"] == "id"
+    assert data["errors"][0]["code"] == AppErrorCode.INVALID.name
+    app.refresh_from_db()
+    assert app.name != "Changed since preview"
+
+
+@patch("saleor.graphql.app.mutations.app_fetch_manifest.fetch_manifest")
+def test_app_reload_manifest_applies_when_manifest_unchanged(
+    mocked_fetch,
+    app,
+    reload_manifest,
+    staff_api_client,
+    staff_user,
+    permission_manage_apps,
+    permission_manage_products,
+    permission_manage_users,
+):
+    # given
+    mocked_fetch.side_effect = lambda *args, **kwargs: copy.deepcopy(reload_manifest)
+    staff_user.user_permissions.add(permission_manage_products, permission_manage_users)
+    preview = _reload(staff_api_client, app, [permission_manage_apps], dry_run=True)
+    incoming = preview["preview"]["incomingManifest"]
+
+    # when - the manifest is unchanged since the preview
+    data = _reload(
+        staff_api_client,
+        app,
+        [permission_manage_apps],
+        expected_incoming_manifest=incoming,
+        check_no_permissions=False,
+    )
+
+    # then
+    assert data["errors"] == []
+    app.refresh_from_db()
+    assert app.name == reload_manifest["name"]
+
+
+@patch("saleor.graphql.app.mutations.app_fetch_manifest.fetch_manifest")
+def test_app_reload_manifest_dry_run_preview_has_sorted_keys(
+    mocked_fetch,
+    app,
+    reload_manifest,
+    app_manifest_webhook,
+    staff_api_client,
+    staff_user,
+    permission_manage_apps,
+    permission_manage_products,
+    permission_manage_users,
+):
+    # given - a webhook with custom headers in non-sorted order
+    app_manifest_webhook["customHeaders"] = {"X-Zeta": "1", "X-Alpha": "2"}
+    mocked_fetch.return_value = reload_manifest
+    staff_user.user_permissions.add(permission_manage_products, permission_manage_users)
+
+    # when
+    data = _reload(staff_api_client, app, [permission_manage_apps], dry_run=True)
+
+    # then - the preview JSON is canonical (keys sorted), so the dashboard's
+    # string comparison is stable
+    incoming = data["preview"]["incomingManifest"]
+    assert incoming == json.dumps(json.loads(incoming), sort_keys=True)
+
+
+@patch("saleor.graphql.app.mutations.app_fetch_manifest.fetch_manifest")
+def test_app_reload_manifest_rejects_overlong_name(
+    mocked_fetch,
+    app,
+    reload_manifest,
+    staff_api_client,
+    staff_user,
+    permission_manage_apps,
+    permission_manage_products,
+    permission_manage_users,
+):
+    # given - a manifest name longer than the App.name column (60 chars)
+    reload_manifest["name"] = "x" * 61
+    mocked_fetch.return_value = reload_manifest
+    staff_user.user_permissions.add(permission_manage_products, permission_manage_users)
+
+    # when
+    data = _reload(staff_api_client, app, [permission_manage_apps])
+
+    # then - a clean validation error, not a DataError/500
+    assert data["app"] is None
+    assert data["errors"][0]["field"] == "name"
+    assert data["errors"][0]["code"] == AppErrorCode.INVALID.name

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -21656,6 +21656,29 @@ type Mutation {
     appId: ID!
   ): AppReenableSyncWebhooks @doc(category: "Apps")
 
+  """
+  Reload an installed app from its manifest URL: the app's fields, permissions, extensions and webhooks are updated to match the manifest. Webhooks are matched by name; a webhook renamed in the manifest is deleted and recreated. The `isActive` flag of existing webhooks and of the app itself, and app tokens, are never modified. Requires the following permissions: AUTHENTICATED_STAFF_USER and MANAGE_APPS.
+  
+  Added in Saleor 3.24.
+  
+  Triggers the following webhook events:
+  - APP_UPDATED (async): An app was reloaded from its manifest.
+  """
+  appReloadManifest(
+    """
+    If true, fetch and validate the manifest and return the preview without applying any changes.
+    """
+    dryRun: Boolean = false
+
+    """
+    The `incomingManifest` returned by a prior dry run. When provided on apply, the mutation refuses to apply if the manifest fetched now differs from it — so an admin never silently applies changes the manifest gained since the preview was reviewed.
+    """
+    expectedIncomingManifest: JSONString
+
+    """ID of the app to reload."""
+    id: ID!
+  ): AppReloadManifest @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP_UPDATED], syncEvents: [])
+
   """Create JWT token."""
   tokenCreate(
     """
@@ -32697,6 +32720,41 @@ type AppReenableSyncWebhooks @doc(category: "Apps") {
   app: App
   appErrors: [AppError!]! @deprecated(reason: "Use `errors` field instead.")
   errors: [AppError!]!
+}
+
+"""
+Reload an installed app from its manifest URL: the app's fields, permissions, extensions and webhooks are updated to match the manifest. Webhooks are matched by name; a webhook renamed in the manifest is deleted and recreated. The `isActive` flag of existing webhooks and of the app itself, and app tokens, are never modified. Requires the following permissions: AUTHENTICATED_STAFF_USER and MANAGE_APPS.
+
+Added in Saleor 3.24.
+
+Triggers the following webhook events:
+- APP_UPDATED (async): An app was reloaded from its manifest.
+"""
+type AppReloadManifest @doc(category: "Apps") @webhookEventsInfo(asyncEvents: [APP_UPDATED], syncEvents: []) {
+  """App reloaded from its manifest."""
+  app: App
+
+  """Current and incoming manifest, for reviewing the changes."""
+  preview: AppManifestReloadPreview
+  appErrors: [AppError!]! @deprecated(reason: "Use `errors` field instead.")
+  errors: [AppError!]!
+}
+
+"""
+Preview of the changes a manifest reload would apply.
+
+Added in Saleor 3.24.
+"""
+type AppManifestReloadPreview @doc(category: "Apps") {
+  """
+  The installed app's current state, serialized in the manifest shape. Covers only the fields a reload applies.
+  """
+  currentManifest: JSONString!
+
+  """
+  The freshly fetched manifest, serialized in the same shape as `currentManifest`.
+  """
+  incomingManifest: JSONString!
 }
 
 """Create JWT token."""


### PR DESCRIPTION
## What & why

When an installed app's manifest changes (new/changed webhooks, permissions, extensions), the only options today are uninstall + reinstall (downtime, new tokens) or a hand-rolled `webhookUpdate` migration script. This adds a first-class **`appReloadManifest`** mutation that re-syncs an installed app from its stored `manifest_url` in place.

```graphql
appReloadManifest(id: ID!, dryRun: Boolean = false, expectedIncomingManifest: JSONString): AppReloadManifest
# AppReloadManifest { app, preview { currentManifest, incomingManifest }, errors }
```

- **`dryRun: true`** fetches + validates the manifest and returns a preview (the app's current state and the incoming manifest, both serialized to the same canonical shape) **without writing anything** — intended to drive a review-before-apply UI.
- **apply** (`dryRun: false`) re-syncs scalar fields, permissions, extensions and webhooks in a single transaction.

## Behavior / design decisions

- **Webhooks matched by name**, updated in place — preserving `is_active` (the admin's activation choice) and `secret_key`/delivery history. A webhook renamed in the manifest is delete+create (name is its only stable identity); new ones created, removed ones deleted.
- **Extensions rebuilt only when changed** — they have no stable per-row id, and reissuing ids on every reload would break dashboard mounts/URLs that reference them, so an unchanged extension set is left untouched.
- **App `is_active`, tokens and `created` are never modified.**
- **Permissions** are re-applied but validated against the requesting staff user (`ensure_can_manage_permissions`), exactly like install — an app can't self-escalate by editing its manifest, and a staff member can only grant permissions they already hold. `MANAGE_APPS` stays ungrantable.
- **`expectedIncomingManifest`** (optional): the client passes back the `incomingManifest` it previewed; if the manifest fetched at apply time differs, the mutation refuses — so an admin never silently applies changes the manifest gained between preview and confirm.
- Requires `AUTHENTICATED_STAFF_USER` + `MANAGE_APPS` (mirrors `appInstall`).
- Manifest scalar lengths are validated against the model columns, turning an over-length value into a clean manifest error instead of a `DataError`/500 (also hardens the existing install path).

## Zero-downtime

In-place webhook updates match the [recommended webhook-migration approach](https://docs.saleor.io/developer/extending/apps/updating-app-webhooks); the resync is atomic, so concurrent events never observe an empty webhook set. Caveat: a **renamed** webhook is delete+create, so its pending deliveries/history are dropped — documented in the mutation description.

## Open questions for maintainers

- **Sync vs async fetch.** The manifest is fetched synchronously in the request (like `appFetchManifest`), not via a Celery task like install — there is no `AppInstallation` job to carry async status for an already-installed app. Happy to move it to a task if preferred.
- Whether to persist the raw manifest so the preview's "current" side doesn't need reconstructing from DB state.
- Circuit-breaker interaction for sync webhooks replaced on reload (`saleor/webhook/circuit_breaker/`).

## Tests

`saleor/graphql/app/tests/mutations/test_app_reload_manifest.py` and `saleor/app/tests/test_manifest_resync.py` cover: dry-run writes nothing, apply of each field/webhook/extension change, `is_active` preserved, rename = delete+create, blank-identifier convergence, extension-id stability, TOCTOU rejection, permission-scope enforcement, over-length rejection, and canonical (sorted-key) preview output. Schema SDL regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)