### PR TITLE
Add unique tie-breaker to default cursor pagination ordering

### DIFF
--- a/saleor/graphql/product/tests/queries/test_product_variants_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_variants_query.py
@@ -141,6 +141,91 @@ def test_fetch_all_variants_without_sku_as_anonymous_user_with_channel(
     assert data["edges"][0]["node"]["id"] == variant_id
 
 
+QUERY_PAGINATE_PRODUCT_VARIANTS = """
+    query paginateVariants($first: Int!, $after: String) {
+        productVariants(first: $first, after: $after) {
+            pageInfo {
+                hasNextPage
+                endCursor
+            }
+            edges {
+                node {
+                    id
+                }
+            }
+        }
+    }
+"""
+
+
+def _fetch_variants_page(client, first, after=None):
+    response = client.post_graphql(
+        QUERY_PAGINATE_PRODUCT_VARIANTS, {"first": first, "after": after}
+    )
+    data = get_graphql_content(response)["data"]["productVariants"]
+    return [edge["node"]["id"] for edge in data["edges"]], data["pageInfo"]
+
+
+@pytest.mark.parametrize(
+    ("_case", "sort_order", "sku"),
+    [
+        ("no_sort_order_no_sku", None, None),
+        ("shared_sort_order_no_sku", 0, None),
+    ],
+)
+def test_pagination_with_non_unique_default_ordering(
+    _case,
+    sort_order,
+    sku,
+    staff_api_client,
+    product,
+    permission_manage_products,
+):
+    """Walk three pages of variants sharing the model's default ordering values.
+
+    The default ordering (`sort_order`, `sku`) is neither unique nor non-nullable,
+    so without a tie-breaker the cursor cannot advance past such a group.
+
+    Reproduces ENG-1728
+    """
+    # given
+    page_size = 2
+    product.variants.all().delete()
+    variants = ProductVariant.objects.bulk_create(
+        [
+            ProductVariant(
+                product=product, name=f"Variant {i}", sort_order=sort_order, sku=sku
+            )
+            for i in range(5)
+        ]
+    )
+    # the variants tie on every ordering field, so they fall back to ascending pk
+    expected_ids = [
+        graphene.Node.to_global_id("ProductVariant", variant.pk) for variant in variants
+    ]
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+
+    # when
+    first_page_ids, first_page_info = _fetch_variants_page(staff_api_client, page_size)
+    second_page_ids, second_page_info = _fetch_variants_page(
+        staff_api_client, page_size, after=first_page_info["endCursor"]
+    )
+    third_page_ids, third_page_info = _fetch_variants_page(
+        staff_api_client, page_size, after=second_page_info["endCursor"]
+    )
+
+    # then
+    assert first_page_ids == expected_ids[:2]
+    assert first_page_info["hasNextPage"] is True
+
+    assert second_page_ids == expected_ids[2:4]
+    assert second_page_info["hasNextPage"] is True
+    assert second_page_info["endCursor"] != first_page_info["endCursor"]
+
+    assert third_page_ids == expected_ids[4:]
+    assert third_page_info["hasNextPage"] is False
+
+
 QUERY_PRODUCT_VARIANTS_BY_IDS = """
     query getProductVariants($ids: [ID!], $channel: String) {
         productVariants(ids: $ids, first: 1, channel: $channel) {

--- a/saleor/graphql/utils/sorting.py
+++ b/saleor/graphql/utils/sorting.py
@@ -114,6 +114,12 @@ def sort_queryset_by_default(
 
     ordering_fields = [field.replace("-", "") for field in default_ordering]
     direction = "-" if "-" in default_ordering[0] else ""
+    # Cursor pagination needs a unique, non-nullable tie-breaker. Without one, rows
+    # sharing the same ordering values are either skipped or served over and over
+    # again, as the cursor cannot advance past them.
+    if not {"pk", "id"} & set(ordering_fields):
+        ordering_fields.append("pk")
+        default_ordering.append(f"{direction}pk")
     if reversed:
         reversed_direction = REVERSED_DIRECTION[direction]
         default_ordering = [f"{reversed_direction}{field}" for field in ordering_fields]

--- a/saleor/graphql/webhook/tests/queries/test_event_delivery_query.py
+++ b/saleor/graphql/webhook/tests/queries/test_event_delivery_query.py
@@ -1,6 +1,9 @@
+import datetime
+
 import graphene
 
 from .....core import EventDeliveryStatus
+from .....core.models import EventDelivery
 from .....webhook.event_types import WebhookEventAsyncType
 from ....tests.utils import get_graphql_content
 
@@ -37,6 +40,86 @@ EVENT_DELIVERY_QUERY = """
       }
     }
 """
+
+
+EVENT_DELIVERIES_PAGINATION_QUERY = """
+    query webhook($id: ID!, $first: Int!, $after: String){
+      webhook(id: $id){
+        eventDeliveries(first: $first, after: $after){
+          pageInfo{
+            hasNextPage
+            endCursor
+          }
+          edges{
+            node{
+              id
+            }
+          }
+        }
+      }
+    }
+"""
+
+
+def _fetch_event_deliveries_page(client, webhook_id, first, after=None):
+    response = client.post_graphql(
+        EVENT_DELIVERIES_PAGINATION_QUERY,
+        variables={"id": webhook_id, "first": first, "after": after},
+    )
+    data = get_graphql_content(response)["data"]["webhook"]["eventDeliveries"]
+    return [edge["node"]["id"] for edge in data["edges"]], data["pageInfo"]
+
+
+def test_event_deliveries_pagination_with_shared_created_at(
+    webhook, staff_api_client, permission_manage_apps
+):
+    """Walk three pages of deliveries sharing the model's default ordering value.
+
+    The default ordering (`-created_at`) is not unique - deliveries fanned out for
+    a single event are bulk created and can land on the same timestamp - so without
+    a tie-breaker the cursor cannot advance past such a group.
+    """
+    # given
+    page_size = 2
+    deliveries = EventDelivery.objects.bulk_create(
+        [
+            EventDelivery(webhook=webhook, event_type=WebhookEventAsyncType.ANY)
+            for _ in range(5)
+        ]
+    )
+    delivery_pks = [delivery.pk for delivery in deliveries]
+    # `created_at` is `auto_now_add`, so the shared timestamp has to be forced in SQL
+    EventDelivery.objects.filter(pk__in=delivery_pks).update(
+        created_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+    )
+    # the deliveries tie on `created_at`, so they fall back to descending pk
+    expected_ids = [
+        graphene.Node.to_global_id("EventDelivery", pk) for pk in reversed(delivery_pks)
+    ]
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
+
+    # when
+    first_page_ids, first_page_info = _fetch_event_deliveries_page(
+        staff_api_client, webhook_id, page_size
+    )
+    second_page_ids, second_page_info = _fetch_event_deliveries_page(
+        staff_api_client, webhook_id, page_size, after=first_page_info["endCursor"]
+    )
+    third_page_ids, third_page_info = _fetch_event_deliveries_page(
+        staff_api_client, webhook_id, page_size, after=second_page_info["endCursor"]
+    )
+
+    # then
+    assert first_page_ids == expected_ids[:2]
+    assert first_page_info["hasNextPage"] is True
+
+    assert second_page_ids == expected_ids[2:4]
+    assert second_page_info["hasNextPage"] is True
+    assert second_page_info["endCursor"] != first_page_info["endCursor"]
+
+    assert third_page_ids == expected_ids[4:]
+    assert third_page_info["hasNextPage"] is False
 
 
 def test_webhook_delivery_attempt_query(


### PR DESCRIPTION
Cursor pagination derives its cursor from the sorting fields in use. When a connection falls back to the model's `Meta.ordering` and that ordering is not unique, the cursor cannot identify a single row, so the "everything after this cursor" filter is wrong for any group of rows sharing the same values:

- if the trailing ordering value is NULL, `_prepare_filter` skips the field entirely and the resulting filter matches the whole queryset, so the same page is served over and over and `endCursor` never advances;
- otherwise the filter jumps past the entire group, silently dropping every remaining row in it.

`productVariants` hits both cases. `ProductVariant.Meta.ordering` is `("sort_order", "sku")`: `sort_order` is scoped per product, so it repeats across the global connection and is NULL for bulk created variants, and `sku` is optional. `Webhook.eventDeliveries` and `EventDelivery.attempts` hit the second case, as both order by `created_at` alone and deliveries fanned out for a single event are bulk created on the same timestamp.

Fix it once in `sort_queryset_by_default`, which every default-ordered connection routes through, by appending `pk` to the ordering when it does not already contain a primary key. `pk` is unique and never NULL, so every cursor now identifies exactly one row. Appending it does not reorder distinct keys, it only makes ties deterministic.

Note that cursors gain a component, so cursors issued before this change are rejected with "Received cursor is invalid." and pagination has to be restarted.

Fixes [ENG-1728](https://linear.app/saleor/issue/ENG-1728)
