### PR TITLE
Fix pageAttributeAssign crash on nonexistent attribute IDs and fix productAttributeAssign's existence check

### DIFF
--- a/saleor/graphql/page/mutations/page_attribute_assign.py
+++ b/saleor/graphql/page/mutations/page_attribute_assign.py
@@ -42,7 +42,7 @@ class PageAttributeAssign(BaseMutation):
         cls,
         errors: dict["str", list[ValidationError]],
         page_type: "page_models.PageType",
-        attr_pks: list[int],
+        attr_pks: list[str],
     ):
         """Ensure the attributes exist, are page attributes and are not yet assigned."""
 
@@ -52,7 +52,7 @@ class PageAttributeAssign(BaseMutation):
 
         # check if all attributes exist
         found_pks = {str(pk) for pk in attr_type_by_pk}
-        missing_pks = [pk for pk in attr_pks if str(pk) not in found_pks]
+        missing_pks = [pk for pk in attr_pks if pk not in found_pks]
 
         if missing_pks:
             missing_attributes_ids = [

--- a/saleor/graphql/page/mutations/page_attribute_assign.py
+++ b/saleor/graphql/page/mutations/page_attribute_assign.py
@@ -44,18 +44,35 @@ class PageAttributeAssign(BaseMutation):
         page_type: "page_models.PageType",
         attr_pks: list[int],
     ):
-        """Ensure the attributes are page attributes and are not already assigned."""
+        """Ensure the attributes exist, are page attributes and are not yet assigned."""
 
