### PR TITLE
Validate transaction PSP reference lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Removed the deprecated `orderAddNote` mutation, along with the `OrderAddNote` type and `OrderAddNoteInput` input. Use the `orderNoteAdd` mutation instead.
 - Removed the `DIGITAL_LINKS` value from the `OrderEventsEmailsEnum` enum and the `DIGITAL_LINK_DOWNLOADED` value from the `CustomerEventsEnum` enum. Events with these types were deleted in 3.23, along with the legacy digital content feature that emitted them.
 - Removed the always-empty `digital_lines` key from the fulfillment confirmation notification payload. Use `physical_lines`, which holds every line of the fulfillment.
+- `transactionCreate` and `transactionUpdate` now reject `pspReference` values longer than 512 characters with an `INVALID` error; invalid Payment App webhook responses create a failure event instead of causing an internal error. - #19594 by @BobSong-dev
 
 ### GraphQL API
 

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -11,7 +11,7 @@ from .....checkout import models as checkout_models
 from .....core.prices import quantize_price
 from .....order import models as order_models
 from .....order.events import transaction_event as order_transaction_event
-from .....payment import TransactionEventType
+from .....payment import PSP_REFERENCE_MAX_LENGTH, TransactionEventType
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionCreateErrorCode
 from .....payment.interface import PaymentMethodDetails
@@ -50,7 +50,12 @@ class TransactionCreateInput(BaseInputObjectType):
     name = graphene.String(description="Payment name of the transaction.")
     message = graphene.String(description="The message of the transaction.")
 
-    psp_reference = graphene.String(description="PSP Reference of the transaction.")
+    psp_reference = graphene.String(
+        description=(
+            "PSP Reference of the transaction. The maximum length is "
+            f"{PSP_REFERENCE_MAX_LENGTH} characters."
+        )
+    )
     available_actions = graphene.List(
         graphene.NonNull(TransactionActionEnum),
         description="List of all possible actions for the transaction",
@@ -90,7 +95,12 @@ class TransactionCreateInput(BaseInputObjectType):
 
 
 class TransactionEventInput(BaseInputObjectType):
-    psp_reference = graphene.String(description="PSP Reference related to this action.")
+    psp_reference = graphene.String(
+        description=(
+            "PSP Reference related to this action. The maximum length is "
+            f"{PSP_REFERENCE_MAX_LENGTH} characters."
+        )
+    )
 
     message = graphene.String(description="The message related to the event.")
 
@@ -135,6 +145,20 @@ class TransactionCreate(BaseMutation):
                     )
                 }
             ) from e
+
+    @classmethod
+    def validate_psp_reference(
+        cls, psp_reference: str | None, field_name: str, error_code: str
+    ):
+        if psp_reference and len(psp_reference) > PSP_REFERENCE_MAX_LENGTH:
+            raise ValidationError(
+                {
+                    field_name: ValidationError(
+                        f"Maximum length for `pspReference` is {PSP_REFERENCE_MAX_LENGTH}.",
+                        code=error_code,
+                    )
+                }
+            )
 
     # TODO This should be unified with metadata_manager and MetadataItemCollection
     # EXT-2054
@@ -237,10 +261,24 @@ class TransactionCreate(BaseMutation):
 
     @classmethod
     def validate_input(
-        cls, instance: checkout_models.Checkout | order_models.Order, transaction
+        cls,
+        instance: checkout_models.Checkout | order_models.Order,
+        transaction,
+        transaction_event,
     ) -> checkout_models.Checkout | order_models.Order:
         currency = instance.currency
 
