### PR TITLE
approach to fix site id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,20 @@ many processes at once. Write code with that in mind:
 - **Make tasks idempotent and safe to retry** — the broker may deliver a task more than once, and pods
   can be killed/rescheduled mid-run.
 
+## Multi-tenancy: never assume one site
+
+A deployment may serve **several sites from one process**, so `settings.SITE_ID` can be unset. Code
+that needs the current site must resolve it the way `SiteManager.get_current` does — `settings.SITE_ID`
+when configured, otherwise `request.get_host()` — and must never bake a single site into a cache key,
+a module global, or a query filter. Anything keyed per site (cache entries, in-memory maps) must carry
+the site in the key, or one tenant will read another's data.
+
+Resolve the site with the `get_site_promise` dataloader rather than `Site.objects.get_current()`: the
+latter populates the patched, process-global `THREADED_SITE_CACHE` (`saleor/site/patch_sites.py`),
+which is never invalidated by `Site`/`SiteSettings` saves, so a later read in the same process returns
+stale data. Prefer deriving a cache key from `SITE_ID`/host (no query) over loading the `Site` on every
+request.
+
 ## Graphql
 
 ###  API versioning

--- a/saleor/graphql/shop/mutations/shop_settings_update.py
+++ b/saleor/graphql/shop/mutations/shop_settings_update.py
@@ -295,7 +295,9 @@ class ShopSettingsUpdate(BaseMutation):
             # Note: we do not use any locks here as we do not expect any use-case
             #       where this mutation would be called concurrently with different
             #       modes.
-            set_allow_storefront_traffic_cache(instance.allow_storefront_traffic)
+            set_allow_storefront_traffic_cache(
+                instance.allow_storefront_traffic, info.context
+            )
 
         if (
             instance.metadata != old_metadata

--- a/saleor/graphql/shop/tests/mutations/test_shop_settings_update.py
+++ b/saleor/graphql/shop/tests/mutations/test_shop_settings_update.py
@@ -892,7 +892,7 @@ SHOP_SETTINGS_UPDATE_STOREFRONT_TRAFFIC_MUTATION = """
 
 
 def test_shop_settings_update_sets_allow_storefront_traffic(
-    staff_api_client, site_settings, permission_manage_settings
+    staff_api_client, site_settings, permission_manage_settings, rf
 ):
     # given
     site_settings.allow_storefront_traffic = True
@@ -914,7 +914,7 @@ def test_shop_settings_update_sets_allow_storefront_traffic(
     assert data["shop"]["allowStorefrontTraffic"] is False
     site_settings.refresh_from_db()
     assert site_settings.allow_storefront_traffic is False
-    assert get_allow_storefront_traffic() is False
+    assert get_allow_storefront_traffic(rf.post("/graphql/")) is False
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/storefront_traffic.py
+++ b/saleor/graphql/storefront_traffic.py
@@ -1,55 +1,78 @@
 import warnings
 
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
 from jwt import InvalidTokenError
 
 from ..account.models import User
 from ..core.auth import get_token_from_request
 from ..site.models import SiteSettings
 from .core import SaleorContext
+from .site.dataloaders import get_site_promise
 
 STOREFRONT_TRAFFIC_ERROR_CODE = "STOREFRONT_TRAFFIC_NOT_ALLOWED"
 STOREFRONT_TRAFFIC_ERROR_MESSAGE = "Storefront traffic is not allowed."
 STOREFRONT_TRAFFIC_CACHE_TIMEOUT = 5 * 60
 
 
-def _get_allow_storefront_traffic_cache_key() -> str:
-    """Build the cache key from ``settings.SITE_ID`` directly.
+def _get_allow_storefront_traffic_cache_key(request: SaleorContext | None) -> str:
+    """Namespace the cache key per site without loading the ``Site``.
 
-    Using ``Site.objects.get_current()`` here would populate the patched,
-    process-global ``THREADED_SITE_CACHE`` on every request. That cache is not
-    invalidated by ``Site``/``SiteSettings`` saves (Django's ``clear_site_cache``
-    signal targets the unused original ``SITE_CACHE``), so it would leak stale
-    site data across requests and tests.
+    Resolves the site the same way ``SiteManager.get_current`` does — by
+    ``settings.SITE_ID`` when it is configured, otherwise by the request host, which
+    is how multi-tenant deployments serve several sites from one process. Both are
+    read straight off the settings/request, so the hot path stays free of queries.
+
+    Calling ``Site.objects.get_current()`` instead would populate the patched,
+    process-global ``THREADED_SITE_CACHE``. That cache is not invalidated by
+    ``Site``/``SiteSettings`` saves (Django's ``clear_site_cache`` signal targets the
+    unused original ``SITE_CACHE``), so it would leak stale site data across requests
+    and tests.
     """
-    site = Site.objects.get_current()
-    return f"allow_storefront_traffic:{site.pk}"
+    if site_id := getattr(settings, "SITE_ID", None):
+        return f"allow_storefront_traffic:{site_id}"
+    if request is None:
+        raise ImproperlyConfigured(
+            "Without settings.SITE_ID the site can only be identified by the request "
+            "host, so a request is required to namespace the storefront traffic cache."
+        )
+    return f"allow_storefront_traffic:{request.get_host()}"
 
 
-def set_allow_storefront_traffic_cache(allow_storefront_traffic: bool) -> None:
+def set_allow_storefront_traffic_cache(
+    allow_storefront_traffic: bool, request: SaleorContext | None = None
+) -> None:
+    """Cache the flag for the request's site.
+
+    ``request`` is only consulted when ``settings.SITE_ID`` is unset, so single-site
+    deployments may omit it.
+    """
     cache.set(
-        _get_allow_storefront_traffic_cache_key(),
+        _get_allow_storefront_traffic_cache_key(request),
         allow_storefront_traffic,
         STOREFRONT_TRAFFIC_CACHE_TIMEOUT,
     )
 
 
-def clear_allow_storefront_traffic_cache() -> None:
-    cache.delete(_get_allow_storefront_traffic_cache_key())
+def clear_allow_storefront_traffic_cache(request: SaleorContext | None = None) -> None:
+    cache.delete(_get_allow_storefront_traffic_cache_key(request))
 
 
-def get_allow_storefront_traffic() -> bool:
-    cache_key = _get_allow_storefront_traffic_cache_key()
+def get_allow_storefront_traffic(request: SaleorContext) -> bool:
+    cache_key = _get_allow_storefront_traffic_cache_key(request)
     allow_storefront_traffic = cache.get(cache_key)
     if allow_storefront_traffic is None:
+        # Only on a cache miss. The dataloader resolves the site exactly like
+        # `get_current` (SITE_ID, else host with a port-stripping fallback) but keeps
+        # the result on the request instead of the process-global site cache.
+        site = get_site_promise(request).get()
         allow_storefront_traffic = (
             SiteSettings.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME)
             .values_list("allow_storefront_traffic", flat=True)
-            .get(site=Site.objects.get_current())
+            .get(site_id=site.pk)
         )
