### PR TITLE
Delete unique attribute values when deleting users

### DIFF
--- a/saleor/attribute/utils.py
+++ b/saleor/attribute/utils.py
@@ -1,21 +1,45 @@
 from collections import defaultdict
+from collections.abc import Iterable
 
 from django.db.models import Exists, OuterRef, Q
 
 from ..account.models import User
 from ..page.models import Page
 from ..product.models import Product, ProductVariant
+from . import AttributeInputType
 from .models import (
     AssignedPageAttributeValue,
     AssignedProductAttributeValue,
     AssignedUserAttributeValue,
     AssignedVariantAttribute,
     AssignedVariantAttributeValue,
+    Attribute,
     AttributeValue,
     AttributeVariant,
 )
 
 T_INSTANCE = Product | ProductVariant | Page | User
+
+
+def delete_user_unique_attribute_values(user_pks: Iterable[int]) -> None:
+    """Delete attribute values of unique-value input types assigned to the users.
+
+    Values of selectable input types (dropdown, multiselect, swatch) are the
+    attribute's shared choices, so on user deletion only their assignments go
+    away (handled by the FK cascade). Values of input types listed in
+    `TYPES_WITH_UNIQUE_VALUES` are created per user and may contain PII, so
+    they must be deleted together with the user. Must be called before the
+    user rows are deleted - the cascade removes the assignments needed to
+    find the values.
+    """
+    assigned_values = AssignedUserAttributeValue.objects.filter(user_id__in=user_pks)
+    unique_value_attributes = Attribute.objects.filter(
+        input_type__in=AttributeInputType.TYPES_WITH_UNIQUE_VALUES
+    )
+    AttributeValue.objects.filter(
+        Exists(assigned_values.filter(value_id=OuterRef("id"))),
+        Exists(unique_value_attributes.filter(id=OuterRef("attribute_id"))),
+    ).delete()
 
 
 instance_to_function_variables_mapping = {

--- a/saleor/attribute/utils.py
+++ b/saleor/attribute/utils.py
@@ -1,12 +1,14 @@
 from collections import defaultdict
 from collections.abc import Iterable
 
+from django.db import transaction
 from django.db.models import Exists, OuterRef, Q
 
 from ..account.models import User
 from ..page.models import Page
 from ..product.models import Product, ProductVariant
 from . import AttributeInputType
+from .lock_objects import attribute_value_qs_select_for_update
 from .models import (
     AssignedPageAttributeValue,
     AssignedProductAttributeValue,
@@ -36,10 +38,16 @@ def delete_user_unique_attribute_values(user_pks: Iterable[int]) -> None:
     unique_value_attributes = Attribute.objects.filter(
         input_type__in=AttributeInputType.TYPES_WITH_UNIQUE_VALUES
     )
-    AttributeValue.objects.filter(
-        Exists(assigned_values.filter(value_id=OuterRef("id"))),
-        Exists(unique_value_attributes.filter(id=OuterRef("attribute_id"))),
-    ).delete()
+    with transaction.atomic():
+        locked_ids = (
+            attribute_value_qs_select_for_update()
+            .filter(
+                Exists(assigned_values.filter(value_id=OuterRef("id"))),
+                Exists(unique_value_attributes.filter(id=OuterRef("attribute_id"))),
+            )
+            .values_list("id", flat=True)
+        )
+        AttributeValue.objects.filter(id__in=locked_ids).delete()
 
 
 instance_to_function_variables_mapping = {

--- a/saleor/graphql/account/bulk_mutations/customer_bulk_delete.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_delete.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ....account import models
+from ....attribute.utils import delete_user_unique_attribute_values
 from ....core.tracing import traced_atomic_transaction
 from ....giftcard.utils import deactivate_assigned_gift_cards
 from ....permission.enums import AccountPermissions
@@ -56,6 +57,7 @@ class CustomerBulkDelete(CustomerDeleteMixin, UserBulkDelete):
             # on_delete=PROTECT, so restricted cards must be detached and
             # deactivated first, atomically with the deletion.
             deactivate_assigned_gift_cards(queryset)
+            delete_user_unique_attribute_values([user.pk for user in instances])
             queryset.delete()
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.CUSTOMER_DELETED)
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/account/bulk_mutations/staff_bulk_delete.py
+++ b/saleor/graphql/account/bulk_mutations/staff_bulk_delete.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from django.core.exceptions import ValidationError
 
 from ....account import models
+from ....attribute.utils import delete_user_unique_attribute_values
 from ....core.tracing import traced_atomic_transaction
 from ....giftcard.utils import deactivate_assigned_gift_cards
 from ....permission.enums import AccountPermissions
@@ -71,6 +72,7 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
             # on_delete=PROTECT, so restricted cards must be detached and
             # deactivated first, atomically with the deletion.
             deactivate_assigned_gift_cards(queryset)
+            delete_user_unique_attribute_values([user.pk for user in instances])
             queryset.delete()
         manager = get_plugin_manager_promise(info.context).get()
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.STAFF_DELETED)

--- a/saleor/graphql/account/mutations/account/account_delete.py
+++ b/saleor/graphql/account/mutations/account/account_delete.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 
 from .....account import models
 from .....account.error_codes import AccountErrorCode
+from .....attribute.utils import delete_user_unique_attribute_values
 from .....core.tokens import (
     account_delete_token_generator,
     legacy_account_delete_token_generator,
@@ -89,6 +90,7 @@ class AccountDelete(ModelDeleteMutation):
             # on_delete=PROTECT, so restricted cards must be detached and
             # deactivated first, atomically with the deletion.
             deactivate_assigned_gift_cards([user])
+            delete_user_unique_attribute_values([user.pk])
             user.delete()
         # After the instance is deleted, set its ID to the original database's
         # ID so that the success response contains ID of the deleted object.

--- a/saleor/graphql/account/mutations/staff/customer_delete.py
+++ b/saleor/graphql/account/mutations/staff/customer_delete.py
@@ -1,6 +1,7 @@
 import graphene
 
 from .....account import models
+from .....attribute.utils import delete_user_unique_attribute_values
 from .....core.tracing import traced_atomic_transaction
 from .....giftcard.utils import deactivate_assigned_gift_cards
 from .....permission.enums import AccountPermissions
@@ -51,6 +52,7 @@ class CustomerDelete(CustomerDeleteMixin, UserDelete):
         # Runs inside the deletion transaction, right before the user is
         # removed. Required because GiftCard.assigned_to is on_delete=PROTECT.
         deactivate_assigned_gift_cards([instance])
+        delete_user_unique_attribute_values([instance.pk])
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/account/mutations/staff/staff_delete.py
+++ b/saleor/graphql/account/mutations/staff/staff_delete.py
@@ -1,6 +1,7 @@
 import graphene
 
 from .....account import models
+from .....attribute.utils import delete_user_unique_attribute_values
 from .....core.tracing import traced_atomic_transaction
 from .....giftcard.utils import deactivate_assigned_gift_cards
 from .....permission.enums import AccountPermissions
@@ -49,6 +50,7 @@ class StaffDelete(StaffDeleteMixin, UserDelete):
             # on_delete=PROTECT, so restricted cards must be detached and
             # deactivated first, atomically with the deletion.
             deactivate_assigned_gift_cards([instance])
+            delete_user_unique_attribute_values([instance.pk])
             instance.delete()
         # After the instance is deleted, set its ID to the original database's
         # ID so that the success response contains ID of the deleted object.

--- a/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_delete.py
+++ b/saleor/graphql/account/tests/bulk_mutations/test_customer_bulk_delete.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import graphene
 
 from .....account.models import User
+from .....attribute.models import AssignedUserAttributeValue, AttributeValue
 from ....tests.utils import get_graphql_content
 
 CUSTOMER_BULK_DELETE_MUTATION = """
@@ -129,3 +130,53 @@ def test_delete_customers_by_app(
         app=app_api_client.app,
         deleted_count=len(deleted_customers),
     )
+
+
+def test_deletes_unique_attribute_values_and_keeps_shared_choices(
+    staff_api_client,
+    customer_user,
+    customer_user2,
+    permission_manage_users,
+    description_customer_attribute,
+    loyalty_customer_attribute,
+):
+    # given: each customer has a unique (plain text) value and a shared choice
+    customers = [customer_user, customer_user2]
+    unique_values = []
+    choice_value = loyalty_customer_attribute.values.get(slug="gold")
+    for customer in customers:
+        plain_text = f"Notes about customer {customer.pk}"
+        unique_value = AttributeValue.objects.create(
+            attribute=description_customer_attribute,
+            name=plain_text,
+            slug=f"{customer.pk}_{description_customer_attribute.pk}",
+            plain_text=plain_text,
+        )
+        unique_values.append(unique_value)
+        AssignedUserAttributeValue.objects.create(user=customer, value=unique_value)
+        AssignedUserAttributeValue.objects.create(user=customer, value=choice_value)
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("User", customer.pk) for customer in customers
+        ]
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_BULK_DELETE_MUTATION, variables, permissions=[permission_manage_users]
+    )
+
+    # then: the unique values are deleted with the users, the shared choice stays
+    content = get_graphql_content(response)
+    assert content["data"]["customerBulkDelete"]["count"] == len(customers)
+    assert (
+        User.objects.filter(pk__in=[customer.pk for customer in customers]).exists()
+        is False
+    )
+    assert (
+        AttributeValue.objects.filter(
+            pk__in=[value.pk for value in unique_values]
+        ).exists()
+        is False
+    )
+    assert AttributeValue.objects.filter(pk=choice_value.pk).exists() is True

--- a/saleor/graphql/account/tests/bulk_mutations/test_staff_bulk_delete.py
+++ b/saleor/graphql/account/tests/bulk_mutations/test_staff_bulk_delete.py
@@ -4,6 +4,7 @@ import graphene
 
 from .....account.error_codes import AccountErrorCode
 from .....account.models import Group, User
+from .....attribute.models import AssignedUserAttributeValue, AttributeValue
 from .....permission.enums import AccountPermissions, OrderPermissions
 from ....tests.utils import assert_no_permission, get_graphql_content
 
@@ -360,3 +361,51 @@ def test_delete_staff_members_superuser_can_delete__out_of_scope_users(
     assert not User.objects.filter(
         id__in=[user.id for user in [staff_user1, staff_user2]]
     ).exists()
+
+
+def test_deletes_unique_attribute_values_and_keeps_shared_choices(
+    staff_api_client,
+    permission_manage_staff,
+    description_customer_attribute,
+    loyalty_customer_attribute,
+):
+    # given: each staff user has a unique (plain text) value and a shared choice
+    staff_users = [
+        User.objects.create(email="staff1@example.com", is_staff=True),
+        User.objects.create(email="staff2@example.com", is_staff=True),
+    ]
+    unique_values = []
+    choice_value = loyalty_customer_attribute.values.get(slug="gold")
+    for staff_user in staff_users:
+        plain_text = f"Notes about staff member {staff_user.pk}"
+        unique_value = AttributeValue.objects.create(
+            attribute=description_customer_attribute,
+            name=plain_text,
+            slug=f"{staff_user.pk}_{description_customer_attribute.pk}",
+            plain_text=plain_text,
+        )
+        unique_values.append(unique_value)
+        AssignedUserAttributeValue.objects.create(user=staff_user, value=unique_value)
+        AssignedUserAttributeValue.objects.create(user=staff_user, value=choice_value)
+    variables = {
+        "ids": [graphene.Node.to_global_id("User", user.pk) for user in staff_users]
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        STAFF_BULK_DELETE_MUTATION, variables, permissions=[permission_manage_staff]
+    )
+
+    # then: the unique values are deleted with the users, the shared choice stays
+    content = get_graphql_content(response)
+    assert content["data"]["staffBulkDelete"]["count"] == len(staff_users)
+    assert (
+        User.objects.filter(pk__in=[user.pk for user in staff_users]).exists() is False
+    )
+    assert (
+        AttributeValue.objects.filter(
+            pk__in=[value.pk for value in unique_values]
+        ).exists()
+        is False
+    )
+    assert AttributeValue.objects.filter(pk=choice_value.pk).exists() is True

--- a/saleor/graphql/account/tests/mutations/account/test_account_delete.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_delete.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from ......account.models import User
+from ......attribute.models import AssignedUserAttributeValue, AttributeValue
 from ......core.tokens import (
     account_delete_token_generator,
     legacy_account_delete_token_generator,
@@ -225,3 +226,34 @@ def test_account_delete_webhook_event_triggered(
     assert not User.objects.filter(pk=user.id).exists()
 
     mocked_trigger_webhooks_async.assert_called()
+
+
+def test_deletes_unique_attribute_values_and_keeps_shared_choices(
+    user_api_client,
+    description_customer_attribute,
+    loyalty_customer_attribute,
+):
+    # given: the user has a unique (plain text) value and a shared choice
+    user = user_api_client.user
+    plain_text = "Notes about the customer"
+    unique_value = AttributeValue.objects.create(
+        attribute=description_customer_attribute,
+        name=plain_text,
+        slug=f"{user.pk}_{description_customer_attribute.pk}",
+        plain_text=plain_text,
+    )
+    choice_value = loyalty_customer_attribute.values.get(slug="gold")
+    AssignedUserAttributeValue.objects.create(user=user, value=unique_value)
+    AssignedUserAttributeValue.objects.create(user=user, value=choice_value)
+    token = account_delete_token_generator.make_token(user)
+    variables = {"token": token}
+
+    # when
+    response = user_api_client.post_graphql(ACCOUNT_DELETE_MUTATION, variables)
+
+    # then: the unique value is deleted with the user, the shared choice stays
+    content = get_graphql_content(response)
+    assert content["data"]["accountDelete"]["errors"] == []
+    assert User.objects.filter(pk=user.pk).exists() is False
+    assert AttributeValue.objects.filter(pk=unique_value.pk).exists() is False
+    assert AttributeValue.objects.filter(pk=choice_value.pk).exists() is True

--- a/saleor/graphql/account/tests/mutations/staff/test_customer_delete.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_customer_delete.py
@@ -7,6 +7,8 @@ from django.core.exceptions import ValidationError
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from ......account.models import User
+from ......attribute.models import AssignedUserAttributeValue, AttributeValue
 from ......webhook.event_types import WebhookEventAsyncType
 from .....tests.utils import get_graphql_content
 from ....mutations.staff import CustomerDelete
@@ -215,3 +217,36 @@ def test_delete_customer_by_external_reference_not_existing(
     # then
     errors = content["data"]["customerDelete"]["errors"]
     assert errors[0]["message"] == f"Couldn't resolve to a node: {ext_ref}"
+
+
+def test_deletes_unique_attribute_values_and_keeps_shared_choices(
+    staff_api_client,
+    customer_user,
+    permission_manage_users,
+    description_customer_attribute,
+    loyalty_customer_attribute,
+):
+    # given: the customer has a unique (plain text) value and a shared choice
+    plain_text = "Notes about the customer"
+    unique_value = AttributeValue.objects.create(
+        attribute=description_customer_attribute,
+        name=plain_text,
+        slug=f"{customer_user.pk}_{description_customer_attribute.pk}",
+        plain_text=plain_text,
+    )
+    choice_value = loyalty_customer_attribute.values.get(slug="gold")
+    AssignedUserAttributeValue.objects.create(user=customer_user, value=unique_value)
+    AssignedUserAttributeValue.objects.create(user=customer_user, value=choice_value)
+    variables = {"id": graphene.Node.to_global_id("User", customer_user.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        CUSTOMER_DELETE_MUTATION, variables, permissions=[permission_manage_users]
+    )
+
+    # then: the unique value is deleted with the user, the shared choice stays
+    content = get_graphql_content(response)
+    assert content["data"]["customerDelete"]["errors"] == []
+    assert User.objects.filter(pk=customer_user.pk).exists() is False
+    assert AttributeValue.objects.filter(pk=unique_value.pk).exists() is False
+    assert AttributeValue.objects.filter(pk=choice_value.pk).exists() is True

--- a/saleor/graphql/account/tests/mutations/staff/test_staff_delete.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_staff_delete.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 
 from ......account.error_codes import AccountErrorCode
 from ......account.models import Group, User
+from ......attribute.models import AssignedUserAttributeValue, AttributeValue
 from ......core.utils.json_serializer import CustomJsonEncoder
 from ......permission.enums import AccountPermissions, OrderPermissions
 from ......webhook.event_types import WebhookEventAsyncType
@@ -344,3 +345,36 @@ def test_staff_update_errors(staff_user, customer_user, admin_user):
     # should not raise any errors
     StaffUpdate.clean_is_active(input, customer_user, staff_user, errors)
     assert not errors["is_active"]
+
+
+def test_deletes_unique_attribute_values_and_keeps_shared_choices(
+    staff_api_client,
+    permission_manage_staff,
+    description_customer_attribute,
+    loyalty_customer_attribute,
+):
+    # given: the staff user has a unique (plain text) value and a shared choice
+    staff_user = User.objects.create(email="staffuser@example.com", is_staff=True)
+    plain_text = "Notes about the staff member"
+    unique_value = AttributeValue.objects.create(
+        attribute=description_customer_attribute,
+        name=plain_text,
+        slug=f"{staff_user.pk}_{description_customer_attribute.pk}",
+        plain_text=plain_text,
+    )
+    choice_value = loyalty_customer_attribute.values.get(slug="gold")
+    AssignedUserAttributeValue.objects.create(user=staff_user, value=unique_value)
+    AssignedUserAttributeValue.objects.create(user=staff_user, value=choice_value)
+    variables = {"id": graphene.Node.to_global_id("User", staff_user.pk)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        STAFF_DELETE_MUTATION, variables, permissions=[permission_manage_staff]
+    )
+
+    # then: the unique value is deleted with the user, the shared choice stays
+    content = get_graphql_content(response)
+    assert content["data"]["staffDelete"]["errors"] == []
+    assert User.objects.filter(pk=staff_user.pk).exists() is False
+    assert AttributeValue.objects.filter(pk=unique_value.pk).exists() is False
+    assert AttributeValue.objects.filter(pk=choice_value.pk).exists() is True


### PR DESCRIPTION
User deletion cascades away `AssignedUserAttributeValue` rows, but the `AttributeValue` rows of unique-value input types (plain text, rich text, file, reference, numeric, date, datetime) are created per user and were left orphaned - including values hidden by customer type rules. Such values are user-entered and can contain PII, which must not survive the user it belongs to.
