### PR TITLE
fix(build): always run linters + add `sfw`

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,49 @@
+name: Linters
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  linters:
+    runs-on: ubuntu-latest
+    container: python:3.12
+    name: Run linters
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install system dependencies
+        run: |
+          apt-get install -y libpq-dev
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          use-cache: false # reduce risks with poisoned cache
+          mode: firewall-free
+
+      - name: Install dependencies
+        run: |
+          sfw uv sync --locked
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
+
+      # Run linters and Django related checks
+      # `git config` command is a workaround for https://github.com/actions/runner-images/issues/6775
+      - name: Run Linters and Checks
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          sfw uv run pre-commit run --all --show-diff-on-failure

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -2,8 +2,14 @@ name: Linters
 
 on:
   pull_request:
+  push:
+    branches: [main]
 
 permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linters:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Tests & Linters
+name: Tests
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
       - "**.py"
       - Dockerfile
       - "saleor/**"
-      - .github/workflows/tests-and-linters.yml
+      - .github/workflows/tests.yml
       - pyproject.toml
       - uv.lock
   push:
@@ -17,7 +17,7 @@ on:
       - "**.py"
       - Dockerfile
       - "saleor/**"
-      - .github/workflows/tests-and-linters.yml
+      - .github/workflows/tests.yml
       - pyproject.toml
       - uv.lock
 
@@ -136,41 +136,3 @@ jobs:
           query_raw_dump_path: results/queries-results.json
           upload_endpoint: ${{ secrets.QUERIES_UPLOAD_ENDPOINT_URL }}
           upload_secret_key: ${{ secrets.QUERIES_UPLOAD_SECRET }}
-
-  linters:
-    runs-on: ubuntu-latest
-    container: python:3.12
-    name: Run linters
-
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install system dependencies
-        run: |
-          apt-get install -y libpq-dev
-
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-
-      - name: Install dependencies
-        run: |
-          uv sync --locked
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-
-
-      # Run linters and Django related checks
-      # `git config` command is a workaround for https://github.com/actions/runner-images/issues/6775
-      - name: Run Linters and Checks
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          uv run pre-commit run --all --show-diff-on-failure
-        if: ${{ always() }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ on:
       - "**.py"
       - Dockerfile
       - "saleor/**"
-      - .github/workflows/tests.yml
+      - .github/workflows/tests.yaml
       - pyproject.toml
       - uv.lock
   push:
@@ -17,7 +17,7 @@ on:
       - "**.py"
       - Dockerfile
       - "saleor/**"
-      - .github/workflows/tests.yml
+      - .github/workflows/tests.yaml
       - pyproject.toml
       - uv.lock
 


### PR DESCRIPTION
Fixes the issue that caused us to have to create https://github.com/saleor/saleor/pull/19572 - we were running pre-commit only when Python code is changed instead of always running it; our pre-commit set-up is not specific to certain type of files thus it does not make sense to apply a file filter.

This also adds `sfw` around the linter job to check dependencies for issues



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
