### PR TITLE
Fix permission checks for attribute value and bulk mutations to respect attribute type

### DIFF
--- a/saleor/graphql/attribute/bulk_mutations.py
+++ b/saleor/graphql/attribute/bulk_mutations.py
@@ -5,7 +5,6 @@ from django.db.models import Exists, OuterRef, Q
 
 from ...attribute import models
 from ...attribute.lock_objects import attribute_value_qs_select_for_update
-from ...permission.enums import PageTypePermissions
 from ...product import models as product_models
 from ...product.utils.search_helpers import (
     mark_products_search_vector_as_dirty_in_batches,
@@ -18,6 +17,10 @@ from ..core.types import AttributeError, NonNullList
 from ..core.utils import WebhookEventInfo
 from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import resolve_global_ids_to_primary_keys
+from .mutations.permissions import (
+    check_any_attribute_type_permission,
+    check_attribute_type_permissions,
+)
 from .types import Attribute, AttributeValue
 
 
@@ -33,10 +36,14 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
         )
 
     class Meta:
-        description = "Deletes attributes."
+        description = (
+            "Deletes attributes.\n\nRequires one of the following permissions, "
+            "depending on the type of each attribute: "
+            "MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, "
+            "MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes."
+        )
         model = models.Attribute
         object_type = Attribute
-        permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
         webhook_events_info = [
@@ -51,11 +58,19 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
     def perform_mutation(  # type: ignore[override]
         cls, root, info: ResolveInfo, /, *, ids
     ):
+        # Concrete permissions are checked after attribute types are resolved.
+        check_any_attribute_type_permission(cls, info.context)
         if not ids:
             return 0, {}
         if size_error := cls.validate_input_size(ids):
             return 0, size_error
         _, attribute_pks = resolve_global_ids_to_primary_keys(ids, "Attribute")
+        attribute_types = (
+            models.Attribute.objects.filter(pk__in=attribute_pks)
+            .values_list("type", flat=True)
+            .distinct()
+        )
+        check_attribute_type_permissions(cls, info.context, attribute_types)
         product_ids = cls.get_product_ids_to_update(attribute_pks)
         response = super().perform_mutation(root, info, ids=ids)
         mark_products_search_vector_as_dirty_in_batches(product_ids)
@@ -107,10 +122,14 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
         )
 
     class Meta:
-        description = "Deletes values of attributes."
+        description = (
+            "Deletes values of attributes.\n\nRequires one of the following "
+            "permissions, depending on the type of each value's attribute: "
+            "MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, "
+            "MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes."
+        )
         model = models.AttributeValue
         object_type = AttributeValue
-        permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
         webhook_events_info = [
@@ -129,12 +148,20 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
     def perform_mutation(  # type: ignore[override]
         cls, root, info: ResolveInfo, /, *, ids
     ):
+        # Concrete permissions are checked after attribute types are resolved.
+        check_any_attribute_type_permission(cls, info.context)
         if not ids:
             return 0, {}
         if size_error := cls.validate_input_size(ids):
             return 0, size_error
-        _, attribute_pks = resolve_global_ids_to_primary_keys(ids, "AttributeValue")
-        product_ids = cls.get_product_ids_to_update(attribute_pks)
+        _, value_pks = resolve_global_ids_to_primary_keys(ids, "AttributeValue")
+        attribute_types = (
+            models.AttributeValue.objects.filter(pk__in=value_pks)
+            .values_list("attribute__type", flat=True)
+            .distinct()
+        )
+        check_attribute_type_permissions(cls, info.context, attribute_types)
+        product_ids = cls.get_product_ids_to_update(value_pks)
         response = super().perform_mutation(root, info, ids=ids)
         mark_products_search_vector_as_dirty_in_batches(product_ids)
         return response

--- a/saleor/graphql/attribute/mutations/attribute_bulk_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_create.py
@@ -383,7 +383,21 @@ class AttributeBulkCreate(BaseMutation):
         )
 
         # check permissions based on attribute type
