### PR TITLE
Assign the default customer type on non-API user-creation paths

### DIFF
--- a/saleor/account/tests/fixtures/customer_type.py
+++ b/saleor/account/tests/fixtures/customer_type.py
@@ -6,7 +6,19 @@ __all__ = [
     "customer_type",
     "customer_type_with_attributes",
     "default_customer_type",
+    "get_or_create_default_customer_type",
 ]
+
+
+def get_or_create_default_customer_type() -> CustomerType:
+    # Transactional tests (django_db(transaction=True)) flush all tables on
+    # teardown, wiping the default customer type created by the data migration,
+    # so recreate it on demand instead of assuming the migration row exists.
+    customer_type, _ = CustomerType.objects.get_or_create(
+        is_default=True,
+        defaults={"name": "Default", "slug": "default"},
+    )
+    return customer_type
 
 
 @pytest.fixture
@@ -31,4 +43,4 @@ def customer_type_with_attributes(
 
 @pytest.fixture
 def default_customer_type(db):
-    return CustomerType.objects.get(is_default=True)
+    return get_or_create_default_customer_type()

--- a/saleor/account/tests/fixtures/customer_type.py
+++ b/saleor/account/tests/fixtures/customer_type.py
@@ -41,6 +41,6 @@ def customer_type_with_attributes(
     return customer_type
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def default_customer_type(db):
     return get_or_create_default_customer_type()

--- a/saleor/account/tests/fixtures/user.py
+++ b/saleor/account/tests/fixtures/user.py
@@ -4,6 +4,7 @@ import pytest
 
 from ....account.models import Group, User, UserManager
 from ....permission.enums import get_permissions
+from .customer_type import get_or_create_default_customer_type
 
 
 def dangerously_get_or_create_superuser(
@@ -37,6 +38,9 @@ def dangerously_create_test_user(
     email = UserManager.normalize_email(email)
     # Google OAuth2 backend send unnecessary username field
     extra_fields.pop("username", None)
+
+    if "customer_type" not in extra_fields and "customer_type_id" not in extra_fields:
+        extra_fields["customer_type"] = get_or_create_default_customer_type()
 
     user = User(email=email, is_active=is_active, is_staff=is_staff, **extra_fields)
     if password:

--- a/saleor/account/tests/test_customer_type.py
+++ b/saleor/account/tests/test_customer_type.py
@@ -78,8 +78,9 @@ def test_assign_default_customer_type_task_backfills_users_without_type(
     customer_user, customer_user2, default_customer_type
 ):
     # given
-    assert customer_user.customer_type is None
-    assert customer_user2.customer_type is None
+    User.objects.filter(pk__in=[customer_user.pk, customer_user2.pk]).update(
+        customer_type=None
+    )
 
     # when
     assign_default_customer_type_to_users_task()
@@ -97,6 +98,8 @@ def test_assign_default_customer_type_task_keeps_existing_assignments(
     # given
     customer_user.customer_type = customer_type
     customer_user.save(update_fields=["customer_type"])
+    customer_user2.customer_type = None
+    customer_user2.save(update_fields=["customer_type"])
 
     # when
     assign_default_customer_type_to_users_task()

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -29,7 +29,7 @@ from ...account.search import (
     update_user_search_vector,
 )
 from ...account.tests.fixtures.user import dangerously_create_test_user
-from ...account.utils import store_user_address
+from ...account.utils import get_default_customer_type, store_user_address
 from ...app.models import App
 from ...attribute.models import (
     AssignedProductAttributeValue,
@@ -527,7 +527,7 @@ def create_address(save=True, **kwargs):
     return address
 
 
-def create_fake_user(user_password, save=True, generate_id=False):
+def create_fake_user(user_password, save=True, generate_id=False, customer_type=None):
     address = create_address(save=save)
     email = get_email(address.first_name, address.last_name)
 
@@ -559,6 +559,7 @@ def create_fake_user(user_password, save=True, generate_id=False):
     )
 
     if save:
+        user.customer_type = customer_type or get_default_customer_type()
         password_validation.validate_password(user_password, user)
         user.set_password(user_password)
         user.save()
@@ -1115,8 +1116,9 @@ def create_fake_order_promotion():
 
 
 def create_users(user_password, how_many=10):
+    default_customer_type = get_default_customer_type()
     for _ in range(how_many):
-        user = create_fake_user(user_password)
+        user = create_fake_user(user_password, customer_type=default_customer_type)
         yield f"User: {user.email}"
 
 
@@ -1142,6 +1144,7 @@ def create_permission_groups(staff_password):
 
 
 def create_staffs(staff_password):
+    default_customer_type = get_default_customer_type()
     for permission in get_permissions():
         base_name = permission.codename.split("_")[1:]
 
@@ -1153,7 +1156,9 @@ def create_staffs(staff_password):
         user_email = ".".join(email_base_name)
         user_email += ".manager@example.com"
 
-        user = _create_staff_user(staff_password, email=user_email)
+        user = _create_staff_user(
+            staff_password, email=user_email, customer_type=default_customer_type
+        )
         group = create_group(group_name, [permission], [user])
 
         yield f"Group: {group}"
@@ -1167,7 +1172,7 @@ def create_group(name, permissions, users):
     return group
 
 
-def _create_staff_user(staff_password, email=None, superuser=False):
+def _create_staff_user(staff_password, email=None, superuser=False, customer_type=None):
     address = create_address()
     first_name = address.first_name
     last_name = address.last_name
@@ -1188,6 +1193,7 @@ def _create_staff_user(staff_password, email=None, superuser=False):
         is_staff=True,
         is_active=True,
         is_superuser=superuser,
+        customer_type=customer_type or get_default_customer_type(),
     )
     staff_user.addresses.add(address)
     update_user_search_vector(staff_user)
@@ -1195,9 +1201,12 @@ def _create_staff_user(staff_password, email=None, superuser=False):
 
 
 def create_staff_users(staff_password, how_many=2, superuser=False):
+    default_customer_type = get_default_customer_type()
     users = []
     for _ in range(how_many):
-        staff_user = _create_staff_user(staff_password, superuser=superuser)
+        staff_user = _create_staff_user(
+            staff_password, superuser=superuser, customer_type=default_customer_type
+        )
         users.append(staff_user)
     return users
 

--- a/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
+++ b/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_update.py
@@ -1452,6 +1452,7 @@ def test_customers_bulk_update_with_invalid_customer_type_id(
     # given
     customer = customer_users[0]
     original_first_name = customer.first_name
+    original_customer_type_id = customer.customer_type_id
     new_first_name = "BulkUpdatedName"
     assert original_first_name != new_first_name
     invalid_customer_type_id = graphene.Node.to_global_id("PageType", 1)
@@ -1486,4 +1487,4 @@ def test_customers_bulk_update_with_invalid_customer_type_id(
     )
     customer.refresh_from_db()
     assert customer.first_name == original_first_name
-    assert customer.customer_type is None
+    assert customer.customer_type_id == original_customer_type_id

--- a/saleor/graphql/account/tests/queries/test_customers_where_attributes.py
+++ b/saleor/graphql/account/tests/queries/test_customers_where_attributes.py
@@ -502,7 +502,9 @@ def test_customer_not_filterable_by_attribute_after_customer_type_change(
     assert content["data"]["customers"]["edges"] == []
 
 
-def test_does_not_match_users_without_customer_type_for_non_default_type_attribute(
+@pytest.mark.parametrize("with_explicit_default_type", [True, False])
+def test_does_not_match_default_type_users_for_non_default_type_attribute(
+    with_explicit_default_type,
     staff_api_client,
     permission_group_manage_users,
     customer_users,
@@ -511,15 +513,18 @@ def test_does_not_match_users_without_customer_type_for_non_default_type_attribu
     loyalty_customer_attribute,
 ):
     # given: the attribute belongs to a non-default customer type only, and
-    # the customer with an assigned value has no customer type - such a
-    # customer belongs to the default type, which lacks the attribute
+    # the customer with an assigned value belongs to the default type -
+    # either explicitly or implicitly via no customer type assigned
     permission_group_manage_users.user_set.add(staff_api_client.user)
     customer_type.customer_attributes.add(loyalty_customer_attribute)
     assert not default_customer_type.customer_attributes.filter(
         pk=loyalty_customer_attribute.pk
     ).exists()
     customer = customer_users[0]
-    assert customer.customer_type_id is None
+    customer.customer_type = (
+        default_customer_type if with_explicit_default_type else None
+    )
+    customer.save(update_fields=["customer_type"])
     value = loyalty_customer_attribute.values.get(slug="gold")
     associate_attribute_values_to_instance(
         customer, {loyalty_customer_attribute.pk: [value]}
@@ -546,7 +551,8 @@ def test_filter_matches_users_without_customer_type_via_default_type(
     permission_group_manage_users.user_set.add(staff_api_client.user)
     default_customer_type.customer_attributes.add(loyalty_customer_attribute)
     customer = customer_users[0]
-    assert customer.customer_type_id is None
+    customer.customer_type = None
+    customer.save(update_fields=["customer_type"])
     value = loyalty_customer_attribute.values.get(slug="gold")
     associate_attribute_values_to_instance(
         customer, {loyalty_customer_attribute.pk: [value]}

--- a/saleor/graphql/account/tests/queries/test_customers_where_filtering.py
+++ b/saleor/graphql/account/tests/queries/test_customers_where_filtering.py
@@ -700,7 +700,8 @@ def test_customers_filter_by_customer_type_one_of_with_default_includes_users_wi
         [customer_with_type, customer_with_other_type], ["customer_type"]
     )
     customer_without_type = customer_users[2]
-    assert customer_without_type.customer_type_id is None
+    customer_without_type.customer_type = None
+    customer_without_type.save(update_fields=["customer_type"])
     variables = {
         "where": {
             "customerType": {
@@ -743,7 +744,8 @@ def test_customers_filter_by_default_customer_type_includes_users_without_type(
         [customer_with_default_type, customer_with_other_type], ["customer_type"]
     )
     customer_without_type = customer_users[2]
-    assert customer_without_type.customer_type_id is None
+    customer_without_type.customer_type = None
+    customer_without_type.save(update_fields=["customer_type"])
     variables = {
         "where": {
             "customerType": {

--- a/saleor/graphql/account/tests/queries/test_user_assigned_attributes.py
+++ b/saleor/graphql/account/tests/queries/test_user_assigned_attributes.py
@@ -233,6 +233,79 @@ def test_assigned_attribute_by_slug_hidden_attribute_by_staff(
     assert assigned_attribute["attribute"]["slug"] == hidden_customer_attribute.slug
 
 
+def test_assigned_attributes_kept_after_switch_to_type_sharing_the_attribute(
+    staff_api_client,
+    permission_manage_users,
+    customer_user,
+    customer_type,
+    default_customer_type,
+    loyalty_customer_attribute,
+):
+    # given: the attribute belongs to two customer types and the value was
+    # assigned while the user belonged to the first one
+    customer_type.customer_attributes.add(loyalty_customer_attribute)
+    default_customer_type.customer_attributes.add(loyalty_customer_attribute)
+    customer_user.customer_type = customer_type
+    customer_user.save(update_fields=["customer_type"])
+    value = loyalty_customer_attribute.values.get(slug="gold")
+    AssignedUserAttributeValue.objects.create(user=customer_user, value=value)
+    user_id = graphene.Node.to_global_id("User", customer_user.pk)
+    variables = {"id": user_id}
+
+    response = staff_api_client.post_graphql(
+        USER_ASSIGNED_ATTRIBUTES_QUERY,
+        variables,
+        permissions=[permission_manage_users],
+    )
+    content = get_graphql_content(response)
+    assigned_attributes = content["data"]["user"]["assignedAttributes"]
+    assert len(assigned_attributes) == 1
+    assert (
+        assigned_attributes[0]["attribute"]["slug"] == loyalty_customer_attribute.slug
+    )
+    assert assigned_attributes[0]["value"]["slug"] == value.slug
+
+    # when: the user switches to the other type sharing the attribute
+    mutation = """
+        mutation CustomerUpdate($id: ID!, $input: CustomerInput!) {
+            customerUpdate(id: $id, input: $input) {
+                user {
+                    customerType {
+                        id
+                    }
+                }
+                errors {
+                    field
+                    code
+                    message
+                }
+            }
+        }
+    """
+    default_customer_type_id = graphene.Node.to_global_id(
+        "CustomerType", default_customer_type.pk
+    )
+    mutation_variables = {
+        "id": user_id,
+        "input": {"customerType": default_customer_type_id},
+    }
+    response = staff_api_client.post_graphql(mutation, mutation_variables)
+    content = get_graphql_content(response)
+    data = content["data"]["customerUpdate"]
+    assert data["errors"] == []
+    assert data["user"]["customerType"]["id"] == default_customer_type_id
+
+    # then: the value stays visible because the new type also has the attribute
+    response = staff_api_client.post_graphql(USER_ASSIGNED_ATTRIBUTES_QUERY, variables)
+    content = get_graphql_content(response)
+    assigned_attributes = content["data"]["user"]["assignedAttributes"]
+    assert len(assigned_attributes) == 1
+    assert (
+        assigned_attributes[0]["attribute"]["slug"] == loyalty_customer_attribute.slug
+    )
+    assert assigned_attributes[0]["value"]["slug"] == value.slug
+
+
 def test_assigned_attribute_by_slug_hidden_attribute_by_owner(
     user_api_client,
     customer_type_with_attributes,

--- a/saleor/graphql/account/tests/queries/test_user_assigned_attributes.py
+++ b/saleor/graphql/account/tests/queries/test_user_assigned_attributes.py
@@ -156,7 +156,8 @@ def test_assigned_attributes_fall_back_to_default_customer_type(
 ):
     # given: the user has no customer type assigned yet
     default_customer_type.customer_attributes.add(segment_customer_attribute)
-    assert customer_user.customer_type_id is None
+    customer_user.customer_type = None
+    customer_user.save(update_fields=["customer_type"])
     variables = {"id": graphene.Node.to_global_id("User", customer_user.pk)}
 
     # when

--- a/saleor/graphql/account/tests/queries/test_user_customer_type.py
+++ b/saleor/graphql/account/tests/queries/test_user_customer_type.py
@@ -85,7 +85,8 @@ def test_customer_type_falls_back_to_default_when_not_assigned(
     user_api_client, customer_user, default_customer_type
 ):
     # given a user created before the backfill finished
-    assert customer_user.customer_type_id is None
+    customer_user.customer_type = None
+    customer_user.save(update_fields=["customer_type"])
 
     # when
     response = user_api_client.post_graphql(ME_CUSTOMER_TYPE_QUERY)


### PR DESCRIPTION
It's been mentioned in one of pull request reviews.