-        set_allow_storefront_traffic_cache(allow_storefront_traffic)
+        set_allow_storefront_traffic_cache(allow_storefront_traffic, request)
     return allow_storefront_traffic
 
 
@@ -101,6 +124,6 @@ def is_storefront_traffic_blocked(request: SaleorContext) -> bool:
     """
     if request.app:
         return False
-    if get_allow_storefront_traffic():
+    if get_allow_storefront_traffic(request):
         return False
     return not _is_staff_user(request)

--- a/saleor/graphql/tests/test_storefront_traffic.py
+++ b/saleor/graphql/tests/test_storefront_traffic.py
@@ -1,10 +1,13 @@
 from types import SimpleNamespace
 
 import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 from jwt import InvalidTokenError
 
 from saleor.core.auth import SALEOR_AUTH_HEADER
 from saleor.graphql.storefront_traffic import (
+    _get_allow_storefront_traffic_cache_key,
     clear_allow_storefront_traffic_cache,
     is_storefront_traffic_blocked,
 )
@@ -132,3 +135,40 @@ def test_unexpected_user_object_is_not_privileged(site_settings):
     # when / then
     with pytest.warns(UserWarning, match="An invalid user object was found"):
         assert is_storefront_traffic_blocked(request) is True
+
+
+def test_cache_key_uses_site_id_when_configured():
+    # given
+    site_id = 7
+    request = SimpleNamespace(get_host=lambda: "ignored.example.com")
+
+    # when / then: the host is irrelevant, the configured site wins
+    with override_settings(SITE_ID=site_id):
+        cache_key = _get_allow_storefront_traffic_cache_key(request)
+    assert cache_key == f"allow_storefront_traffic:{site_id}"
+
+
+def test_cache_key_falls_back_to_host_without_site_id():
+    # given: a multi-tenant deployment serving several sites from one process
+    host = "tenant.example.com"
+    request = SimpleNamespace(get_host=lambda: host)
+
+    # when
+    with override_settings(SITE_ID=None):
+        cache_key = _get_allow_storefront_traffic_cache_key(request)
+
+    # then
+    assert cache_key == f"allow_storefront_traffic:{host}"
+
+
+def test_cache_key_without_site_id_and_without_request():
+    # when / then
+    with (
+        override_settings(SITE_ID=None),
+        pytest.raises(ImproperlyConfigured) as exc_info,
+    ):
+        _get_allow_storefront_traffic_cache_key(None)
+    assert str(exc_info.value) == (
+        "Without settings.SITE_ID the site can only be identified by the request "
+        "host, so a request is required to namespace the storefront traffic cache."
+    )


### PR DESCRIPTION
TDD red state for a per-tenant `SiteSettings.allow_storefront_traffic`
flag (default True). When disabled, only App-authenticated and staff-user
requests may call the API directly; anonymous requests and authenticated
non-staff customers are rejected with HTTP 401 and error code
STOREFRONT_TRAFFIC_NOT_ALLOWED.

- unit tests for the decision helper (saleor/graphql/storefront_traffic.py,
  not yet implemented): anonymous + app separate, user type x flag parametrized
- view enforcement integration tests (batch -> single 401, introspection,
  invalid token, real query + tokenCreate)
- shopSettingsUpdate write + permission and Shop.allowStorefrontTraffic read

