### PR TITLE
perf: batch User field resolvers

### DIFF
--- a/saleor/graphql/account/dataloaders.py
+++ b/saleor/graphql/account/dataloaders.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from collections.abc import Iterable
+from copy import copy
 from typing import TypeVar, cast
 
 from ...account.models import Address, CustomerEvent, Group, User
@@ -16,6 +17,69 @@ class AddressByIdLoader(DataLoader[int, Address]):
     def batch_load(self, keys):
         address_map = Address.objects.using(self.database_connection_name).in_bulk(keys)
         return [address_map.get(address_id) for address_id in keys]
+
+
+class AddressesByUserIdLoader(
+    DataLoader[tuple[int, int | None, int | None], list[Address]]
+):
+    context_key = "addresses_by_user_id"
+
+    def batch_load(self, keys: Iterable[tuple[int, int | None, int | None]]):
+        keys = list(keys)
+        user_ids = [user_id for user_id, _, _ in keys]
+        user_address_relations = (
+            User.addresses.through.objects.using(self.database_connection_name)
+            .filter(user_id__in=user_ids)
+            .values_list("user_id", "address_id")
+            .order_by("address_id")
+        )
+        relations = list(user_address_relations)
+        addresses = Address.objects.using(self.database_connection_name).in_bulk(
+            [address_id for _, address_id in relations]
+        )
+        default_ids_by_user = {
+            user_id: (default_shipping_address_id, default_billing_address_id)
+            for user_id, default_shipping_address_id, default_billing_address_id in keys
+        }
+        addresses_by_user = defaultdict(list)
+        for user_id, address_id in relations:
+            address = copy(addresses[address_id])
+            default_shipping_address_id, default_billing_address_id = (
+                default_ids_by_user[user_id]
+            )
+            setattr(
+                address,
+                "user_default_shipping_address_pk",
+                default_shipping_address_id,
+            )
+            setattr(
+                address,
+                "user_default_billing_address_pk",
+                default_billing_address_id,
+            )
+            addresses_by_user[user_id].append(address)
+        return [addresses_by_user[user_id] for user_id in user_ids]
+
+
+class PermissionGroupsByUserIdLoader(DataLoader[int, list[Group]]):
+    context_key = "permission_groups_by_user_id"
+
+    def batch_load(self, keys: Iterable[int]):
+        keys = list(keys)
+        user_group_relations = (
+            User.groups.through.objects.using(self.database_connection_name)
+            .filter(user_id__in=keys)
+            .values_list("user_id", "group_id")
+            .order_by("group_id")
+        )
+        relations = list(user_group_relations)
+        groups = Group.objects.using(self.database_connection_name).in_bulk(
+            [group_id for _, group_id in relations]
+        )
+        groups_by_user = defaultdict(list)
+        for user_id, group_id in relations:
+            groups_by_user[user_id].append(groups[group_id])
+        return [groups_by_user[user_id] for user_id in keys]
 
 
 class UserByUserIdLoader(DataLoader[str, User]):

--- a/saleor/graphql/account/tests/test_dataloaders.py
+++ b/saleor/graphql/account/tests/test_dataloaders.py
@@ -1,0 +1,80 @@
+from ....account.models import Group
+from ...context import SaleorContext
+from ..dataloaders import AddressesByUserIdLoader, PermissionGroupsByUserIdLoader
+
+
+def test_addresses_by_user_id_loader_batches_users(
+    customer_user,
+    customer_user2,
+    address,
+    django_assert_num_queries,
+):
+    # given
+    second_address = address.get_copy()
+    customer_user.addresses.add(address)
+    customer_user2.addresses.add(second_address)
+    customer_user.default_shipping_address = address
+    customer_user.save(update_fields=["default_shipping_address"])
+    customer_user2.default_billing_address = second_address
+    customer_user2.save(update_fields=["default_billing_address"])
+    expected_address_ids = [
+        list(customer_user.addresses.order_by("pk").values_list("pk", flat=True)),
+        list(customer_user2.addresses.order_by("pk").values_list("pk", flat=True)),
+    ]
+    keys = [
+        (
+            customer_user.id,
+            customer_user.default_shipping_address_id,
+            customer_user.default_billing_address_id,
+        ),
+        (
+            customer_user2.id,
+            customer_user2.default_shipping_address_id,
+            customer_user2.default_billing_address_id,
+        ),
+    ]
+    loader = AddressesByUserIdLoader(SaleorContext())
+
+    # when
+    with django_assert_num_queries(2):
+        result = loader.batch_load(keys)
+
+    # then
+    assert [
+        [item.id for item in addresses] for addresses in result
+    ] == expected_address_ids
+    first_default = next(item for item in result[0] if item.id == address.id)
+    second_default = next(item for item in result[1] if item.id == second_address.id)
+    assert first_default.user_default_shipping_address_pk == address.id
+    assert (
+        first_default.user_default_billing_address_pk
+        == customer_user.default_billing_address_id
+    )
+    assert (
+        second_default.user_default_shipping_address_pk
+        == customer_user2.default_shipping_address_id
+    )
+    assert second_default.user_default_billing_address_pk == second_address.id
+
+
+def test_permission_groups_by_user_id_loader_batches_users(
+    customer_user,
+    customer_user2,
+    django_assert_num_queries,
+):
+    # given
+    first_group = Group.objects.create(name="First group")
+    second_group = Group.objects.create(name="Second group")
+    customer_user.groups.add(first_group)
+    customer_user2.groups.add(first_group, second_group)
+    loader = PermissionGroupsByUserIdLoader(SaleorContext())
+
+    # when
+    with django_assert_num_queries(2):
+        result = loader.batch_load([customer_user.id, customer_user2.id])
+
+    # then
+    assert [[group.id for group in groups] for groups in result] == [
+        [first_group.id],
+        [first_group.id, second_group.id],
+    ]

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -7,7 +7,6 @@ from graphene import relay
 from promise import Promise
 
 from ...account import models
