### PR TITLE
fix(core): strip leading/trailing whitespace and validate type in validate_storefront_url

### DIFF
--- a/saleor/core/utils/url.py
+++ b/saleor/core/utils/url.py
@@ -14,6 +14,9 @@ def validate_storefront_url(url):
     Raise ValidationError if URL isn't in RFC 1808 format
     or it isn't allowed by ALLOWED_CLIENT_HOSTS in settings.
     """
+    if not url or not isinstance(url, str):
+        raise ValidationError("Invalid URL. URL must be a non-empty string.")
+    url = url.strip()
     try:
         parsed_url = urlparse(url)
         domain, _ = split_domain_port(parsed_url.netloc)


### PR DESCRIPTION
## Description
This PR updates `validate_storefront_url` in `saleor/core/utils/url.py`.

## Details
- Strips leading and trailing whitespace from the URL parameter before parsing.
- Adds a type check to raise a clean `ValidationError` if a non-string or empty input is supplied.