+        cls.validate_psp_reference(
+            transaction.get("psp_reference"),
+            field_name="transaction",
+            error_code=TransactionCreateErrorCode.INVALID.value,
+        )
+        if transaction_event:
+            cls.validate_psp_reference(
+                transaction_event.get("psp_reference"),
+                field_name="transactionEvent",
+                error_code=TransactionCreateErrorCode.INVALID.value,
+            )
         cls.validate_money_input(
             transaction,
             currency,
@@ -342,7 +380,9 @@ class TransactionCreate(BaseMutation):
             order_or_checkout_instance, id
         )
         order_or_checkout_instance = cls.validate_input(
-            order_or_checkout_instance, transaction=transaction
+            order_or_checkout_instance,
+            transaction=transaction,
+            transaction_event=transaction_event,
         )
         payment_details_data: PaymentMethodDetails | None = None
         if payment_method_details := transaction.pop("payment_method_details", None):

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -14,7 +14,11 @@ from .....order import models as order_models
 from .....order.utils import (
     calculate_order_granted_refund_status,
 )
-from .....payment import OPTIONAL_AMOUNT_EVENTS, TransactionEventType
+from .....payment import (
+    OPTIONAL_AMOUNT_EVENTS,
+    PSP_REFERENCE_MAX_LENGTH,
+    TransactionEventType,
+)
 from .....payment import models as payment_models
 from .....payment.interface import PaymentMethodDetails
 from .....payment.lock_objects import (
@@ -91,7 +95,11 @@ class TransactionEventReport(DeprecatedModelMutation):
             required=False,
         )
         psp_reference = graphene.String(
-            description="PSP Reference of the event to report.", required=True
+            description=(
+                "PSP Reference of the event to report. The maximum length is "
+                f"{PSP_REFERENCE_MAX_LENGTH} characters."
+            ),
+            required=True,
         )
         type = graphene.Argument(
             TransactionEventTypeEnum,

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -106,9 +106,25 @@ class TransactionUpdate(TransactionCreate):
 
     @classmethod
     def validate_transaction_input(
-        cls, instance: payment_models.TransactionItem, transaction_data
+        cls,
+        instance: payment_models.TransactionItem,
+        transaction_data,
+        transaction_event_data,
     ):
+        transaction_data = transaction_data or {}
         currency = instance.currency
+        if transaction_data:
+            cls.validate_psp_reference(
+                transaction_data.get("psp_reference"),
+                field_name="transaction",
+                error_code=TransactionUpdateErrorCode.INVALID.value,
+            )
+        if transaction_event_data:
+            cls.validate_psp_reference(
+                transaction_event_data.get("psp_reference"),
+                field_name="transactionEvent",
+                error_code=TransactionUpdateErrorCode.INVALID.value,
+            )
         if transaction_data.get("available_actions") is not None:
             transaction_data["available_actions"] = list(
                 set(transaction_data.get("available_actions", []))
@@ -219,8 +235,9 @@ class TransactionUpdate(TransactionCreate):
         previous_charged_value = instance.charged_value
         previous_refunded_value = instance.refunded_value
 
+        cls.validate_transaction_input(instance, transaction, transaction_event)
+
         if transaction:
-            cls.validate_transaction_input(instance, transaction)
             cls.assign_app_to_transaction_data_if_missing(instance, transaction, app)
             cls.cleanup_and_update_metadata_data(
                 instance,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -12,7 +12,11 @@ from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....order import OrderAuthorizeStatus, OrderChargeStatus, OrderEvents, OrderStatus
 from .....order.models import Order
 from .....order.utils import update_order_authorize_data, update_order_charge_data
-from .....payment import PaymentMethodType, TransactionEventType
+from .....payment import (
+    PSP_REFERENCE_MAX_LENGTH,
+    PaymentMethodType,
+    TransactionEventType,
+)
 from .....payment.error_codes import TransactionCreateErrorCode
 from .....payment.lock_objects import (
     get_checkout_and_transaction_item_locked_for_update,
@@ -2891,3 +2895,47 @@ def test_transaction_create_checkout_completed_race_condition(
     assert order.status == OrderStatus.UNFULFILLED
     assert order.charge_status == OrderChargeStatus.NONE
     assert order.authorize_status == OrderAuthorizeStatus.FULL
+
+
+@pytest.mark.parametrize(
+    ("transaction", "transaction_event", "error_field"),
+    [
+        ({"pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1)}, None, "transaction"),
+        (
+            {},
+            {"pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1)},
+            "transactionEvent",
+        ),
+    ],
+)
+def test_transaction_create_rejects_too_long_psp_reference(
+    transaction,
+    transaction_event,
+    error_field,
+    order_with_lines,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": transaction,
+        "transaction_event": transaction_event,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["transactionCreate"]
+    assert data["errors"] == [
+        {
+            "field": error_field,
+            "message": f"Maximum length for `pspReference` is {PSP_REFERENCE_MAX_LENGTH}.",
+            "code": TransactionCreateErrorCode.INVALID.name,
+        }
+    ]
+    assert not order_with_lines.payment_transactions.exists()

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -11,7 +11,11 @@ from .....checkout.complete_checkout import create_order_from_checkout
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....order import OrderAuthorizeStatus, OrderChargeStatus, OrderEvents, OrderStatus
 from .....order.models import Order
-from .....payment import PaymentMethodType, TransactionEventType
+from .....payment import (
+    PSP_REFERENCE_MAX_LENGTH,
+    PaymentMethodType,
+    TransactionEventType,
+)
 from .....payment.error_codes import TransactionUpdateErrorCode
 from .....payment.lock_objects import (
     get_checkout_and_transaction_item_locked_for_update,
@@ -3820,3 +3824,52 @@ def test_transaction_update_checkout_completed_race_condition(
     assert order.charge_status == OrderChargeStatus.FULL
     assert order.authorize_status == OrderAuthorizeStatus.FULL
     assert order.total_charged.amount == checkout.total.gross.amount
+
+
+@pytest.mark.parametrize(
+    ("transaction_data", "transaction_event", "error_field"),
+    [
+        (
+            {"pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1)},
+            None,
+            "transaction",
+        ),
+        (
+            None,
+            {"pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1)},
+            "transactionEvent",
+        ),
+    ],
+)
+def test_transaction_update_rejects_too_long_psp_reference(
+    transaction_data,
+    transaction_event,
+    error_field,
+    transaction_item_created_by_app,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    transaction = transaction_item_created_by_app
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction": transaction_data,
+        "transaction_event": transaction_event,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["transactionUpdate"]
+    assert data["errors"] == [
+        {
+            "field": error_field,
+            "message": f"Maximum length for `pspReference` is {PSP_REFERENCE_MAX_LENGTH}.",
+            "code": TransactionUpdateErrorCode.INVALID.name,
+        }
+    ]
+    assert not transaction.events.exists()

--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+PSP_REFERENCE_MAX_LENGTH = 512
+
 
 class PaymentError(Exception):
     def __init__(self, message, code=None):

--- a/saleor/payment/models.py
+++ b/saleor/payment/models.py
@@ -18,6 +18,7 @@ from ..core.models import ModelWithMetadata
 from ..core.taxes import zero_money
 from ..permission.enums import PaymentPermissions
 from . import (
+    PSP_REFERENCE_MAX_LENGTH,
     ChargeStatus,
     CustomPaymentChoices,
     PaymentMethodType,
@@ -36,7 +37,9 @@ class TransactionItem(ModelWithMetadata):
     idempotency_key = models.CharField(max_length=512, blank=True, null=True)
     name = models.CharField(max_length=512, blank=True, null=True, default="")
     message = models.CharField(max_length=512, blank=True, null=True, default="")
-    psp_reference = models.CharField(max_length=512, blank=True, null=True)
+    psp_reference = models.CharField(
+        max_length=PSP_REFERENCE_MAX_LENGTH, blank=True, null=True
+    )
     available_actions = ArrayField(
         models.CharField(max_length=128, choices=TransactionAction.CHOICES),
         default=list,
@@ -206,7 +209,9 @@ class TransactionItem(ModelWithMetadata):
 class TransactionEvent(models.Model):
     created_at = models.DateTimeField(default=timezone.now)
     idempotency_key = models.CharField(max_length=512, blank=True, null=True)
-    psp_reference = models.CharField(max_length=512, blank=True, null=True)
+    psp_reference = models.CharField(
+        max_length=PSP_REFERENCE_MAX_LENGTH, blank=True, null=True
+    )
     message = models.CharField(max_length=512, blank=True, null=True, default="")
     transaction = models.ForeignKey(
         TransactionItem, related_name="events", on_delete=models.CASCADE

--- a/saleor/webhook/response_schemas/transaction.py
+++ b/saleor/webhook/response_schemas/transaction.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, HttpUrl, field_validator
 from ...graphql.core.utils import str_to_enum
 from ...payment import (
     OPTIONAL_PSP_REFERENCE_EVENTS,
+    PSP_REFERENCE_MAX_LENGTH,
     PaymentMethodType,
     TransactionAction,
     TransactionEventType,
@@ -143,6 +144,7 @@ class TransactionBaseSchema(BaseModel):
         Field(
             validation_alias="pspReference",
             default=None,
+            max_length=PSP_REFERENCE_MAX_LENGTH,
             description=(
                 "PSP reference received from payment provider. Optional for the following results: "
                 + ", ".join([event.upper() for event in OPTIONAL_PSP_REFERENCE_EVENTS])
@@ -265,6 +267,7 @@ class TransactionAsyncSchema(BaseModel):
         str,
         Field(
             validation_alias="pspReference",
+            max_length=PSP_REFERENCE_MAX_LENGTH,
             description="PSP reference received from payment provider.",
         ),
     ]
@@ -291,6 +294,7 @@ class TransactionSyncFailureSchema(TransactionBaseSchema):
         Field(
             validation_alias="pspReference",
             default=None,
+            max_length=PSP_REFERENCE_MAX_LENGTH,
             description="PSP reference received from payment provider.",
         ),
     ]
@@ -301,6 +305,7 @@ class TransactionSyncSuccessSchema(TransactionBaseSchema):
         str,
         Field(
             validation_alias="pspReference",
+            max_length=PSP_REFERENCE_MAX_LENGTH,
             description="PSP reference received from payment provider.",
         ),
     ]
@@ -402,6 +407,7 @@ class TransactionSessionFailureSchema(TransactionSessionBaseSchema):
         Field(
             validation_alias="pspReference",
             default=None,
+            max_length=PSP_REFERENCE_MAX_LENGTH,
             description="PSP reference received from payment provider.",
         ),
     ]
@@ -417,6 +423,7 @@ class TransactionSessionCancelSuccessSchema(TransactionSessionBaseSchema):
         Field(
             validation_alias="pspReference",
             default=None,
+            max_length=PSP_REFERENCE_MAX_LENGTH,
             description="PSP reference received from payment provider.",
         ),
     ]
@@ -435,6 +442,7 @@ class TransactionSessionActionRequiredSchema(TransactionSessionBaseSchema):
         Field(
             validation_alias="pspReference",
             default=None,
+            max_length=PSP_REFERENCE_MAX_LENGTH,
             description="PSP reference received from payment provider.",
         ),
     ]
@@ -454,6 +462,7 @@ class TransactionSessionSuccessSchema(TransactionSessionBaseSchema):
         str,
         Field(
             validation_alias="pspReference",
+            max_length=PSP_REFERENCE_MAX_LENGTH,
             description="PSP reference received from payment provider.",
         ),
     ]

--- a/saleor/webhook/tests/response_schemas/test_transaction.py
+++ b/saleor/webhook/tests/response_schemas/test_transaction.py
@@ -7,7 +7,11 @@ from django.utils import timezone
 from freezegun import freeze_time
 from pydantic import ValidationError
 
-from ....payment import TransactionAction, TransactionEventType
+from ....payment import (
+    PSP_REFERENCE_MAX_LENGTH,
+    TransactionAction,
+    TransactionEventType,
+)
 from ...response_schemas.transaction import (
     PaymentGatewayInitializeSessionSchema,
     TransactionBaseSchema,
@@ -22,6 +26,7 @@ from ...response_schemas.transaction import (
     TransactionRefundRequestedSyncSuccessSchema,
     TransactionSessionActionRequiredSchema,
     TransactionSessionBaseSchema,
+    TransactionSessionCancelSuccessSchema,
     TransactionSessionFailureSchema,
     TransactionSessionSuccessSchema,
 )
@@ -1274,3 +1279,71 @@ def test_payment_gateway_initialize_schema_invalid_data(data_value):
     # then
     assert len(exc_info.value.errors()) == 1
     assert exc_info.value.errors()[0]["loc"] == ("data",)
+
+
+@pytest.mark.parametrize(
+    ("schema", "data"),
+    [
+        (
+            TransactionBaseSchema,
+            {
+                "pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1),
+                "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+            },
+        ),
+        (
+            TransactionChargeRequestedAsyncSchema,
+            {"pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1)},
+        ),
+        (
+            TransactionChargeRequestedSyncFailureSchema,
+            {
+                "pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1),
+                "result": TransactionEventType.CHARGE_FAILURE.upper(),
+            },
+        ),
+        (
+            TransactionChargeRequestedSyncSuccessSchema,
+            {
+                "pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1),
+                "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+            },
+        ),
+        (
+            TransactionSessionFailureSchema,
+            {
+                "pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1),
+                "result": TransactionEventType.CHARGE_FAILURE.upper(),
+            },
+        ),
+        (
+            TransactionSessionCancelSuccessSchema,
+            {
+                "pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1),
+                "result": TransactionEventType.CANCEL_SUCCESS.upper(),
+            },
+        ),
+        (
+            TransactionSessionActionRequiredSchema,
+            {
+                "pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1),
+                "result": TransactionEventType.CHARGE_ACTION_REQUIRED.upper(),
+            },
+        ),
+        (
+            TransactionSessionSuccessSchema,
+            {
+                "pspReference": "p" * (PSP_REFERENCE_MAX_LENGTH + 1),
+                "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+            },
+        ),
+    ],
+)
+def test_transaction_schemas_reject_too_long_psp_reference(schema, data):
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        schema.model_validate(data)
+
+    # then
+    assert len(exc_info.value.errors()) == 1
+    assert exc_info.value.errors()[0]["loc"] == ("pspReference",)


### PR DESCRIPTION
Fixes #12696

## Summary

- Return an `INVALID` mutation error before persisting an overlong `pspReference` in `transactionCreate` and `transactionUpdate`, including nested transaction events.
- Enforce the same 512-character boundary while parsing Payment App transaction webhook responses, allowing the existing failure-event flow to handle invalid responses safely.
- Document the input limit and add GraphQL and response-schema regression coverage.

## Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

## Docs

- [ ] Link to documentation: not required; the GraphQL input descriptions document the limit.

## Pull Request Checklist

- [x] Privileged queries and mutations are guarded by existing permission checks.
- [x] Database queries remain constant; no migration is needed.
- [x] The changes are covered by test cases.
- [ ] All new fields/inputs/mutations have added-version labels (none added).
- [ ] All migrations have dependencies (none added).
- [ ] All indexes are added concurrently (none added).
- [ ] All RunSQL and RunPython migrations have a revert option (none added).

## Verification

- `uvx ruff check` and `uvx ruff format --check` pass for changed Python files.
- `python -m compileall` passes for changed Python files.
- Full pytest could not be run locally because the repository's `pytest-memray` dev dependency does not support Windows; upstream CI should run the targeted suite on Linux.