### PR TITLE
Make empty attributes where-filter match nothing for pages, products, and variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Removed the deprecated `orderSettings` query field. Use the `channel` query and read its `orderSettings` field instead.
 - Removed the `DIGITAL_LINKS` value from the `OrderEventsEmailsEnum` enum and the `DIGITAL_LINK_DOWNLOADED` value from the `CustomerEventsEnum` enum. Events with these types were deleted in 3.23, along with the legacy digital content feature that emitted them.
 - Removed the always-empty `digital_lines` key from the fulfillment confirmation notification payload. Use `physical_lines`, which holds every line of the fulfillment.
+- Providing an empty `attributes` list (`null` or `[]`) in `where` filters for pages, products, and product variants now matches no objects instead of being ignored.
 
 ### GraphQL API
 

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -726,7 +726,7 @@ class PageWhere(MetadataWhereBase):
     @staticmethod
     def filter_attributes(qs, _, value):
         if not value:
-            return qs
+            return qs.none()
         return filter_pages_by_attributes(qs, value)
 
     def is_valid(self):

--- a/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_attributes.py
+++ b/saleor/graphql/page/tests/queries/pages_with_where/test_with_where_attributes.py
@@ -6,6 +6,44 @@ from .....tests.utils import get_graphql_content
 from .shared import QUERY_PAGES_WITH_WHERE
 
 
+@pytest.mark.parametrize(
+    ("_case", "attributes_value"),
+    [
+        ("empty_list", []),
+        ("null", None),
+    ],
+)
+def test_pages_query_with_empty_attributes(
+    _case,
+    attributes_value,
+    staff_api_client,
+    page_list,
+    page_type,
+    size_page_attribute,
+):
+    # given
+    page_type.page_attributes.add(size_page_attribute)
+    page_attr_value = size_page_attribute.values.first()
+
+    associate_attribute_values_to_instance(
+        page_list[0], {size_page_attribute.pk: [page_attr_value]}
+    )
+
+    variables = {"where": {"attributes": attributes_value}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PAGES_WITH_WHERE,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    pages_nodes = content["data"]["pages"]["edges"]
+    assert content["data"]["pages"]["totalCount"] == 0
+    assert pages_nodes == []
+
+
 def test_pages_query_with_attribute_slug(
     staff_api_client, page_list, page_type, size_page_attribute
 ):

--- a/saleor/graphql/product/filters/product_variant.py
+++ b/saleor/graphql/product/filters/product_variant.py
@@ -770,7 +770,7 @@ class ProductVariantWhere(MetadataWhereFilterBase):
     @staticmethod
     def filter_attributes(qs, _, value):
         if not value:
-            return qs
+            return qs.none()
         return filter_variants_by_attributes(qs, value)
 
     def filter_stock_availability(self, qs, name, value):

--- a/saleor/graphql/product/tests/queries/test_products_query_with_where.py
+++ b/saleor/graphql/product/tests/queries/test_products_query_with_where.py
@@ -744,7 +744,16 @@ def test_products_filter_by_attributes_value_slug(
     assert returned_ids == {product1_id, product2_id}
 
 
-def test_products_filter_by_attributes_empty_list(
+@pytest.mark.parametrize(
+    ("_case", "attributes_value"),
+    [
+        ("empty_list", []),
+        ("null", None),
+    ],
+)
+def test_products_filter_by_attributes_empty(
+    _case,
+    attributes_value,
     api_client,
     product_list,
     channel_USD,
@@ -773,7 +782,7 @@ def test_products_filter_by_attributes_empty_list(
     variables = {
         "channel": channel_USD.slug,
         "where": {
-            "attributes": [],
+            "attributes": attributes_value,
         },
     }
 

--- a/saleor/graphql/product/tests/queries/variants_where/test_over_attributes.py
+++ b/saleor/graphql/product/tests/queries/variants_where/test_over_attributes.py
@@ -6,6 +6,47 @@ from .....tests.utils import get_graphql_content
 from .shared import PRODUCT_VARIANTS_WHERE_QUERY
 
 
+@pytest.mark.parametrize(
+    ("_case", "attributes_value"),
+    [
+        ("empty_list", []),
+        ("null", None),
+    ],
+)
+def test_product_variants_query_with_empty_attributes(
+    _case,
+    attributes_value,
+    staff_api_client,
+    product_variant_list,
+    weight_attribute,
+    channel_USD,
+):
+    # given
+    product_type = product_variant_list[0].product.product_type
+    product_type.variant_attributes.add(weight_attribute)
+    attr_value = weight_attribute.values.first()
+
+    associate_attribute_values_to_instance(
+        product_variant_list[0], {weight_attribute.pk: [attr_value]}
+    )
+
+    variables = {
+        "where": {"attributes": attributes_value},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANTS_WHERE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_variants_nodes = content["data"]["productVariants"]["edges"]
+    assert product_variants_nodes == []
+
+
 def test_product_variants_query_with_attribute_slug(
     staff_api_client, product_variant_list, weight_attribute, channel_USD
 ):


### PR DESCRIPTION
Makes the `attributes` `where`-filter behave consistently across entities when it is explicitly provided but empty (`null` or `[]`): it now matches **no** objects instead of being silently ignored.

Affected queries:
- `pages(where: {attributes: null})` / `{attributes: []}` → 0 results (was: all pages)
- `productVariants(where: {attributes: null})` / `{attributes: []}` → 0 results (was: all variants)
- `products(where: {attributes: null})` / `{attributes: []}` → 0 results (already behaved this way via `filter_products_by_attributes`; now covered by tests)
