### PR TITLE
ci: attach schema.graphql to GitHub releases

### DIFF
--- a/.github/workflows/create-tag-with-release-pr.yml
+++ b/.github/workflows/create-tag-with-release-pr.yml
@@ -64,12 +64,18 @@ jobs:
               ref: `refs/tags/${process.env.VERSION}`,
               sha: context.sha
             })
+      - name: Checkout tagged commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: |
+            saleor/graphql/schema.graphql
       - name: Create github release
         env:
           VERSION: ${{ steps.set-version.outputs.VERSION }}
           IS_LATEST: ${{ steps.check-latest.outputs.IS_LATEST }}
         run: |
-          gh release create -d "$VERSION" --repo="$GITHUB_REPOSITORY" --latest="$IS_LATEST" --generate-notes --verify-tag
+          gh release create -d "$VERSION" --repo="$GITHUB_REPOSITORY" --latest="$IS_LATEST" --generate-notes --verify-tag saleor/graphql/schema.graphql
 
   publish:
     needs: [create-release-tag]


### PR DESCRIPTION
Port https://github.com/saleor/saleor/pull/19516 so we 3.23.x releases have schemas attached correctly