-from ...checkout.utils import get_user_checkout
 from ...core.exceptions import PermissionDenied
 from ...graphql.meta.inputs import MetadataInput, MetadataInputDescription
 from ...order import OrderStatus
@@ -69,7 +68,9 @@ from .dataloaders import (
     AccessibleChannelsByGroupIdLoader,
     AccessibleChannelsByUserIdLoader,
     AddressByIdLoader,
+    AddressesByUserIdLoader,
     CustomerEventsByUserLoader,
+    PermissionGroupsByUserIdLoader,
     RestrictedChannelAccessByUserIdLoader,
     ThumbnailByUserIdSizeAndFormatLoader,
 )
@@ -493,22 +494,28 @@ class User(ModelObjectType[models.User]):
         doc_category = DOC_CATEGORY_USERS
 
     @staticmethod
-    def resolve_addresses(root: models.User, _info: ResolveInfo):
+    def resolve_addresses(root: models.User, info: ResolveInfo):
         if is_newly_created_user(root):
             return []
-        return root.addresses.annotate_default(root).all()
+        return AddressesByUserIdLoader(info.context).load(
+            (
+                root.id,
+                root.default_shipping_address_id,
+                root.default_billing_address_id,
+            )
+        )
 
     @staticmethod
     def resolve_checkout(root: models.User, info: ResolveInfo):
         if is_newly_created_user(root):
             return None
-        database_connection_name = get_database_connection_name(info.context)
-        checkout = get_user_checkout(
-            root, database_connection_name=database_connection_name
-        )
-        if not checkout:
-            return None
-        return SyncWebhookControlContext(node=checkout)
+
+        def _resolve_checkout(checkouts):
+            if not checkouts:
+                return None
+            return SyncWebhookControlContext(node=checkouts[0])
+
+        return CheckoutByUserLoader(info.context).load(root.id).then(_resolve_checkout)
 
     @staticmethod
     @traced_resolver
@@ -612,7 +619,7 @@ class User(ModelObjectType[models.User]):
     def resolve_permission_groups(root: models.User, info: ResolveInfo):
         if is_newly_created_user(root):
             return []
-        return root.groups.using(get_database_connection_name(info.context)).all()
+        return PermissionGroupsByUserIdLoader(info.context).load(root.id)
 
     @staticmethod
     def resolve_editable_groups(root: models.User, info: ResolveInfo):


### PR DESCRIPTION
# perf: batch User field resolvers

## Description

Moves the remaining database-backed `User` field resolvers identified in #13752 to
request-scoped data loaders:

- `addresses`
- `permissionGroups`
- deprecated `checkout`

The address loader preserves address ordering and the annotations used by
`isDefaultShippingAddress` and `isDefaultBillingAddress`. The permission-group loader
preserves group ordering. The checkout resolver reuses the existing active-channel
checkout loader and keeps the model's default ordering.

Fixes #13752.

This is an independently tested alternative to #18966. In addition to query-count
coverage, it preserves per-user default-address annotations when an address is shared,
retains the checkout model's `-last_change, pk` ordering, and avoids sharing mutable
address instances between users in the same request.

## Why

The previous resolvers queried once per returned user. On multi-user GraphQL requests,
that causes query counts to grow with the number of users. The new loaders batch each
relationship across the request.

## Verification

- New data-loader tests — 2 passed
  - multiple users' addresses load in exactly two queries
  - multiple users' permission groups load in exactly two queries
- Existing User GraphQL regression suite — 47 passed
- Ruff lint and formatting — passed
- Mypy on changed application files — passed
- Whitespace check — passed
