### PR TITLE
Fix appCreate/appUpdate crash on null permissions input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,4 +45,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 #### Search improvements
 
+### Fixes
+
+- Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. The input is now accepted and the app is created or updated with no permissions.
+
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,6 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
-- Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. The input is now accepted and the app is created or updated with no permissions.
+- Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/app/mutations/app_create.py
+++ b/saleor/graphql/app/mutations/app_create.py
@@ -67,7 +67,7 @@ class AppCreate(DeprecatedModelMutation):
         # clean and prepare permissions
         if "permissions" in cleaned_input:
             requestor = get_user_or_app_from_context(info.context)
-            permissions = cleaned_input.pop("permissions")
+            permissions = cleaned_input.pop("permissions") or []
             ensure_app_permissions_allowed(permissions)
             cleaned_input["permissions"] = get_permissions(permissions)
             ensure_can_manage_permissions(requestor, permissions)

--- a/saleor/graphql/app/mutations/app_create.py
+++ b/saleor/graphql/app/mutations/app_create.py
@@ -64,10 +64,10 @@ class AppCreate(DeprecatedModelMutation):
     @classmethod
     def clean_input(cls, info, instance, data, **kwargs):
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
-        # clean and prepare permissions
-        if "permissions" in cleaned_input:
+        # clean and prepare permissions; a null input creates an app with none
+        permissions = cleaned_input.pop("permissions", None)
+        if permissions is not None:
             requestor = get_user_or_app_from_context(info.context)
-            permissions = cleaned_input.pop("permissions") or []
             ensure_app_permissions_allowed(permissions)
             cleaned_input["permissions"] = get_permissions(permissions)
             ensure_can_manage_permissions(requestor, permissions)

--- a/saleor/graphql/app/mutations/app_update.py
+++ b/saleor/graphql/app/mutations/app_update.py
@@ -56,9 +56,10 @@ class AppUpdate(DeprecatedModelMutation):
             code = AppErrorCode.OUT_OF_SCOPE_APP.value
             raise ValidationError({"id": ValidationError(msg, code=code)})
 
-        # clean and prepare permissions
-        if "permissions" in cleaned_input:
-            permissions = cleaned_input.pop("permissions") or []
+        # clean and prepare permissions; a null input leaves them untouched,
+        # an empty list clears them
+        permissions = cleaned_input.pop("permissions", None)
+        if permissions is not None:
             ensure_app_permissions_allowed(permissions)
             cleaned_input["permissions"] = get_permissions(permissions)
             ensure_can_manage_permissions(requestor, permissions)

--- a/saleor/graphql/app/mutations/app_update.py
+++ b/saleor/graphql/app/mutations/app_update.py
@@ -58,7 +58,7 @@ class AppUpdate(DeprecatedModelMutation):
 
         # clean and prepare permissions
         if "permissions" in cleaned_input:
-            permissions = cleaned_input.pop("permissions")
+            permissions = cleaned_input.pop("permissions") or []
             ensure_app_permissions_allowed(permissions)
             cleaned_input["permissions"] = get_permissions(permissions)
             ensure_can_manage_permissions(requestor, permissions)

--- a/saleor/graphql/app/tests/mutations/test_app_create.py
+++ b/saleor/graphql/app/tests/mutations/test_app_create.py
@@ -2,6 +2,7 @@ import json
 from unittest import mock
 
 import graphene
+import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
@@ -108,6 +109,38 @@ def test_app_create_no_identifier_mutation(
     assert default_token[-4:] == app.tokens.get().token_last_4
     assert app.uuid is not None
     assert app.identifier == graphene.Node.to_global_id("App", app.pk)
+
+
+@pytest.mark.parametrize(
+    ("_case", "permissions_variable"),
+    [
+        ("omitted", {}),
+        ("explicit_null", {"permissions": None}),
+    ],
+)
+def test_app_create_without_permissions(
+    _case,
+    permissions_variable,
+    permission_manage_apps,
+    staff_api_client,
+):
+    # given
+    name = "New integration"
+    variables = {"name": name, **permissions_variable}
+
+    # when
+    response = staff_api_client.post_graphql(
+        APP_CREATE_MUTATION, variables=variables, permissions=(permission_manage_apps,)
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["appCreate"]
+    assert data["errors"] == []
+    app = App.objects.get()
+    assert app.name == name
+    assert list(app.permissions.all()) == []
+    assert data["app"]["permissions"] == []
 
 
 @freeze_time("2022-05-12 12:00:00")

--- a/saleor/graphql/app/tests/mutations/test_app_create.py
+++ b/saleor/graphql/app/tests/mutations/test_app_create.py
@@ -116,6 +116,7 @@ def test_app_create_no_identifier_mutation(
     [
         ("omitted", {}),
         ("explicit_null", {"permissions": None}),
+        ("empty_list", {"permissions": []}),
     ],
 )
 def test_app_create_without_permissions(

--- a/saleor/graphql/app/tests/mutations/test_app_update.py
+++ b/saleor/graphql/app/tests/mutations/test_app_update.py
@@ -2,6 +2,7 @@ import json
 from unittest import mock
 
 import graphene
+import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
@@ -457,6 +458,73 @@ def test_app_update_mutation_removed_app(
     assert app_data["app"] is None
     assert app_data["errors"][0]["code"] == AppErrorCode.NOT_FOUND.name
     assert app_data["errors"][0]["field"] == "id"
+
+
+@pytest.mark.parametrize(
+    ("_case", "permissions_variable"),
+    [
+        ("omitted", {}),
+        ("explicit_null", {"permissions": None}),
+    ],
+)
+def test_app_update_null_permissions_leaves_them_untouched(
+    _case,
+    permissions_variable,
+    app,
+    permission_manage_apps,
+    permission_manage_products,
+    staff_api_client,
+    staff_user,
+):
+    # given
+    app.permissions.add(permission_manage_products)
+    staff_user.user_permissions.add(permission_manage_products)
+    variables = {
+        "id": graphene.Node.to_global_id("App", app.pk),
+        **permissions_variable,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        APP_UPDATE_MUTATION, variables=variables, permissions=(permission_manage_apps,)
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["appUpdate"]
+    assert data["errors"] == []
+    assert [permission["code"] for permission in data["app"]["permissions"]] == [
+        PermissionEnum.MANAGE_PRODUCTS.name
+    ]
+    assert list(app.permissions.all()) == [permission_manage_products]
+
+
+def test_app_update_empty_permissions_clears_them(
+    app,
+    permission_manage_apps,
+    permission_manage_products,
+    staff_api_client,
+    staff_user,
+):
+    # given
+    app.permissions.add(permission_manage_products)
+    staff_user.user_permissions.add(permission_manage_products)
+    variables = {
+        "id": graphene.Node.to_global_id("App", app.pk),
+        "permissions": [],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        APP_UPDATE_MUTATION, variables=variables, permissions=(permission_manage_apps,)
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["appUpdate"]
+    assert data["errors"] == []
+    assert data["app"]["permissions"] == []
+    assert app.permissions.exists() is False
 
 
 def test_app_update_rejects_manage_apps_permission(


### PR DESCRIPTION
AppInput.permissions is optional, but if skipped, unhandled error is raised. This PR adds an `[]` fallback