-        permissions = (ATTRIBUTE_TYPE_PERMISSION_MAP[cleaned_input["type"]],)
+        attribute_type = cleaned_input["type"]
+        permission = ATTRIBUTE_TYPE_PERMISSION_MAP.get(attribute_type)
+        if permission is None:
+            index_error_map[attribute_index].append(
+                AttributeBulkCreateError(
+                    path="type",
+                    message=(
+                        f"No permission is defined for attribute type {attribute_type}."
+                    ),
+                    code=AttributeBulkCreateErrorCode.INVALID.value,
+                )
+            )
+            return None
+
+        permissions = (permission,)
         if not cls.check_permissions(info.context, permissions):
             index_error_map[attribute_index].append(
                 AttributeBulkCreateError(

--- a/saleor/graphql/attribute/mutations/attribute_bulk_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_create.py
@@ -16,7 +16,6 @@ from ....attribute import (
 from ....attribute.error_codes import AttributeBulkCreateErrorCode
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils import prepare_unique_slug
-from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
 from ...core import ResolveInfo
@@ -27,10 +26,10 @@ from ...core.mutations import BaseMutation, DeprecatedModelMutation
 from ...core.types import AttributeBulkCreateError, BaseObjectType, NonNullList
 from ...core.utils import WebhookEventInfo, get_duplicated_values
 from ...plugins.dataloaders import get_plugin_manager_promise
-from ..enums import AttributeTypeEnum
 from ..mutations.attribute_create import AttributeCreateInput, AttributeValueCreateInput
 from ..types import Attribute
 from .mixins import AttributeMixin
+from .permissions import ATTRIBUTE_TYPE_PERMISSION_MAP
 
 ONLY_SWATCH_FIELDS = ["file_url", "content_type", "value"]
 DEPRECATED_ATTR_FIELDS = [
@@ -384,12 +383,7 @@ class AttributeBulkCreate(BaseMutation):
         )
 
         # check permissions based on attribute type
-        permissions: tuple[ProductTypePermissions] | tuple[PageTypePermissions]
-        if cleaned_input["type"] == AttributeTypeEnum.PRODUCT_TYPE.value:
-            permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
-        else:
-            permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
-
+        permissions = (ATTRIBUTE_TYPE_PERMISSION_MAP[cleaned_input["type"]],)
         if not cls.check_permissions(info.context, permissions):
             index_error_map[attribute_index].append(
                 AttributeBulkCreateError(

--- a/saleor/graphql/attribute/mutations/attribute_bulk_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_update.py
@@ -19,7 +19,6 @@ from ....attribute.lock_objects import (
 )
 from ....core.tracing import traced_atomic_transaction
 from ....page.utils import mark_pages_search_vector_as_dirty_in_batches
-from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....product.utils.search_helpers import (
     mark_products_search_vector_as_dirty_in_batches,
 )
@@ -43,11 +42,11 @@ from ...core.utils import (
 )
 from ...core.validators import validate_one_of_args_is_in_mutation
 from ...plugins.dataloaders import get_plugin_manager_promise
-from ..enums import AttributeTypeEnum
 from ..types import Attribute
 from .attribute_bulk_create import DEPRECATED_ATTR_FIELDS, clean_values
 from .attribute_update import AttributeUpdateInput
 from .mixins import AttributeMixin
+from .permissions import ATTRIBUTE_TYPE_PERMISSION_MAP
 from .utils import (
     get_page_ids_to_search_index_update_for_attribute_values,
     get_product_ids_to_search_index_update_for_attribute_values,
@@ -378,12 +377,7 @@ class AttributeBulkUpdate(BaseMutation):
         attribute_data["instance"] = attr
 
         # check permissions based on attribute type
-        permissions: tuple[ProductTypePermissions] | tuple[PageTypePermissions]
-        if attr.type == AttributeTypeEnum.PRODUCT_TYPE.value:
-            permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
-        else:
-            permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
-
+        permissions = (ATTRIBUTE_TYPE_PERMISSION_MAP[attr.type],)
         if not cls.check_permissions(info.context, permissions):
             index_error_map[attribute_index].append(
                 AttributeBulkUpdateError(

--- a/saleor/graphql/attribute/mutations/attribute_bulk_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_bulk_update.py
@@ -377,7 +377,19 @@ class AttributeBulkUpdate(BaseMutation):
         attribute_data["instance"] = attr
 
         # check permissions based on attribute type
-        permissions = (ATTRIBUTE_TYPE_PERMISSION_MAP[attr.type],)
+        permission = ATTRIBUTE_TYPE_PERMISSION_MAP.get(attr.type)
+        if permission is None:
+            index_error_map[attribute_index].append(
+                AttributeBulkUpdateError(
+                    message=(
+                        f"No permission is defined for attribute type {attr.type}."
+                    ),
+                    code=AttributeBulkUpdateErrorCode.INVALID.value,
+                )
+            )
+            return None
+
+        permissions = (permission,)
         if not cls.check_permissions(info.context, permissions):
             index_error_map[attribute_index].append(
                 AttributeBulkUpdateError(

--- a/saleor/graphql/attribute/mutations/attribute_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_create.py
@@ -4,8 +4,6 @@ from django.core.exceptions import ValidationError
 from ....attribute import AttributeInputType
 from ....attribute import models as models
 from ....attribute.error_codes import AttributeErrorCode
-from ....core.exceptions import PermissionDenied
-from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
@@ -21,6 +19,7 @@ from ..descriptions import AttributeDescriptions, AttributeValueDescriptions
 from ..enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 from ..types import Attribute
 from .mixins import REFERENCE_TYPES_LIMIT, AttributeMixin
+from .permissions import check_attribute_type_permissions
 
 
 class AttributeValueInput(BaseInputObjectType):
@@ -168,13 +167,7 @@ class AttributeCreate(AttributeMixin, DeprecatedModelMutation):
         cls, _root, info: ResolveInfo, /, *, input
     ):
         # check permissions based on attribute type
-        permissions: tuple[ProductTypePermissions] | tuple[PageTypePermissions]
-        if input["type"] == AttributeTypeEnum.PRODUCT_TYPE.value:
-            permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
-        else:
-            permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
-        if not cls.check_permissions(info.context, permissions):
-            raise PermissionDenied(permissions=permissions)
+        check_attribute_type_permissions(cls, info.context, [input["type"]])
 
         cls.validate_reference_types_limit(input)
         instance = models.Attribute()

--- a/saleor/graphql/attribute/mutations/attribute_delete.py
+++ b/saleor/graphql/attribute/mutations/attribute_delete.py
@@ -2,13 +2,10 @@ import graphene
 from django.db import transaction
 from django.db.models import Exists, OuterRef
 
-from ....attribute import AttributeType
 from ....attribute import models as models
 from ....attribute.lock_objects import attribute_value_qs_select_for_update
-from ....core.exceptions import PermissionDenied
 from ....page import models as page_models
 from ....page.utils import mark_pages_search_vector_as_dirty_in_batches
-from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....product import models as product_models
 from ....product.utils.search_helpers import (
     mark_products_search_vector_as_dirty_in_batches,
@@ -21,6 +18,10 @@ from ...core.types import AttributeError
 from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Attribute
+from .permissions import (
+    check_any_attribute_type_permission,
+    check_attribute_type_permissions,
+)
 
 
 class AttributeDelete(ModelDeleteMutation, ModelWithExtRefMutation):
@@ -66,23 +67,9 @@ class AttributeDelete(ModelDeleteMutation, ModelWithExtRefMutation):
     ):
         """Perform a mutation that deletes a model instance."""
         # Concrete permission is checked after instance is resolved.
-        type_permissions = (
-            ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-            PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
-        )
-        if not cls.check_permissions(info.context, type_permissions):
-            raise PermissionDenied(permissions=type_permissions)
-
+        check_any_attribute_type_permission(cls, info.context)
         instance = cls.get_instance(info, external_reference=external_reference, id=id)
-
-        # Check permissions based on attribute type
-        permissions: tuple[ProductTypePermissions] | tuple[PageTypePermissions]
-        if instance.type == AttributeType.PRODUCT_TYPE:
-            permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
-        else:
-            permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
-        if not cls.check_permissions(info.context, permissions):
-            raise PermissionDenied(permissions=permissions)
+        check_attribute_type_permissions(cls, info.context, [instance.type])
 
         product_ids = cls.get_product_ids_to_search_index_update(instance)
         page_ids = cls.get_page_ids_to_search_index_update(instance)

--- a/saleor/graphql/attribute/mutations/attribute_reorder_values.py
+++ b/saleor/graphql/attribute/mutations/attribute_reorder_values.py
@@ -4,7 +4,6 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from ....attribute import models as models
 from ....attribute.error_codes import AttributeErrorCode
 from ....core.tracing import traced_atomic_transaction
-from ....permission.enums import ProductTypePermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
@@ -16,6 +15,10 @@ from ...core.utils import WebhookEventInfo
 from ...core.utils.reordering import perform_reordering
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Attribute, AttributeValue
+from .permissions import (
+    check_any_attribute_type_permission,
+    check_attribute_type_permissions,
+)
 
 
 class AttributeReorderValues(BaseMutation):
@@ -24,9 +27,13 @@ class AttributeReorderValues(BaseMutation):
     )
 
     class Meta:
-        description = "Reorder the values of an attribute."
+        description = (
+            "Reorder the values of an attribute.\n\nRequires one of the following "
+            "permissions, depending on the attribute type: "
+            "MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, "
+            "MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes."
+        )
         doc_category = DOC_CATEGORY_ATTRIBUTES
-        permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
         webhook_events_info = [
@@ -54,6 +61,8 @@ class AttributeReorderValues(BaseMutation):
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, attribute_id, moves
     ):
+        # Concrete permission is checked after the attribute is resolved.
+        check_any_attribute_type_permission(cls, info.context)
         pk = cls.get_global_id_or_error(
             attribute_id, only_type=Attribute, field="attribute_id"
         )
@@ -69,6 +78,8 @@ class AttributeReorderValues(BaseMutation):
                     )
                 }
             ) from e
+
+        check_attribute_type_permissions(cls, info.context, [attribute.type])
 
         values_m2m = attribute.values.all()
         operations = {}

--- a/saleor/graphql/attribute/mutations/attribute_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_update.py
@@ -1,12 +1,9 @@
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....attribute import AttributeType
 from ....attribute import models as models
 from ....attribute.error_codes import AttributeErrorCode
-from ....core.exceptions import PermissionDenied
 from ....page.utils import mark_pages_search_vector_as_dirty_in_batches
-from ....permission.enums import PageTypePermissions, ProductTypePermissions
 from ....product.utils.search_helpers import (
     mark_products_search_vector_as_dirty_in_batches,
 )
@@ -24,6 +21,10 @@ from ..descriptions import AttributeDescriptions, AttributeValueDescriptions
 from ..types import Attribute
 from .attribute_create import AttributeValueInput
 from .mixins import REFERENCE_TYPES_LIMIT, AttributeMixin
+from .permissions import (
+    check_any_attribute_type_permission,
+    check_attribute_type_permissions,
+)
 from .utils import (
     get_page_ids_to_search_index_update_for_attribute_values,
     get_product_ids_to_search_index_update_for_attribute_values,
@@ -165,23 +166,9 @@ class AttributeUpdate(AttributeMixin, ModelWithExtRefMutation):
         cls, _root, info: ResolveInfo, /, *, external_reference=None, id=None, input
     ):
         # Concrete permission is checked after instance is resolved.
-        type_permissions = (
-            ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-            PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
-        )
-        if not cls.check_permissions(info.context, type_permissions):
-            raise PermissionDenied(permissions=type_permissions)
-
+        check_any_attribute_type_permission(cls, info.context)
         instance = cls.get_instance(info, external_reference=external_reference, id=id)
-
-        # Check permissions based on attribute type
-        permissions: tuple[ProductTypePermissions] | tuple[PageTypePermissions]
-        if instance.type == AttributeType.PRODUCT_TYPE:
-            permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
-        else:
-            permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
-        if not cls.check_permissions(info.context, permissions):
-            raise PermissionDenied(permissions=permissions)
+        check_attribute_type_permissions(cls, info.context, [instance.type])
 
         cls.validate_reference_types_limit(input)
         # Do cleaning and uniqueness checks

--- a/saleor/graphql/attribute/mutations/attribute_value_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_create.py
@@ -5,7 +5,6 @@ from ....attribute import AttributeInputType
 from ....attribute import models as models
 from ....attribute.error_codes import AttributeErrorCode
 from ....core.utils import generate_unique_slug
-from ....permission.enums import ProductPermissions
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
@@ -16,6 +15,10 @@ from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Attribute, AttributeValue
 from .attribute_create import AttributeValueCreateInput
 from .mixins import AttributeMixin
+from .permissions import (
+    check_any_attribute_type_permission,
+    check_attribute_type_permissions,
+)
 from .validators import validate_value_is_unique
 
 
@@ -37,8 +40,12 @@ class AttributeValueCreate(AttributeMixin, DeprecatedModelMutation):
     class Meta:
         model = models.AttributeValue
         object_type = AttributeValue
-        description = "Creates a value for an attribute."
-        permissions = (ProductPermissions.MANAGE_PRODUCTS,)
+        description = (
+            "Creates a value for an attribute.\n\nRequires one of the following "
+            "permissions, depending on the attribute type: "
+            "MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, "
+            "MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes."
+        )
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
         webhook_events_info = [
@@ -95,7 +102,10 @@ class AttributeValueCreate(AttributeMixin, DeprecatedModelMutation):
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, attribute_id, input
     ):
+        # Concrete permission is checked after the attribute is resolved.
+        check_any_attribute_type_permission(cls, info.context)
         attribute = cls.get_node_or_error(info, attribute_id, only_type=Attribute)
+        check_attribute_type_permissions(cls, info.context, [attribute.type])
         instance = models.AttributeValue(attribute=attribute)
         cleaned_input = cls.clean_input(info, instance, input)
         instance = cls.construct_instance(instance, cleaned_input)

--- a/saleor/graphql/attribute/mutations/attribute_value_delete.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_delete.py
@@ -4,7 +4,6 @@ import graphene
 
 from ....attribute import models as models
 from ....page.utils import mark_pages_search_vector_as_dirty_in_batches
-from ....permission.enums import ProductTypePermissions
 from ....product.utils.search_helpers import (
     mark_products_search_vector_as_dirty_in_batches,
 )
@@ -16,6 +15,10 @@ from ...core.types import AttributeError
 from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Attribute, AttributeValue
+from .permissions import (
+    check_any_attribute_type_permission,
+    check_attribute_type_permissions,
+)
 from .utils import (
     get_page_ids_to_search_index_update_for_attribute_values,
     get_product_ids_to_search_index_update_for_attribute_values,
@@ -35,8 +38,12 @@ class AttributeValueDelete(ModelDeleteMutation, ModelWithExtRefMutation):
     class Meta:
         model = models.AttributeValue
         object_type = AttributeValue
-        description = "Deletes a value of an attribute."
-        permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
+        description = (
+            "Deletes a value of an attribute.\n\nRequires one of the following "
+            "permissions, depending on the type of the value's attribute: "
+            "MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, "
+            "MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes."
+        )
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
         webhook_events_info = [
@@ -54,8 +61,11 @@ class AttributeValueDelete(ModelDeleteMutation, ModelWithExtRefMutation):
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, external_reference=None, id=None
     ):
+        # Concrete permission is checked after the instance is resolved.
+        check_any_attribute_type_permission(cls, info.context)
         instance = cls.get_instance(info, external_reference=external_reference, id=id)
         instance = cast(models.AttributeValue, instance)
+        check_attribute_type_permissions(cls, info.context, [instance.attribute.type])
         product_ids = get_product_ids_to_search_index_update_for_attribute_values(
             [instance]
         )

--- a/saleor/graphql/attribute/mutations/attribute_value_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_update.py
@@ -4,7 +4,6 @@ from django.db.models import Exists, OuterRef, Q
 from ....attribute import models as models
 from ....page import models as page_models
 from ....page.utils import mark_pages_search_vector_as_dirty_in_batches
-from ....permission.enums import ProductTypePermissions
 from ....product import models as product_models
 from ....product.utils.search_helpers import (
     mark_products_search_vector_as_dirty_in_batches,
@@ -14,11 +13,15 @@ from ...core import ResolveInfo
 from ...core.context import ChannelContext
 from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import AttributeError
-from ...core.utils import WebhookEventInfo
+from ...core.utils import WebhookEventInfo, from_global_id_or_error
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Attribute, AttributeValue
 from .attribute_update import AttributeValueUpdateInput
 from .attribute_value_create import AttributeValueCreate
+from .permissions import (
+    check_any_attribute_type_permission,
+    check_attribute_type_permissions,
+)
 
 
 class AttributeValueUpdate(AttributeValueCreate, ModelWithExtRefMutation):
@@ -39,8 +42,12 @@ class AttributeValueUpdate(AttributeValueCreate, ModelWithExtRefMutation):
     class Meta:
         model = models.AttributeValue
         object_type = AttributeValue
-        description = "Updates value of an attribute."
-        permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
+        description = (
+            "Updates value of an attribute.\n\nRequires one of the following "
+            "permissions, depending on the type of the value's attribute: "
+            "MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, "
+            "MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes."
+        )
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
         webhook_events_info = [
@@ -66,6 +73,14 @@ class AttributeValueUpdate(AttributeValueCreate, ModelWithExtRefMutation):
 
     @classmethod
     def perform_mutation(cls, root, info: ResolveInfo, /, **data):
+        # Concrete permission is checked once the value's attribute type is known.
+        check_any_attribute_type_permission(cls, info.context)
+        object_id = cls.get_object_id(**data)
+        _, pk = from_global_id_or_error(object_id, AttributeValue, raise_error=True)
+        attribute_types = models.AttributeValue.objects.filter(pk=pk).values_list(
+            "attribute__type", flat=True
+        )
+        check_attribute_type_permissions(cls, info.context, attribute_types)
         return super(AttributeValueCreate, cls).perform_mutation(root, info, **data)
 
     @classmethod

--- a/saleor/graphql/attribute/mutations/permissions.py
+++ b/saleor/graphql/attribute/mutations/permissions.py
@@ -35,8 +35,19 @@ def check_any_attribute_type_permission(
 def check_attribute_type_permissions(
     mutation_cls: type[BaseMutation], context, attribute_types: Iterable[str]
 ) -> None:
-    """Require the permission matching each of the given attribute types."""
+    """Require the permission matching each of the given attribute types.
+
+    An attribute type missing from `ATTRIBUTE_TYPE_PERMISSION_MAP` is denied
+    rather than allowed, so adding a type without mapping it fails closed.
+    """
     attribute_types_set = set(attribute_types)
+    if unmapped_types := attribute_types_set - ATTRIBUTE_TYPE_PERMISSION_MAP.keys():
+        raise PermissionDenied(
+            message=(
+                "No permission is defined for attribute type "
+                f"{sorted(unmapped_types)[0]}."
+            )
+        )
     missing_permissions = [
         permission
         for attribute_type, permission in ATTRIBUTE_TYPE_PERMISSION_MAP.items()

--- a/saleor/graphql/attribute/mutations/permissions.py
+++ b/saleor/graphql/attribute/mutations/permissions.py
@@ -1,0 +1,47 @@
+from collections.abc import Iterable
+
+from ....attribute import AttributeType
+from ....core.exceptions import PermissionDenied
+from ....permission.enums import (
+    BasePermissionEnum,
+    PageTypePermissions,
+    ProductTypePermissions,
+)
+from ...core.mutations import BaseMutation
+
+ATTRIBUTE_TYPE_PERMISSION_MAP: dict[str, BasePermissionEnum] = {
+    AttributeType.PRODUCT_TYPE: (
+        ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES
+    ),
+    AttributeType.PAGE_TYPE: PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+}
+
+
+def check_any_attribute_type_permission(
+    mutation_cls: type[BaseMutation], context
+) -> None:
+    """Require any of the attribute type permissions.
+
+    Used as a pre-gate before the mutation input is resolved, so permission
+    errors take precedence over validation errors. The concrete permission is
+    checked with `check_attribute_type_permissions` once the target attribute
+    types are known.
+    """
+    permissions = tuple(ATTRIBUTE_TYPE_PERMISSION_MAP.values())
+    if not mutation_cls.check_permissions(context, permissions):
+        raise PermissionDenied(permissions=permissions)
+
+
+def check_attribute_type_permissions(
+    mutation_cls: type[BaseMutation], context, attribute_types: Iterable[str]
+) -> None:
+    """Require the permission matching each of the given attribute types."""
+    attribute_types_set = set(attribute_types)
+    missing_permissions = [
+        permission
+        for attribute_type, permission in ATTRIBUTE_TYPE_PERMISSION_MAP.items()
+        if attribute_type in attribute_types_set
+        and not mutation_cls.check_permissions(context, (permission,))
+    ]
+    if missing_permissions:
+        raise PermissionDenied(permissions=missing_permissions)

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_create.py
@@ -809,3 +809,47 @@ def test_attribute_bulk_create_with_invalid_reference_types(
         assert len(result["errors"]) == 1
         assert result["errors"][0]["code"] == AttributeBulkCreateErrorCode.INVALID.name
         assert result["errors"][0]["path"] == "referenceTypes"
+
+
+def test_attribute_type_without_mapped_permission_returns_error(
+    staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_page_types_and_attributes,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_product_types_and_attributes,
+        permission_manage_page_types_and_attributes,
+    )
+    attribute_name = "Test Attribute"
+    variables = {
+        "attributes": [
+            {"name": attribute_name, "type": AttributeTypeEnum.PRODUCT_TYPE.name}
+        ]
+    }
+
+    # when
+    with patch.dict(
+        "saleor.graphql.attribute.mutations.attribute_bulk_create."
+        "ATTRIBUTE_TYPE_PERMISSION_MAP",
+        {},
+        clear=True,
+    ):
+        response = staff_api_client.post_graphql(
+            ATTRIBUTE_BULK_CREATE_MUTATION, variables
+        )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["attributeBulkCreate"]
+    assert data["count"] == 0
+    assert len(data["results"]) == 1
+    errors = data["results"][0]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["path"] == "type"
+    assert errors[0]["code"] == AttributeBulkCreateErrorCode.INVALID.name
+    assert errors[0]["message"] == (
+        "No permission is defined for attribute type "
+        f"{AttributeTypeEnum.PRODUCT_TYPE.value}."
+    )
+    assert Attribute.objects.filter(name=attribute_name).exists() is False

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_update.py
@@ -1153,3 +1153,48 @@ def test_attribute_bulk_update_invalid_reference_types(
         assert len(result["errors"]) == 1
         assert result["errors"][0]["code"] == AttributeBulkUpdateErrorCode.INVALID.name
         assert result["errors"][0]["path"] == "referenceTypes"
+
+
+def test_attribute_type_without_mapped_permission_returns_error(
+    staff_api_client,
+    color_attribute,
+    permission_manage_product_types_and_attributes,
+    permission_manage_page_types_and_attributes,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_product_types_and_attributes,
+        permission_manage_page_types_and_attributes,
+    )
+    original_name = color_attribute.name
+    attributes = [
+        {
+            "id": graphene.Node.to_global_id("Attribute", color_attribute.pk),
+            "fields": {"name": "NewName"},
+        }
+    ]
+
+    # when
+    with patch.dict(
+        "saleor.graphql.attribute.mutations.attribute_bulk_update."
+        "ATTRIBUTE_TYPE_PERMISSION_MAP",
+        {},
+        clear=True,
+    ):
+        response = staff_api_client.post_graphql(
+            ATTRIBUTE_BULK_UPDATE_MUTATION, {"attributes": attributes}
+        )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["attributeBulkUpdate"]
+    assert data["count"] == 0
+    assert len(data["results"]) == 1
+    errors = data["results"][0]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == AttributeBulkUpdateErrorCode.INVALID.name
+    assert errors[0]["message"] == (
+        f"No permission is defined for attribute type {color_attribute.type}."
+    )
+    color_attribute.refresh_from_db(fields=("name",))
+    assert color_attribute.name == original_name

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_delete.py
@@ -330,3 +330,32 @@ def test_delete_product_attribute_without_product_type_permission(
     # then
     assert_no_permission(response)
     assert attribute._meta.model.objects.filter(pk=attribute.pk).exists()
+
+
+def test_attribute_type_without_mapped_permission_is_denied(
+    staff_api_client,
+    color_attribute,
+    permission_manage_product_types_and_attributes,
+    permission_manage_page_types_and_attributes,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_product_types_and_attributes,
+        permission_manage_page_types_and_attributes,
+    )
+    variables = {"id": graphene.Node.to_global_id("Attribute", color_attribute.pk)}
+
+    # when
+    with mock.patch.dict(
+        "saleor.graphql.attribute.mutations.permissions.ATTRIBUTE_TYPE_PERMISSION_MAP",
+        {},
+        clear=True,
+    ):
+        response = staff_api_client.post_graphql(ATTRIBUTE_DELETE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)
+    assert (
+        color_attribute._meta.model.objects.filter(pk=color_attribute.pk).exists()
+        is True
+    )

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_reorder_values.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_reorder_values.py
@@ -2,6 +2,7 @@ import json
 from unittest import mock
 
 import graphene
+import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
@@ -9,7 +10,7 @@ from .....attribute.models import AttributeValue
 from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_no_permission, get_graphql_content
 
 ATTRIBUTE_VALUES_REORDER_MUTATION = """
     mutation attributeReorderValues($attributeId: ID!, $moves: [ReorderInput!]!) {
@@ -250,3 +251,100 @@ def test_sort_values_trigger_webhook(
     assert attribute_updated_call in mocked_webhook_trigger.call_args_list
     assert attribute_value_1_updated_call in mocked_webhook_trigger.call_args_list
     assert attribute_value_2_updated_call in mocked_webhook_trigger.call_args_list
+
+
+@pytest.mark.parametrize(
+    (
+        "_case",
+        "client_fixture",
+        "attribute_fixture",
+        "permission_fixture",
+        "is_allowed",
+    ),
+    [
+        (
+            "Unauthenticated user should be rejected",
+            "api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Authenticated unprivileged user (non-staff) should be rejected",
+            "user_api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Staff user w/o any permission should be rejected",
+            "staff_api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Product attribute w/ page permission should be rejected",
+            "staff_api_client",
+            "color_attribute",
+            "permission_manage_page_types_and_attributes",
+            False,
+        ),
+        (
+            "Product attribute w/ product permission should be allowed",
+            "staff_api_client",
+            "color_attribute",
+            "permission_manage_product_types_and_attributes",
+            True,
+        ),
+        (
+            "Page attribute w/ product permission should be rejected",
+            "staff_api_client",
+            "size_page_attribute",
+            "permission_manage_product_types_and_attributes",
+            False,
+        ),
+        (
+            "Page attribute w/ page permission should be allowed",
+            "staff_api_client",
+            "size_page_attribute",
+            "permission_manage_page_types_and_attributes",
+            True,
+        ),
+    ],
+)
+def test_authorization(
+    request, _case, client_fixture, attribute_fixture, permission_fixture, is_allowed
+):
+    # given
+    client = request.getfixturevalue(client_fixture)
+    attribute = request.getfixturevalue(attribute_fixture)
+    if permission_fixture:
+        client.user.user_permissions.add(request.getfixturevalue(permission_fixture))
+    values = attribute.values
+    values.set(list(values.all()))
+    initial_order = list(values.values_list("pk", flat=True))
+    assert len(initial_order) == 2
+    variables = {
+        "attributeId": graphene.Node.to_global_id("Attribute", attribute.pk),
+        "moves": [
+            {
+                "id": graphene.Node.to_global_id("AttributeValue", initial_order[0]),
+                "sortOrder": +1,
+            }
+        ],
+    }
+
+    # when
+    response = client.post_graphql(ATTRIBUTE_VALUES_REORDER_MUTATION, variables)
+
+    # then
+    if is_allowed:
+        content = get_graphql_content(response)
+        data = content["data"]["attributeReorderValues"]
+        assert data["errors"] == []
+        expected_order = [initial_order[1], initial_order[0]]
+        assert list(values.values_list("pk", flat=True)) == expected_order
+    else:
+        assert_no_permission(response)
+        assert list(values.values_list("pk", flat=True)) == initial_order

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -13,7 +13,7 @@ from .....attribute.models import AttributeValue
 from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_no_permission, get_graphql_content
 from ...mutations.validators import validate_value_is_unique
 
 
@@ -73,7 +73,7 @@ CREATE_ATTRIBUTE_VALUE_MUTATION = """
 
 
 def test_create_attribute_value(
-    staff_api_client, color_attribute, permission_manage_products
+    staff_api_client, color_attribute, permission_manage_product_types_and_attributes
 ):
     # given
     attribute = color_attribute
@@ -89,7 +89,7 @@ def test_create_attribute_value(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
 
     # then
@@ -115,7 +115,7 @@ def test_create_attribute_value_trigger_webhooks(
     any_webhook,
     staff_api_client,
     color_attribute,
-    permission_manage_products,
+    permission_manage_product_types_and_attributes,
     settings,
 ):
     # given
@@ -130,7 +130,7 @@ def test_create_attribute_value_trigger_webhooks(
     response = staff_api_client.post_graphql(
         CREATE_ATTRIBUTE_VALUE_MUTATION,
         variables,
-        permissions=[permission_manage_products],
+        permissions=[permission_manage_product_types_and_attributes],
     )
     content = get_graphql_content(response)
     data = content["data"]["attributeValueCreate"]
@@ -188,7 +188,7 @@ def test_create_attribute_value_with_the_same_name_as_different_attribute_value(
     staff_api_client,
     attribute_without_values,
     color_attribute,
-    permission_manage_products,
+    permission_manage_product_types_and_attributes,
 ):
     # given
     attribute = attribute_without_values
@@ -202,7 +202,7 @@ def test_create_attribute_value_with_the_same_name_as_different_attribute_value(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
 
     # then
@@ -219,7 +219,7 @@ def test_create_attribute_value_with_the_same_name_as_different_attribute_value(
 
 
 def test_create_swatch_attribute_value_with_value(
-    staff_api_client, swatch_attribute, permission_manage_products
+    staff_api_client, swatch_attribute, permission_manage_product_types_and_attributes
 ):
     # given
     attribute = swatch_attribute
@@ -231,7 +231,7 @@ def test_create_swatch_attribute_value_with_value(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
 
     # then
@@ -251,7 +251,7 @@ def test_create_swatch_attribute_value_with_value(
 
 
 def test_create_swatch_attribute_value_with_file(
-    staff_api_client, swatch_attribute, permission_manage_products
+    staff_api_client, swatch_attribute, permission_manage_product_types_and_attributes
 ):
     # given
     attribute = swatch_attribute
@@ -269,7 +269,7 @@ def test_create_swatch_attribute_value_with_file(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
 
     # then
@@ -289,7 +289,7 @@ def test_create_swatch_attribute_value_with_file(
 
 
 def test_create_swatch_attribute_value_with_value_and_file(
-    staff_api_client, swatch_attribute, permission_manage_products
+    staff_api_client, swatch_attribute, permission_manage_product_types_and_attributes
 ):
     # given
     attribute = swatch_attribute
@@ -307,7 +307,7 @@ def test_create_swatch_attribute_value_with_value_and_file(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
 
     # then
@@ -331,7 +331,11 @@ def test_create_swatch_attribute_value_with_value_and_file(
     ],
 )
 def test_create_attribute_value_provide_not_allowed_input_data(
-    field, value, staff_api_client, color_attribute, permission_manage_products
+    field,
+    value,
+    staff_api_client,
+    color_attribute,
+    permission_manage_product_types_and_attributes,
 ):
     # given
     attribute = color_attribute
@@ -342,7 +346,7 @@ def test_create_attribute_value_provide_not_allowed_input_data(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
 
     # then
@@ -356,7 +360,7 @@ def test_create_attribute_value_provide_not_allowed_input_data(
 
 
 def test_create_attribute_value_not_unique_name(
-    staff_api_client, color_attribute, permission_manage_products
+    staff_api_client, color_attribute, permission_manage_product_types_and_attributes
 ):
     # given
     attribute = color_attribute
@@ -367,7 +371,7 @@ def test_create_attribute_value_not_unique_name(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
 
     # then
@@ -378,7 +382,7 @@ def test_create_attribute_value_not_unique_name(
 
 
 def test_create_attribute_value_capitalized_name(
-    staff_api_client, color_attribute, permission_manage_products
+    staff_api_client, color_attribute, permission_manage_product_types_and_attributes
 ):
     # given
     attribute = color_attribute
@@ -389,7 +393,7 @@ def test_create_attribute_value_capitalized_name(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
 
     # then
@@ -400,7 +404,7 @@ def test_create_attribute_value_capitalized_name(
 
 
 def test_create_attribute_value_with_non_unique_external_reference(
-    staff_api_client, color_attribute, permission_manage_products
+    staff_api_client, color_attribute, permission_manage_product_types_and_attributes
 ):
     # given
     query = CREATE_ATTRIBUTE_VALUE_MUTATION
@@ -419,7 +423,7 @@ def test_create_attribute_value_with_non_unique_external_reference(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
     content = get_graphql_content(response)
 
@@ -431,3 +435,100 @@ def test_create_attribute_value_with_non_unique_external_reference(
         error["message"]
         == "Attribute value with this External reference already exists."
     )
+
+
+@pytest.mark.parametrize(
+    (
+        "_case",
+        "client_fixture",
+        "attribute_fixture",
+        "permission_fixture",
+        "is_allowed",
+    ),
+    [
+        (
+            "Unauthenticated user should be rejected",
+            "api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Authenticated unprivileged user (non-staff) should be rejected",
+            "user_api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Staff user w/o any permission should be rejected",
+            "staff_api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Product attribute w/ manage products permission should be rejected",
+            "staff_api_client",
+            "color_attribute",
+            "permission_manage_products",
+            False,
+        ),
+        (
+            "Product attribute w/ page permission should be rejected",
+            "staff_api_client",
+            "color_attribute",
+            "permission_manage_page_types_and_attributes",
+            False,
+        ),
+        (
+            "Product attribute w/ product permission should be allowed",
+            "staff_api_client",
+            "color_attribute",
+            "permission_manage_product_types_and_attributes",
+            True,
+        ),
+        (
+            "Page attribute w/ product permission should be rejected",
+            "staff_api_client",
+            "size_page_attribute",
+            "permission_manage_product_types_and_attributes",
+            False,
+        ),
+        (
+            "Page attribute w/ page permission should be allowed",
+            "staff_api_client",
+            "size_page_attribute",
+            "permission_manage_page_types_and_attributes",
+            True,
+        ),
+    ],
+)
+def test_authorization(
+    request, _case, client_fixture, attribute_fixture, permission_fixture, is_allowed
+):
+    # given
+    client = request.getfixturevalue(client_fixture)
+    attribute = request.getfixturevalue(attribute_fixture)
+    if permission_fixture:
+        client.user.user_permissions.add(request.getfixturevalue(permission_fixture))
+    name = "New value"
+    variables = {
+        "attributeId": graphene.Node.to_global_id("Attribute", attribute.pk),
+        "name": name,
+    }
+
+    # when
+    response = client.post_graphql(CREATE_ATTRIBUTE_VALUE_MUTATION, variables)
+
+    # then
+    if is_allowed:
+        content = get_graphql_content(response)
+        data = content["data"]["attributeValueCreate"]
+        assert data["errors"] == []
+        value = attribute.values.get(name=name)
+        assert data["attributeValue"]["name"] == value.name
+        assert data["attributeValue"]["slug"] == value.slug
+    else:
+        assert_no_permission(response)
+        assert attribute.values.filter(name=name).exists() is False

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
@@ -14,7 +14,7 @@ from .....attribute.utils import associate_attribute_values_to_instance
 from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_no_permission, get_graphql_content
 
 ATTRIBUTE_VALUE_DELETE_MUTATION = """
     mutation AttributeValueDelete($id: ID!) {
@@ -75,7 +75,7 @@ def test_delete_attribute_value_update_search_index_dirty_in_product(
 def test_delete_attribute_value_update_search_index_dirty_in_page(
     staff_api_client,
     page,
-    permission_manage_product_types_and_attributes,
+    permission_manage_page_types_and_attributes,
 ):
     # given
     attribute_value = page.attributevalues.first()
@@ -86,7 +86,7 @@ def test_delete_attribute_value_update_search_index_dirty_in_page(
 
     # when
     staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query, variables, permissions=[permission_manage_page_types_and_attributes]
     )
 
     # then
@@ -339,3 +339,88 @@ def test_delete_attribute_value_by_external_reference_not_existing(
     # then
     errors = content["data"]["attributeValueDelete"]["errors"]
     assert errors[0]["message"] == f"Couldn't resolve to a node: {ext_ref}"
+
+
+@pytest.mark.parametrize(
+    (
+        "_case",
+        "client_fixture",
+        "attribute_fixture",
+        "permission_fixture",
+        "is_allowed",
+    ),
+    [
+        (
+            "Unauthenticated user should be rejected",
+            "api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Authenticated unprivileged user (non-staff) should be rejected",
+            "user_api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Staff user w/o any permission should be rejected",
+            "staff_api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Product attribute value w/ page permission should be rejected",
+            "staff_api_client",
+            "color_attribute",
+            "permission_manage_page_types_and_attributes",
+            False,
+        ),
+        (
+            "Product attribute value w/ product permission should be allowed",
+            "staff_api_client",
+            "color_attribute",
+            "permission_manage_product_types_and_attributes",
+            True,
+        ),
+        (
+            "Page attribute value w/ product permission should be rejected",
+            "staff_api_client",
+            "size_page_attribute",
+            "permission_manage_product_types_and_attributes",
+            False,
+        ),
+        (
+            "Page attribute value w/ page permission should be allowed",
+            "staff_api_client",
+            "size_page_attribute",
+            "permission_manage_page_types_and_attributes",
+            True,
+        ),
+    ],
+)
+def test_authorization(
+    request, _case, client_fixture, attribute_fixture, permission_fixture, is_allowed
+):
+    # given
+    client = request.getfixturevalue(client_fixture)
+    attribute = request.getfixturevalue(attribute_fixture)
+    if permission_fixture:
+        client.user.user_permissions.add(request.getfixturevalue(permission_fixture))
+    value = attribute.values.first()
+    variables = {"id": graphene.Node.to_global_id("AttributeValue", value.pk)}
+
+    # when
+    response = client.post_graphql(ATTRIBUTE_VALUE_DELETE_MUTATION, variables)
+
+    # then
+    if is_allowed:
+        content = get_graphql_content(response)
+        data = content["data"]["attributeValueDelete"]
+        assert data["attributeValue"]["name"] == value.name
+        assert attribute.values.filter(pk=value.pk).exists() is False
+    else:
+        assert_no_permission(response)
+        assert attribute.values.filter(pk=value.pk).exists() is True

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -16,7 +16,7 @@ from .....attribute.utils import associate_attribute_values_to_instance
 from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_no_permission, get_graphql_content
 
 UPDATE_ATTRIBUTE_VALUE_MUTATION = """
 mutation AttributeValueUpdate($id: ID!, $input: AttributeValueUpdateInput!) {
@@ -118,7 +118,7 @@ def test_update_attribute_value_update_search_index_dirty_in_product(
 def test_update_attribute_value_update_search_index_dirty_in_page(
     staff_api_client,
     page,
-    permission_manage_product_types_and_attributes,
+    permission_manage_page_types_and_attributes,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -131,7 +131,7 @@ def test_update_attribute_value_update_search_index_dirty_in_page(
 
     # when
     staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query, variables, permissions=[permission_manage_page_types_and_attributes]
     )
 
     # then
@@ -646,3 +646,95 @@ def test_update_attribute_value_with_non_unique_external_reference(
         error["message"]
         == "Attribute value with this External reference already exists."
     )
+
+
+@pytest.mark.parametrize(
+    (
+        "_case",
+        "client_fixture",
+        "attribute_fixture",
+        "permission_fixture",
+        "is_allowed",
+    ),
+    [
+        (
+            "Unauthenticated user should be rejected",
+            "api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Authenticated unprivileged user (non-staff) should be rejected",
+            "user_api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Staff user w/o any permission should be rejected",
+            "staff_api_client",
+            "color_attribute",
+            None,
+            False,
+        ),
+        (
+            "Product attribute value w/ page permission should be rejected",
+            "staff_api_client",
+            "color_attribute",
+            "permission_manage_page_types_and_attributes",
+            False,
+        ),
+        (
+            "Product attribute value w/ product permission should be allowed",
+            "staff_api_client",
+            "color_attribute",
+            "permission_manage_product_types_and_attributes",
+            True,
+        ),
+        (
+            "Page attribute value w/ product permission should be rejected",
+            "staff_api_client",
+            "size_page_attribute",
+            "permission_manage_product_types_and_attributes",
+            False,
+        ),
+        (
+            "Page attribute value w/ page permission should be allowed",
+            "staff_api_client",
+            "size_page_attribute",
+            "permission_manage_page_types_and_attributes",
+            True,
+        ),
+    ],
+)
+def test_authorization(
+    request, _case, client_fixture, attribute_fixture, permission_fixture, is_allowed
+):
+    # given
+    client = request.getfixturevalue(client_fixture)
+    attribute = request.getfixturevalue(attribute_fixture)
+    if permission_fixture:
+        client.user.user_permissions.add(request.getfixturevalue(permission_fixture))
+    value = attribute.values.first()
+    original_name = value.name
+    new_name = "Updated name"
+    variables = {
+        "id": graphene.Node.to_global_id("AttributeValue", value.pk),
+        "input": {"name": new_name},
+    }
+
+    # when
+    response = client.post_graphql(UPDATE_ATTRIBUTE_VALUE_MUTATION, variables)
+
+    # then
+    value.refresh_from_db(fields=("name",))
+    if is_allowed:
+        content = get_graphql_content(response)
+        data = content["data"]["attributeValueUpdate"]
+        assert data["errors"] == []
+        assert value.name == new_name
+        assert data["attributeValue"]["name"] == new_name
+    else:
+        assert_no_permission(response)
+        assert value.name == original_name

--- a/saleor/graphql/attribute/tests/mutations/test_bulk_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_bulk_delete.py
@@ -5,7 +5,7 @@ import pytest
 
 from .....attribute.models import Attribute, AttributeValue
 from .....attribute.utils import associate_attribute_values_to_instance
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_no_permission, get_graphql_content
 
 ATTRIBUTE_BULK_DELETE_MUTATION = """
     mutation attributeBulkDelete($ids: [ID!]!) {
@@ -33,7 +33,7 @@ def attribute_value_list(color_attribute):
 def test_delete_attributes(
     staff_api_client,
     product_type_attribute_list,
-    permission_manage_page_types_and_attributes,
+    permission_manage_product_types_and_attributes,
 ):
     query = ATTRIBUTE_BULK_DELETE_MUTATION
 
@@ -44,7 +44,7 @@ def test_delete_attributes(
         ]
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_page_types_and_attributes]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
     content = get_graphql_content(response)
 
@@ -62,7 +62,7 @@ def test_delete_attributes_trigger_webhooks(
     any_webhook,
     staff_api_client,
     product_type_attribute_list,
-    permission_manage_page_types_and_attributes,
+    permission_manage_product_types_and_attributes,
     settings,
 ):
     # given
@@ -79,7 +79,7 @@ def test_delete_attributes_trigger_webhooks(
     response = staff_api_client.post_graphql(
         ATTRIBUTE_BULK_DELETE_MUTATION,
         variables,
-        permissions=[permission_manage_page_types_and_attributes],
+        permissions=[permission_manage_product_types_and_attributes],
     )
     content = get_graphql_content(response)
 
@@ -91,7 +91,7 @@ def test_delete_attributes_trigger_webhooks(
 def test_delete_attributes_products_search_document_updated(
     staff_api_client,
     product_type_attribute_list,
-    permission_manage_page_types_and_attributes,
+    permission_manage_product_types_and_attributes,
     product_list,
     color_attribute,
 ):
@@ -137,7 +137,7 @@ def test_delete_attributes_products_search_document_updated(
         ]
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_page_types_and_attributes]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
     content = get_graphql_content(response)
 
@@ -157,7 +157,9 @@ ATTRIBUTE_VALUE_BULK_DELETE_MUTATION = """
 
 
 def test_delete_attribute_values(
-    staff_api_client, attribute_value_list, permission_manage_page_types_and_attributes
+    staff_api_client,
+    attribute_value_list,
+    permission_manage_product_types_and_attributes,
 ):
     query = ATTRIBUTE_VALUE_BULK_DELETE_MUTATION
 
@@ -168,7 +170,7 @@ def test_delete_attribute_values(
         ]
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_page_types_and_attributes]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
     content = get_graphql_content(response)
 
@@ -186,7 +188,7 @@ def test_delete_attribute_values_trigger_webhook(
     any_webhook,
     staff_api_client,
     attribute_value_list,
-    permission_manage_page_types_and_attributes,
+    permission_manage_product_types_and_attributes,
     settings,
 ):
     # given
@@ -205,7 +207,7 @@ def test_delete_attribute_values_trigger_webhook(
     response = staff_api_client.post_graphql(
         ATTRIBUTE_VALUE_BULK_DELETE_MUTATION,
         variables,
-        permissions=[permission_manage_page_types_and_attributes],
+        permissions=[permission_manage_product_types_and_attributes],
     )
     content = get_graphql_content(response)
     expected_call_count = len(attributes) + len(attribute_value_list)
@@ -219,7 +221,7 @@ def test_delete_attribute_values_search_document_updated(
     staff_api_client,
     product_list,
     attribute_value_list,
-    permission_manage_page_types_and_attributes,
+    permission_manage_product_types_and_attributes,
 ):
     query = ATTRIBUTE_VALUE_BULK_DELETE_MUTATION
     value_1, value_2, value_3 = attribute_value_list
@@ -257,7 +259,7 @@ def test_delete_attribute_values_search_document_updated(
         ]
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_page_types_and_attributes]
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
     )
     content = get_graphql_content(response)
 
@@ -270,3 +272,254 @@ def test_delete_attribute_values_search_document_updated(
     product_2.refresh_from_db()
     assert product_1.search_vector
     assert product_2.search_vector
+
+
+@pytest.mark.parametrize(
+    (
+        "_case",
+        "client_fixture",
+        "attribute_list_fixtures",
+        "permission_fixtures",
+        "is_allowed",
+    ),
+    [
+        (
+            "Unauthenticated user should be rejected",
+            "api_client",
+            ["product_type_attribute_list"],
+            [],
+            False,
+        ),
+        (
+            "Unauthenticated user should be rejected even with empty ids",
+            "api_client",
+            [],
+            [],
+            False,
+        ),
+        (
+            "Authenticated unprivileged user (non-staff) should be rejected",
+            "user_api_client",
+            ["product_type_attribute_list"],
+            [],
+            False,
+        ),
+        (
+            "Staff user w/o any permission should be rejected",
+            "staff_api_client",
+            ["product_type_attribute_list"],
+            [],
+            False,
+        ),
+        (
+            "Product attributes w/ page permission should be rejected",
+            "staff_api_client",
+            ["product_type_attribute_list"],
+            ["permission_manage_page_types_and_attributes"],
+            False,
+        ),
+        (
+            "Product attributes w/ product permission should be allowed",
+            "staff_api_client",
+            ["product_type_attribute_list"],
+            ["permission_manage_product_types_and_attributes"],
+            True,
+        ),
+        (
+            "Page attributes w/ product permission should be rejected",
+            "staff_api_client",
+            ["page_type_attribute_list"],
+            ["permission_manage_product_types_and_attributes"],
+            False,
+        ),
+        (
+            "Page attributes w/ page permission should be allowed",
+            "staff_api_client",
+            ["page_type_attribute_list"],
+            ["permission_manage_page_types_and_attributes"],
+            True,
+        ),
+        (
+            "Mixed attributes w/ product permission only should be rejected",
+            "staff_api_client",
+            ["product_type_attribute_list", "page_type_attribute_list"],
+            ["permission_manage_product_types_and_attributes"],
+            False,
+        ),
+        (
+            "Mixed attributes w/ page permission only should be rejected",
+            "staff_api_client",
+            ["product_type_attribute_list", "page_type_attribute_list"],
+            ["permission_manage_page_types_and_attributes"],
+            False,
+        ),
+        (
+            "Mixed attributes w/ both permissions should be allowed",
+            "staff_api_client",
+            ["product_type_attribute_list", "page_type_attribute_list"],
+            [
+                "permission_manage_product_types_and_attributes",
+                "permission_manage_page_types_and_attributes",
+            ],
+            True,
+        ),
+    ],
+)
+def test_delete_attributes_authorization(
+    request,
+    _case,
+    client_fixture,
+    attribute_list_fixtures,
+    permission_fixtures,
+    is_allowed,
+):
+    # given
+    client = request.getfixturevalue(client_fixture)
+    attributes = [
+        attribute
+        for fixture in attribute_list_fixtures
+        for attribute in request.getfixturevalue(fixture)
+    ]
+    for permission_fixture in permission_fixtures:
+        client.user.user_permissions.add(request.getfixturevalue(permission_fixture))
+    attribute_pks = [attribute.pk for attribute in attributes]
+    variables = {
+        "ids": [graphene.Node.to_global_id("Attribute", pk) for pk in attribute_pks]
+    }
+
+    # when
+    response = client.post_graphql(ATTRIBUTE_BULK_DELETE_MUTATION, variables)
+
+    # then
+    if is_allowed:
+        content = get_graphql_content(response)
+        assert content["data"]["attributeBulkDelete"]["count"] == len(attributes)
+        assert Attribute.objects.filter(pk__in=attribute_pks).exists() is False
+    else:
+        assert_no_permission(response)
+        assert Attribute.objects.filter(pk__in=attribute_pks).count() == len(attributes)
+
+
+@pytest.mark.parametrize(
+    (
+        "_case",
+        "client_fixture",
+        "attribute_fixtures",
+        "permission_fixtures",
+        "is_allowed",
+    ),
+    [
+        (
+            "Unauthenticated user should be rejected",
+            "api_client",
+            ["color_attribute"],
+            [],
+            False,
+        ),
+        (
+            "Unauthenticated user should be rejected even with empty ids",
+            "api_client",
+            [],
+            [],
+            False,
+        ),
+        (
+            "Authenticated unprivileged user (non-staff) should be rejected",
+            "user_api_client",
+            ["color_attribute"],
+            [],
+            False,
+        ),
+        (
+            "Staff user w/o any permission should be rejected",
+            "staff_api_client",
+            ["color_attribute"],
+            [],
+            False,
+        ),
+        (
+            "Product attribute values w/ page permission should be rejected",
+            "staff_api_client",
+            ["color_attribute"],
+            ["permission_manage_page_types_and_attributes"],
+            False,
+        ),
+        (
+            "Product attribute values w/ product permission should be allowed",
+            "staff_api_client",
+            ["color_attribute"],
+            ["permission_manage_product_types_and_attributes"],
+            True,
+        ),
+        (
+            "Page attribute values w/ product permission should be rejected",
+            "staff_api_client",
+            ["size_page_attribute"],
+            ["permission_manage_product_types_and_attributes"],
+            False,
+        ),
+        (
+            "Page attribute values w/ page permission should be allowed",
+            "staff_api_client",
+            ["size_page_attribute"],
+            ["permission_manage_page_types_and_attributes"],
+            True,
+        ),
+        (
+            "Mixed attribute values w/ product permission only should be rejected",
+            "staff_api_client",
+            ["color_attribute", "size_page_attribute"],
+            ["permission_manage_product_types_and_attributes"],
+            False,
+        ),
+        (
+            "Mixed attribute values w/ page permission only should be rejected",
+            "staff_api_client",
+            ["color_attribute", "size_page_attribute"],
+            ["permission_manage_page_types_and_attributes"],
+            False,
+        ),
+        (
+            "Mixed attribute values w/ both permissions should be allowed",
+            "staff_api_client",
+            ["color_attribute", "size_page_attribute"],
+            [
+                "permission_manage_product_types_and_attributes",
+                "permission_manage_page_types_and_attributes",
+            ],
+            True,
+        ),
+    ],
+)
+def test_delete_attribute_values_authorization(
+    request,
+    _case,
+    client_fixture,
+    attribute_fixtures,
+    permission_fixtures,
+    is_allowed,
+):
+    # given
+    client = request.getfixturevalue(client_fixture)
+    value_pks = [
+        pk
+        for fixture in attribute_fixtures
+        for pk in request.getfixturevalue(fixture).values.values_list("pk", flat=True)
+    ]
+    for permission_fixture in permission_fixtures:
+        client.user.user_permissions.add(request.getfixturevalue(permission_fixture))
+    variables = {
+        "ids": [graphene.Node.to_global_id("AttributeValue", pk) for pk in value_pks]
+    }
+
+    # when
+    response = client.post_graphql(ATTRIBUTE_VALUE_BULK_DELETE_MUTATION, variables)
+
+    # then
+    if is_allowed:
+        content = get_graphql_content(response)
+        assert content["data"]["attributeValueBulkDelete"]["count"] == len(value_pks)
+        assert AttributeValue.objects.filter(pk__in=value_pks).exists() is False
+    else:
+        assert_no_permission(response)
+        assert AttributeValue.objects.filter(pk__in=value_pks).count() == len(value_pks)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -21379,9 +21379,9 @@ type Mutation {
   ): AttributeBulkTranslate @doc(category: "Attributes")
 
   """
-  Deletes attributes. 
+  Deletes attributes.
   
-  Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
+  Requires one of the following permissions, depending on the type of each attribute: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
   
   Triggers the following webhook events:
   - ATTRIBUTE_DELETED (async): An attribute was deleted.
@@ -21394,9 +21394,9 @@ type Mutation {
   ): AttributeBulkDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_DELETED], syncEvents: [])
 
   """
-  Deletes values of attributes. 
+  Deletes values of attributes.
   
-  Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
+  Requires one of the following permissions, depending on the type of each value's attribute: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
   
   Triggers the following webhook events:
   - ATTRIBUTE_VALUE_DELETED (async): An attribute value was deleted.
@@ -21410,9 +21410,9 @@ type Mutation {
   ): AttributeValueBulkDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_VALUE_DELETED, ATTRIBUTE_UPDATED], syncEvents: [])
 
   """
-  Creates a value for an attribute. 
+  Creates a value for an attribute.
   
-  Requires one of the following permissions: MANAGE_PRODUCTS.
+  Requires one of the following permissions, depending on the attribute type: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
   
   Triggers the following webhook events:
   - ATTRIBUTE_VALUE_CREATED (async): An attribute value was created.
@@ -21427,9 +21427,9 @@ type Mutation {
   ): AttributeValueCreate @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_VALUE_CREATED, ATTRIBUTE_UPDATED], syncEvents: [])
 
   """
-  Deletes a value of an attribute. 
+  Deletes a value of an attribute.
   
-  Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Requires one of the following permissions, depending on the type of the value's attribute: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
   
   Triggers the following webhook events:
   - ATTRIBUTE_VALUE_DELETED (async): An attribute value was deleted.
@@ -21444,9 +21444,9 @@ type Mutation {
   ): AttributeValueDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEvents: [ATTRIBUTE_VALUE_DELETED, ATTRIBUTE_UPDATED], syncEvents: [])
 
   """
-  Updates value of an attribute. 
+  Updates value of an attribute.
   
-  Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Requires one of the following permissions, depending on the type of the value's attribute: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
   
   Triggers the following webhook events:
   - ATTRIBUTE_VALUE_UPDATED (async): An attribute value was updated.
@@ -21493,9 +21493,9 @@ type Mutation {
   ): AttributeValueTranslate @doc(category: "Attributes")
 
   """
-  Reorder the values of an attribute. 
+  Reorder the values of an attribute.
   
-  Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Requires one of the following permissions, depending on the attribute type: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
   
   Triggers the following webhook events:
   - ATTRIBUTE_VALUE_UPDATED (async): An attribute value was updated.
@@ -32055,9 +32055,9 @@ input AttributeBulkTranslateInput @doc(category: "Attributes") {
 }
 
 """
-Deletes attributes. 
+Deletes attributes.
 
-Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
+Requires one of the following permissions, depending on the type of each attribute: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
 
 Triggers the following webhook events:
 - ATTRIBUTE_DELETED (async): An attribute was deleted.
@@ -32070,9 +32070,9 @@ type AttributeBulkDelete @doc(category: "Attributes") @webhookEventsInfo(asyncEv
 }
 
 """
-Deletes values of attributes. 
+Deletes values of attributes.
 
-Requires one of the following permissions: MANAGE_PAGE_TYPES_AND_ATTRIBUTES.
+Requires one of the following permissions, depending on the type of each value's attribute: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
 
 Triggers the following webhook events:
 - ATTRIBUTE_VALUE_DELETED (async): An attribute value was deleted.
@@ -32086,9 +32086,9 @@ type AttributeValueBulkDelete @doc(category: "Attributes") @webhookEventsInfo(as
 }
 
 """
-Creates a value for an attribute. 
+Creates a value for an attribute.
 
-Requires one of the following permissions: MANAGE_PRODUCTS.
+Requires one of the following permissions, depending on the attribute type: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
 
 Triggers the following webhook events:
 - ATTRIBUTE_VALUE_CREATED (async): An attribute value was created.
@@ -32103,9 +32103,9 @@ type AttributeValueCreate @doc(category: "Attributes") @webhookEventsInfo(asyncE
 }
 
 """
-Deletes a value of an attribute. 
+Deletes a value of an attribute.
 
-Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+Requires one of the following permissions, depending on the type of the value's attribute: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
 
 Triggers the following webhook events:
 - ATTRIBUTE_VALUE_DELETED (async): An attribute value was deleted.
@@ -32120,9 +32120,9 @@ type AttributeValueDelete @doc(category: "Attributes") @webhookEventsInfo(asyncE
 }
 
 """
-Updates value of an attribute. 
+Updates value of an attribute.
 
-Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+Requires one of the following permissions, depending on the type of the value's attribute: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
 
 Triggers the following webhook events:
 - ATTRIBUTE_VALUE_UPDATED (async): An attribute value was updated.
@@ -32218,9 +32218,9 @@ type AttributeValueTranslate @doc(category: "Attributes") {
 }
 
 """
-Reorder the values of an attribute. 
+Reorder the values of an attribute.
 
-Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+Requires one of the following permissions, depending on the attribute type: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES for `PRODUCT_TYPE` attributes, MANAGE_PAGE_TYPES_AND_ATTRIBUTES for `PAGE_TYPE` attributes.
 
 Triggers the following webhook events:
 - ATTRIBUTE_VALUE_UPDATED (async): An attribute value was updated.


### PR DESCRIPTION
> [!WARNING]
> To be backported.

 Makes the attribute mutations resolve their required permission from the attribute's type.

| Mutation | Before |
|---|---|
| `attributeBulkDelete` | `MANAGE_PAGE_TYPES_AND_ATTRIBUTES` |
| `attributeValueBulkDelete` | `MANAGE_PAGE_TYPES_AND_ATTRIBUTES` |
| `attributeValueCreate` | `MANAGE_PRODUCTS` |
| `attributeValueUpdate` | `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` |
| `attributeValueDelete` | `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` |
| `attributeReorderValues` | `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` |

Now: `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` for `PRODUCT_TYPE` attributes, `MANAGE_PAGE_TYPES_AND_ATTRIBUTES` for `PAGE_TYPE` attributes, mixed bulk batches require both.