-        # check if any attribute is not a page type
-        invalid_attributes = models.Attribute.objects.filter(pk__in=attr_pks).exclude(
-            type=AttributeType.PAGE_TYPE
+        attr_type_by_pk = dict(
+            models.Attribute.objects.filter(pk__in=attr_pks).values_list("pk", "type")
         )
 
-        if invalid_attributes:
-            invalid_attributes_ids = [
-                graphene.Node.to_global_id("Attribute", attr.pk)
-                for attr in invalid_attributes
+        # check if all attributes exist
+        found_pks = {str(pk) for pk in attr_type_by_pk}
+        missing_pks = [pk for pk in attr_pks if str(pk) not in found_pks]
+
+        if missing_pks:
+            missing_attributes_ids = [
+                graphene.Node.to_global_id("Attribute", pk) for pk in missing_pks
             ]
+            error = ValidationError(
+                "Attribute doesn't exist.",
+                code=PageErrorCode.NOT_FOUND.value,
+                params={"attributes": missing_attributes_ids},
+            )
+            errors["attribute_ids"].append(error)
+
+        # check if any attribute is not a page type
+        invalid_attributes_ids = [
+            graphene.Node.to_global_id("Attribute", pk)
+            for pk, attr_type in attr_type_by_pk.items()
+            if attr_type != AttributeType.PAGE_TYPE
+        ]
+
+        if invalid_attributes_ids:
             error = ValidationError(
                 "Only page attributes can be assigned.",
                 code=PageErrorCode.INVALID.value,

--- a/saleor/graphql/page/tests/mutations/test_page_attribute_assign.py
+++ b/saleor/graphql/page/tests/mutations/test_page_attribute_assign.py
@@ -262,6 +262,83 @@ def test_assign_attributes_to_page_type_not_page_attribute(
     assert errors[0]["attributes"] == [color_attribute_id]
 
 
+def test_assign_attributes_to_page_type_nonexistent_attribute(
+    staff_api_client,
+    permission_manage_page_types_and_attributes,
+    page_type,
+):
+    # given
+    staff_user = staff_api_client.user
+    staff_user.user_permissions.add(permission_manage_page_types_and_attributes)
+
+    page_type_attr_count = page_type.page_attributes.count()
+
+    nonexistent_attr_id = graphene.Node.to_global_id("Attribute", -1)
+
+    variables = {
+        "pageTypeId": graphene.Node.to_global_id("PageType", page_type.pk),
+        "attributeIds": [nonexistent_attr_id],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PAGE_ASSIGN_ATTR_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageAttributeAssign"]
+    errors = data["errors"]
+
+    assert not data["pageType"]
+    page_type.refresh_from_db()
+    assert page_type.page_attributes.count() == page_type_attr_count
+    assert len(errors) == 1
+    assert errors[0]["field"] == "attributeIds"
+    assert errors[0]["code"] == PageErrorCode.NOT_FOUND.name
+    assert errors[0]["message"] == "Attribute doesn't exist."
+    assert errors[0]["attributes"] == [nonexistent_attr_id]
+
+
+def test_assign_attributes_to_page_type_nonexistent_and_valid_attribute(
+    staff_api_client,
+    permission_manage_page_types_and_attributes,
+    page_type,
+    author_page_attribute,
+):
+    # given
+    staff_user = staff_api_client.user
+    staff_user.user_permissions.add(permission_manage_page_types_and_attributes)
+
+    page_type_attr_count = page_type.page_attributes.count()
+
+    author_page_attr_id = graphene.Node.to_global_id(
+        "Attribute", author_page_attribute.pk
+    )
+    nonexistent_attr_id = graphene.Node.to_global_id("Attribute", -1)
+
+    variables = {
+        "pageTypeId": graphene.Node.to_global_id("PageType", page_type.pk),
+        "attributeIds": [author_page_attr_id, nonexistent_attr_id],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PAGE_ASSIGN_ATTR_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageAttributeAssign"]
+    errors = data["errors"]
+
+    assert not data["pageType"]
+    page_type.refresh_from_db()
+    assert page_type.page_attributes.count() == page_type_attr_count
+    assert author_page_attribute not in page_type.page_attributes.all()
+    assert len(errors) == 1
+    assert errors[0]["field"] == "attributeIds"
+    assert errors[0]["code"] == PageErrorCode.NOT_FOUND.name
+    assert errors[0]["message"] == "Attribute doesn't exist."
+    assert errors[0]["attributes"] == [nonexistent_attr_id]
+
+
 def test_assign_attributes_to_page_type_attribute_already_assigned(
     staff_api_client,
     permission_manage_page_types_and_attributes,

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -228,18 +228,21 @@ class ProductAttributeAssign(BaseMutation, VariantAssignmentValidationMixin):
         variant_attrs_pks = [pk for pk, _, __ in variant_attrs_data]
 
         attrs_pk = product_attrs_pks + variant_attrs_pks
-        attributes = attribute_models.Attribute.objects.filter(
-            id__in=attrs_pk
-        ).values_list("pk", flat=True)
-        if len(attrs_pk) != len(attributes):
-            invalid_attrs = set(attrs_pk) - set(attributes)
-            invalid_attrs = [
-                graphene.Node.to_global_id("Attribute", pk) for pk in invalid_attrs
+        found_pks = {
+            str(pk)
+            for pk in attribute_models.Attribute.objects.filter(
+                pk__in=attrs_pk
+            ).values_list("pk", flat=True)
+        }
+        missing_pks = [pk for pk in attrs_pk if str(pk) not in found_pks]
+        if missing_pks:
+            missing_attrs = [
+                graphene.Node.to_global_id("Attribute", pk) for pk in missing_pks
             ]
             error = ValidationError(
                 "Attribute doesn't exist.",
                 code=ProductErrorCode.NOT_FOUND.value,
-                params={"attributes": list(invalid_attrs)},
+                params={"attributes": missing_attrs},
             )
             errors["operations"].append(error)
 

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -234,7 +234,7 @@ class ProductAttributeAssign(BaseMutation, VariantAssignmentValidationMixin):
                 pk__in=attrs_pk
             ).values_list("pk", flat=True)
         }
-        missing_pks = [pk for pk in attrs_pk if str(pk) not in found_pks]
+        missing_pks = [pk for pk in attrs_pk if pk not in found_pks]
         if missing_pks:
             missing_attrs = [
                 graphene.Node.to_global_id("Attribute", pk) for pk in missing_pks

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -631,9 +631,50 @@ def test_assign_non_existing_attributes_to_product_type(
     )
     content = get_graphql_content(response)
     content = content["data"]["productAttributeAssign"]
+    assert len(content["errors"]) == 1
     assert content["errors"][0]["code"] == ProductErrorCode.NOT_FOUND.name
     assert content["errors"][0]["field"] == "operations"
     assert content["errors"][0]["attributes"] == [attribute_id]
+
+
+def test_assign_non_existing_and_existing_attributes_to_product_type(
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    product_type_attribute_list,
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type", has_variants=True, kind=ProductTypeKind.NORMAL
+    )
+    product_type_global_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+
+    existing_attribute = product_type_attribute_list[0]
+    existing_attribute_id = graphene.Node.to_global_id(
+        "Attribute", existing_attribute.pk
+    )
+    nonexistent_attribute_id = graphene.Node.to_global_id("Attribute", -1)
+
+    operations = [
+        {"type": "PRODUCT", "id": existing_attribute_id},
+        {"type": "PRODUCT", "id": nonexistent_attribute_id},
+    ]
+    variables = {"productTypeId": product_type_global_id, "operations": operations}
+
+    # when
+    response = staff_api_client.post_graphql(
+        PRODUCT_ASSIGN_ATTR_QUERY,
+        variables,
+        permissions=[permission_manage_product_types_and_attributes],
+    )
+
+    # then
+    content = get_graphql_content(response)["data"]["productAttributeAssign"]
+    errors = content["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == ProductErrorCode.NOT_FOUND.name
+    assert errors[0]["field"] == "operations"
+    assert errors[0]["attributes"] == [nonexistent_attribute_id]
+    assert product_type.product_attributes.exists() is False
 
 
 def test_assign_variant_attribute_to_product_type_with_disabled_variants(


### PR DESCRIPTION
> [!IMPORTANT]
> To be backported.

`pageAttributeAssign` only checked attribute type and prior assignment, both via filters that silently drop missing pks, so a decoded but nonexistent attribute ID passed validation and blew up on the FK constraint in `page_type.page_attributes.add()` — an `IntegrityError` surfacing as HTTP 500. Any client sending a stale ID (e.g. racing an `attributeDelete`) could trigger it.

`clean_attributes` now fetches pk/type pairs once, reports missing pks with a `NOT_FOUND` error (matching `productAttributeAssign`), and derives the existing wrong-type check from the same fetch, keeping the query count flat.

Also fix `productAttributeAssign`'s existence check: it diffed string input pks against int DB pks, so any missing attribute caused every input ID to be reported as missing instead of only the absent ones.