### PR TITLE
Fix DB locks - never-evaluated `select_for_update` querysets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,6 +369,27 @@ def my_model_qs_select_for_update() -> QuerySet[MyModel]:
     return MyModel.objects.order_by("pk").select_for_update(of=["self"])
 ```
 
+### select_for_update pitfalls
+
+1. Querysets are lazy - an unevaluated lock queryset runs no SQL, so no lock is
+   taken and it fails silently. Force evaluation inside the transaction with
+   `list(...)`, `.get()`/`.first()`, or use it as an `__in` subquery of the write.
+
+   ```python
+   with transaction.atomic():
+       # Bad: lazy - no lock
+       _locked = model_qs_select_for_update().filter(pk__in=pks)
+       # Good: rows locked, only pks fetched
+       _locked = list(
+           model_qs_select_for_update().filter(pk__in=pks).values_list("pk", flat=True)
+       )
+       Model.objects.bulk_update(objs, ["field"])
+   ```
+
+2. Test the lock with the `assert_locks_rows_before_write` fixture
+   (`saleor/tests/fixtures.py`) - it captures the block's queries and asserts an
+   ordered `FOR UPDATE` query is emitted before the `UPDATE`.
+
 ## Database Transactions
 
 Wrap related operations in transactions using `traced_atomic_transaction`:

--- a/saleor/attribute/lock_objects.py
+++ b/saleor/attribute/lock_objects.py
@@ -4,6 +4,8 @@ from .models.base import Attribute, AttributeValue
 
 
 def attribute_value_qs_select_for_update() -> QuerySet[AttributeValue]:
+    # Matching lock order (sort_order, pk) of `perform_reordering` to avoid deadlocks.
+    # TODO: switch to a stable pk-only ordering together with the reordering logic.
     return AttributeValue.objects.order_by("sort_order", "pk").select_for_update(
         of=(["self"])
     )

--- a/saleor/attribute/models/base.py
+++ b/saleor/attribute/models/base.py
@@ -338,10 +338,10 @@ class AttributeValueManager(models.Manager):
             from ..lock_objects import attribute_value_qs_select_for_update
 
             with transaction.atomic():
-                _locked_qs = (
+                _locked_ids = list(
                     attribute_value_qs_select_for_update()
                     .filter(pk__in=[obj.pk for obj in objects_to_be_updated])
-                    .select_for_update(of=(["self"]))
+                    .values_list("pk", flat=True)
                 )
                 self.bulk_update(
                     objects_to_be_updated,

--- a/saleor/attribute/tests/models/test_base.py
+++ b/saleor/attribute/tests/models/test_base.py
@@ -146,3 +146,47 @@ def test_max_sort_order_0_when_deleting_attribute_value_with_sort_order_0():
     assert attribute.max_sort_order == 0
     value2.refresh_from_db()
     assert value2.sort_order == 0
+
+
+def test_bulk_update_or_create_locks_rows_before_update(capture_queries):
+    # given
+    attribute = Attribute.objects.create(
+        slug="test-slug",
+        name="test name",
+        type=AttributeType.PRODUCT_TYPE,
+    )
+    value = AttributeValue.objects.create(
+        attribute=attribute, name="value", slug="value"
+    )
+    new_name = "updated name"
+
+    # when
+    with capture_queries() as ctx:
+        results = AttributeValue.objects.bulk_update_or_create(
+            [
+                {
+                    "attribute": attribute,
+                    "slug": value.slug,
+                    "defaults": {"name": new_name},
+                }
+            ]
+        )
+
+    # then
+    value.refresh_from_db(fields=("name",))
+    assert value.name == new_name
+    assert results == [value]
+
+    # the lock SELECT should run before the bulk UPDATE.
+    lock_and_update_queries = [
+        query["sql"]
+        for query in ctx.captured_queries
+        if "FOR UPDATE" in query["sql"] or query["sql"].startswith("UPDATE")
+    ]
+    assert len(lock_and_update_queries) == 2
+    lock_query, update_query = lock_and_update_queries
+    assert "FOR UPDATE" in lock_query
+    # deterministic ordering makes concurrent lockers acquire rows in the same
+    # order, which is what prevents deadlocks between them.
+    assert "ORDER BY" in lock_query
+    assert update_query.startswith("UPDATE")

--- a/saleor/attribute/tests/models/test_base.py
+++ b/saleor/attribute/tests/models/test_base.py
@@ -148,7 +148,7 @@ def test_max_sort_order_0_when_deleting_attribute_value_with_sort_order_0():
     assert value2.sort_order == 0
 
 
-def test_bulk_update_or_create_locks_rows_before_update(capture_queries):
+def test_bulk_update_or_create_locks_rows_before_update(assert_locks_rows_before_write):
     # given
     attribute = Attribute.objects.create(
         slug="test-slug",
@@ -161,7 +161,7 @@ def test_bulk_update_or_create_locks_rows_before_update(capture_queries):
     new_name = "updated name"
 
     # when
-    with capture_queries() as ctx:
+    with assert_locks_rows_before_write():
         results = AttributeValue.objects.bulk_update_or_create(
             [
                 {
@@ -176,17 +176,3 @@ def test_bulk_update_or_create_locks_rows_before_update(capture_queries):
     value.refresh_from_db(fields=("name",))
     assert value.name == new_name
     assert results == [value]
-
-    # the lock SELECT should run before the bulk UPDATE.
-    lock_and_update_queries = [
-        query["sql"]
-        for query in ctx.captured_queries
-        if "FOR UPDATE" in query["sql"] or query["sql"].startswith("UPDATE")
-    ]
-    assert len(lock_and_update_queries) == 2
-    lock_query, update_query = lock_and_update_queries
-    assert "FOR UPDATE" in lock_query
-    # deterministic ordering makes concurrent lockers acquire rows in the same
-    # order, which is what prevents deadlocks between them.
-    assert "ORDER BY" in lock_query
-    assert update_query.startswith("UPDATE")

--- a/saleor/checkout/lock_objects.py
+++ b/saleor/checkout/lock_objects.py
@@ -4,8 +4,8 @@ from .models import Checkout, CheckoutLine
 
 
 def checkout_qs_select_for_update() -> QuerySet[Checkout]:
-    return Checkout.objects.order_by("pk").select_for_update(of=(["self"]))
+    return Checkout.objects.order_by("pk").select_for_update(of=["self"])
 
 
 def checkout_lines_qs_select_for_update() -> QuerySet[CheckoutLine]:
-    return CheckoutLine.objects.order_by("pk").select_for_update(of=(["self"]))
+    return CheckoutLine.objects.order_by("pk").select_for_update(of=["self"])

--- a/saleor/checkout/search/indexing.py
+++ b/saleor/checkout/search/indexing.py
@@ -49,7 +49,7 @@ def update_checkouts_search_vector(checkouts: list["Checkout"]):
 
     with transaction.atomic():
         with allow_writer():
-            _locked_checkouts = (
+            _locked_checkouts = list(
                 checkout_qs_select_for_update()
                 .filter(pk__in=[checkout.pk for checkout in checkouts])
                 .values_list("pk", flat=True)

--- a/saleor/checkout/tests/test_search_indexing.py
+++ b/saleor/checkout/tests/test_search_indexing.py
@@ -143,26 +143,27 @@ def test_update_checkouts_search_vector_constant_queries(
     checkout_list = checkout_list_with_relations
 
     # when & then
-    # Expected query breakdown (14 total):
+    # Expected query breakdown (15 total):
     # First transaction block:
-    # 1. Select for update (filter dirty checkouts)
-    # 2. Update search_index_dirty flag
+    # 1. Transaction savepoint
+    # 2. Update search_index_dirty flag (locks via inlined FOR UPDATE subquery)
+    # 3. Release savepoint
     # Load checkout data:
-    # 3. Load users (1 query)
-    # 4. Load addresses (1 query)
-    # 5. Load payments (1 query)
-    # 6. Load checkout lines (1 query)
-    # 7. Load transactions (1 query)
-    # 8. Load product variants (1 query)
-    # 9. Load products (1 query)
-    # 10. Load transaction events (1 query)
+    # 4. Load users (1 query)
+    # 5. Load addresses (1 query)
+    # 6. Load payments (1 query)
+    # 7. Load checkout lines (1 query)
+    # 8. Load transactions (1 query)
+    # 9. Load product variants (1 query)
+    # 10. Load products (1 query)
+    # 11. Load transaction events (1 query)
     # Second transaction block:
-    # 11. Transaction savepoint
-    # 12. Select for update (lock checkouts)
-    # 13. Bulk update search vectors
-    # 14. Release savepoint
+    # 12. Transaction savepoint
+    # 13. Select for update (lock checkouts)
+    # 14. Bulk update search vectors
+    # 15. Release savepoint
 
-    expected_queries = 14
+    expected_queries = 15
     with django_assert_num_queries(expected_queries):
         update_checkouts_search_vector(checkout_list[: len(checkout_list) - 1])
     with django_assert_num_queries(expected_queries):
@@ -708,3 +709,21 @@ def test_update_checkouts_search_vector_resets_flag_on_load_data_exception(
     checkout.refresh_from_db()
     assert checkout.search_index_dirty is True
     assert not checkout.search_vector
+
+
+def test_update_checkouts_search_vector_locks_rows_before_write(
+    checkout_with_item, assert_locks_rows_before_write
+):
+    # given
+    assert not checkout_with_item.search_vector
+
+    # when
+    # patch out set_search_index_dirty - it emits its own locked UPDATE and is
+    # tested separately; here we only verify the search vector write phase.
+    with patch("saleor.checkout.search.indexing.set_search_index_dirty"):
+        with assert_locks_rows_before_write():
+            update_checkouts_search_vector([checkout_with_item])
+
+    # then
+    checkout_with_item.refresh_from_db(fields=("search_vector",))
+    assert checkout_with_item.search_vector

--- a/saleor/page/lock_objects.py
+++ b/saleor/page/lock_objects.py
@@ -4,4 +4,4 @@ from .models import Page
 
 
 def page_qs_select_for_update() -> QuerySet[Page]:
-    return Page.objects.order_by("pk").select_for_update(of=(["self"]))
+    return Page.objects.order_by("pk").select_for_update(of=["self"])

--- a/saleor/page/search.py
+++ b/saleor/page/search.py
@@ -48,7 +48,7 @@ def update_pages_search_vector(
 
     # Save updates
     with transaction.atomic():
-        _locked_pages = (
+        _locked_pages = list(
             page_qs_select_for_update()
             .filter(id__in=[page.id for page in pages])
             .values_list("id", flat=True)

--- a/saleor/page/tests/test_search.py
+++ b/saleor/page/tests/test_search.py
@@ -23,6 +23,27 @@ def test_update_pages_search_vector_multiple_pages(page_list):
         assert page.search_index_dirty is False
 
 
+def test_update_pages_search_vector_locks_rows_before_write(page_list, capture_queries):
+    # when
+    with capture_queries() as ctx:
+        update_pages_search_vector(page_list)
+
+    # then
+    # the lock SELECT should run before the bulk UPDATE.
+    lock_and_update_queries = [
+        query["sql"]
+        for query in ctx.captured_queries
+        if "FOR UPDATE" in query["sql"] or query["sql"].startswith("UPDATE")
+    ]
+    assert len(lock_and_update_queries) == 2
+    lock_query, update_query = lock_and_update_queries
+    assert "FOR UPDATE" in lock_query
+    # pk ordering makes concurrent lockers acquire rows in the same order,
+    # which is what prevents deadlocks between them.
+    assert "ORDER BY" in lock_query
+    assert update_query.startswith("UPDATE")
+
+
 def test_update_pages_search_vector_empty_list(db):
     """Test updating search vector with empty page IDs list."""
     # given
@@ -94,19 +115,20 @@ def test_update_pages_search_vector_constant_queries(
     page_list = page_list_with_attributes
 
     # when & then
-    # Expected query breakdown (10 total):
+    # Expected query breakdown (11 total):
     # 1. Load page types (1 query)
-    # 2. Load page data for select_for_update (1 query)
+    # 2. Load page data (1 query)
     # 3. Load page-attribute relationships (1 query)
     # 4. Load attributes (1 query)
     # 5. Load attribute value assignments - batched (1 query)
     # 6. Load attribute values - batched (1 query)
     # 7. Load reference page titles (1 query)
     # 8. Transaction savepoint (1 query)
-    # 9. Bulk update (1 query)
-    # 10. Release savepoint (1 query)
+    # 9. Lock pages with select_for_update (1 query)
+    # 10. Bulk update (1 query)
+    # 11. Release savepoint (1 query)
 
-    expected_queries = 10
+    expected_queries = 11
     with django_assert_num_queries(expected_queries):  # Expected number of queries
         update_pages_search_vector(page_list[: len(page_list) - 1])
     with django_assert_num_queries(

--- a/saleor/page/tests/test_search.py
+++ b/saleor/page/tests/test_search.py
@@ -23,25 +23,12 @@ def test_update_pages_search_vector_multiple_pages(page_list):
         assert page.search_index_dirty is False
 
 
-def test_update_pages_search_vector_locks_rows_before_write(page_list, capture_queries):
-    # when
-    with capture_queries() as ctx:
+def test_update_pages_search_vector_locks_rows_before_write(
+    page_list, assert_locks_rows_before_write
+):
+    # when/then
+    with assert_locks_rows_before_write():
         update_pages_search_vector(page_list)
-
-    # then
-    # the lock SELECT should run before the bulk UPDATE.
-    lock_and_update_queries = [
-        query["sql"]
-        for query in ctx.captured_queries
-        if "FOR UPDATE" in query["sql"] or query["sql"].startswith("UPDATE")
-    ]
-    assert len(lock_and_update_queries) == 2
-    lock_query, update_query = lock_and_update_queries
-    assert "FOR UPDATE" in lock_query
-    # pk ordering makes concurrent lockers acquire rows in the same order,
-    # which is what prevents deadlocks between them.
-    assert "ORDER BY" in lock_query
-    assert update_query.startswith("UPDATE")
 
 
 def test_update_pages_search_vector_empty_list(db):

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -165,6 +165,39 @@ def assert_max_num_queries(capture_queries):
 
 
 @pytest.fixture
+def assert_locks_rows_before_write(capture_queries):
+    """Assert that the wrapped block locks rows before writing them.
+
+    Verifies the emitted SQL contains exactly one `SELECT ... FOR UPDATE` with a
+    deterministic `ORDER BY` (concurrent lockers acquiring rows in the same
+    order is what prevents deadlocks between them), followed by exactly one
+    `UPDATE`. Asserting on SQL is deliberate, as a missing lock is hard to
+    detect with a behavioral test.
+    """
+
+    @contextmanager
+    def _assert_locks_rows_before_write():
+        with capture_queries() as ctx:
+            yield
+
+        lock_and_update_queries = [
+            query["sql"]
+            for query in ctx.captured_queries
+            if "FOR UPDATE" in query["sql"] or query["sql"].startswith("UPDATE")
+        ]
+        assert len(lock_and_update_queries) == 2, (
+            "expected exactly one lock SELECT and one UPDATE query, got: "
+            f"{lock_and_update_queries}"
+        )
+        lock_query, update_query = lock_and_update_queries
+        assert "FOR UPDATE" in lock_query, "rows were not locked before the write"
+        assert "ORDER BY" in lock_query, "the lock query has no deterministic order"
+        assert update_query.startswith("UPDATE")
+
+    return _assert_locks_rows_before_write
+
+
+@pytest.fixture
 def address(db):  # pylint: disable=W0613
     return Address.objects.create(
         first_name="John",


### PR DESCRIPTION
While working on other stuff, I found locking code where the `select_for_update` queryset was built and assigned but never evaluated. Querysets are lazy, so no SQL ran at all - no `FOR UPDATE` lock was taken and the `bulk_update` that followed ran unlocked, in arbitrary row order (deadlock risk against other writers)

- Fixed by forcing evaluation with `list(...)` inside the transaction
- Added the `assert_locks_rows_before_write` fixture, which asserts an ordered
  `FOR UPDATE` query runs before the `UPDATE` - to catch missing locks
- Documented the pitfall in `AGENTS.md`

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
