### PR TITLE
Remove deprecated orderAddNote mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Removed the deprecated `shopDomainUpdate` mutation. Use the `PUBLIC_URL` environment variable to configure the shop domain instead.
 - Removed the deprecated `orderSettingsUpdate` mutation. Use the `channelUpdate` mutation with the `orderSettings` input to update order settings per channel instead.
 - Removed the deprecated `orderSettings` query field. Use the `channel` query and read its `orderSettings` field instead.
+- Removed the deprecated `orderAddNote` mutation, along with the `OrderAddNote` type and `OrderAddNoteInput` input. Use the `orderNoteAdd` mutation instead.
 - Removed the `DIGITAL_LINKS` value from the `OrderEventsEmailsEnum` enum and the `DIGITAL_LINK_DOWNLOADED` value from the `CustomerEventsEnum` enum. Events with these types were deleted in 3.23, along with the legacy digital content feature that emitted them.
 - Removed the always-empty `digital_lines` key from the fulfillment confirmation notification payload. Use `physical_lines`, which holds every line of the fulfillment.
 

--- a/saleor/graphql/order/mutations/order_note_add.py
+++ b/saleor/graphql/order/mutations/order_note_add.py
@@ -10,7 +10,7 @@ from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
 from ...core.context import SyncWebhookControlContext
 from ...core.doc_category import DOC_CATEGORY_ORDERS
-from ...core.types import BaseInputObjectType, Error, OrderError
+from ...core.types import Error
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order, OrderEvent
 from .order_note_common import OrderNoteCommon
@@ -68,28 +68,3 @@ class OrderNoteAdd(OrderNoteCommon):
             order=SyncWebhookControlContext(order),
             event=SyncWebhookControlContext(event),
         )
-
-
-class OrderAddNoteInput(BaseInputObjectType):
-    message = graphene.String(
-        description="Note message.",
-        name="message",
-        required=True,
-    )
-
-    class Meta:
-        doc_category = DOC_CATEGORY_ORDERS
-
-
-class OrderAddNote(OrderNoteAdd):
-    class Arguments(OrderNoteAdd.Arguments):
-        input = OrderAddNoteInput(
-            required=True, description="Fields required to create a note for the order."
-        )
-
-    class Meta:
-        description = "Adds note to the order."
-        doc_category = DOC_CATEGORY_ORDERS
-        permissions = (OrderPermissions.MANAGE_ORDERS,)
-        error_type_class = OrderError
-        error_type_field = "order_errors"

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -71,7 +71,7 @@ from .mutations.order_line_discount_update import OrderLineDiscountUpdate
 from .mutations.order_line_update import OrderLineUpdate
 from .mutations.order_lines_create import OrderLinesCreate
 from .mutations.order_mark_as_paid import OrderMarkAsPaid
-from .mutations.order_note_add import OrderAddNote, OrderNoteAdd
+from .mutations.order_note_add import OrderNoteAdd
 from .mutations.order_note_update import OrderNoteUpdate
 from .mutations.order_refund import OrderRefund
 from .mutations.order_update import OrderUpdate
@@ -291,9 +291,6 @@ class OrderMutations(graphene.ObjectType):
     )
     draft_order_update = DraftOrderUpdate.Field()
 
-    order_add_note = OrderAddNote.Field(
-        deprecation_reason="Use `orderNoteAdd` instead."
-    )
     order_cancel = OrderCancel.Field()
     order_capture = OrderCapture.Field(deprecation_reason=DEPRECATED_LEGACY_PAYMENTS)
     order_confirm = OrderConfirm.Field()

--- a/saleor/graphql/order/tests/mutations/test_order_note_add.py
+++ b/saleor/graphql/order/tests/mutations/test_order_note_add.py
@@ -111,7 +111,7 @@ def test_order_note_add_fail_on_empty_message(
     order_updated_webhook_mock.assert_not_called()
 
 
-def test_order_add_note_as_user_no_channel_access(
+def test_order_note_add_as_user_no_channel_access(
     staff_api_client,
     permission_group_all_perms_channel_USD_only,
     order_with_lines,
@@ -136,7 +136,7 @@ def test_order_add_note_as_user_no_channel_access(
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
-def test_order_add_note_by_app(
+def test_order_note_add_by_app(
     order_updated_webhook_mock,
     app_api_client,
     permission_manage_orders,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19401,19 +19401,6 @@ type Mutation {
   ): DraftOrderUpdate @doc(category: "Orders")
 
   """
-  Adds note to the order. 
-  
-  Requires one of the following permissions: MANAGE_ORDERS.
-  """
-  orderAddNote(
-    """ID of the order to add a note for."""
-    order: ID!
-
-    """Fields required to create a note for the order."""
-    input: OrderAddNoteInput!
-  ): OrderAddNote @doc(category: "Orders") @deprecated(reason: "Use `orderNoteAdd` instead.")
-
-  """
   Cancel an order. 
   
   Requires one of the following permissions: MANAGE_ORDERS.
@@ -27317,26 +27304,6 @@ input DraftOrderInput @doc(category: "Orders") {
 
   """Order language code."""
   languageCode: LanguageCodeEnum
-}
-
-"""
-Adds note to the order. 
-
-Requires one of the following permissions: MANAGE_ORDERS.
-"""
-type OrderAddNote @doc(category: "Orders") {
-  """Order with the note added."""
-  order: Order
-
-  """Order note created."""
-  event: OrderEvent
-  orderErrors: [OrderError!]! @deprecated(reason: "Use `errors` field instead.")
-  errors: [OrderError!]!
-}
-
-input OrderAddNoteInput @doc(category: "Orders") {
-  """Note message."""
-  message: String!
 }
 
 """


### PR DESCRIPTION
Drop the `orderAddNote` mutation together with its `OrderAddNote` type and
`OrderAddNoteInput` input. It was deprecated in favour of `orderNoteAdd`,
which it subclassed and which stays unchanged.

(no traffic)