### PR TITLE
Improve transaction API error messages with event details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Improved transaction API error messages for duplicate events to include `pspReference`, event type, and amount details - #13951
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -25,6 +25,8 @@ from .....payment.utils import (
     authorization_success_already_exists,
     create_failed_transaction_event,
     get_already_existing_event,
+    get_authorization_success_already_exists_error_message,
+    get_event_amount_mismatch_error_message,
     get_source_object,
     get_transaction_event_amount,
     invalidate_cache_for_stored_payment_methods_if_needed,
@@ -408,9 +410,8 @@ class TransactionEventReport(DeprecatedModelMutation):
             existing_event = get_already_existing_event(transaction_event)
             if existing_event and existing_event.amount != transaction_event.amount:
                 error_code = TransactionEventReportErrorCode.INCORRECT_DETAILS.value
-                error_msg = (
-                    "The transaction with provided `pspReference` and "
-                    "`type` already exists with different amount."
+                error_msg = get_event_amount_mismatch_error_message(
+                    transaction_event, existing_event
                 )
                 error_field = "pspReference"
             elif existing_event:
@@ -421,11 +422,8 @@ class TransactionEventReport(DeprecatedModelMutation):
                 and authorization_success_already_exists(transaction.pk)
             ):
                 error_code = TransactionEventReportErrorCode.ALREADY_EXISTS.value
-                error_msg = (
-                    "Event with `AUTHORIZATION_SUCCESS` already "
-                    "reported for the transaction. Use "
-                    "`AUTHORIZATION_ADJUSTMENT` to change the "
-                    "authorization amount."
+                error_msg = get_authorization_success_already_exists_error_message(
+                    psp_reference=transaction_event.psp_reference
                 )
                 error_field = "type"
             else:

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -156,7 +156,8 @@ class TransactionUpdate(TransactionCreate):
                 raise ValidationError(
                     {
                         "transaction": ValidationError(
-                            "Transaction with provided `pspReference` already exists.",
+                            "Transaction with provided `pspReference` "
+                            f"({psp_reference}) already exists.",
                             code=TransactionUpdateErrorCode.UNIQUE.value,
                         )
                     }

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -935,6 +935,10 @@ def test_transaction_event_report_incorrect_amount_for_already_existing(
     error = transaction_report_data["errors"][0]
     assert error["code"] == TransactionEventReportErrorCode.INCORRECT_DETAILS.name
     assert error["field"] == "pspReference"
+    assert psp_reference in error["message"]
+    assert TransactionEventType.CHARGE_SUCCESS in error["message"]
+    assert str(already_existing_amount) in error["message"]
+    assert str(new_amount) in error["message"]
 
     assert TransactionEvent.objects.count() == 2
     event = TransactionEvent.objects.filter(
@@ -942,6 +946,7 @@ def test_transaction_event_report_incorrect_amount_for_already_existing(
     ).first()
     assert event
     assert event.include_in_calculations is False
+    assert event.message == error["message"]
 
 
 @patch(

--- a/saleor/payment/tests/test_utils/test_utils.py
+++ b/saleor/payment/tests/test_utils/test_utils.py
@@ -2673,8 +2673,11 @@ def test_deduplicate_event_different_amount(
     # then
     assert result_event.id == events[0].id
     assert err_msg == (
-        "The transaction with provided `pspReference` and "
-        "`type` already exists with different amount."
+        "The transaction with provided `pspReference` "
+        f"({event.psp_reference}) and `type` ({event.type}) "
+        "already exists with different amount. "
+        f"Existing amount: {events[0].amount_value} {events[0].currency}, "
+        f"received amount: {event.amount_value} {event.currency}."
     )
     assert caplog.records[0].levelno == logging.WARNING
     assert caplog.records[0].message == err_msg
@@ -2705,7 +2708,8 @@ def test_deduplicate_event_authorization_already_exists(
     assert result_event
     assert err_msg == (
         "Event with `AUTHORIZATION_SUCCESS` already "
-        "reported for the transaction. Use "
+        "reported for the transaction. "
+        f"Reported `pspReference`: {event.psp_reference}. Use "
         "`AUTHORIZATION_ADJUSTMENT` to change the "
         "authorization amount."
     )

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1151,6 +1151,35 @@ def get_already_existing_event(event: TransactionEvent) -> TransactionEvent | No
     return None
 
 
+def get_event_amount_mismatch_error_message(
+    event: TransactionEvent, existing_event: TransactionEvent
+) -> str:
+    """Build a detailed error for conflicting duplicate transaction events."""
+    return (
+        "The transaction with provided `pspReference` "
+        f"({event.psp_reference}) and `type` ({event.type}) "
+        "already exists with different amount. "
+        f"Existing amount: {existing_event.amount_value} {existing_event.currency}, "
+        f"received amount: {event.amount_value} {event.currency}."
+    )
+
+
+def get_authorization_success_already_exists_error_message(
+    *, psp_reference: str | None = None
+) -> str:
+    """Build a detailed error when AUTHORIZATION_SUCCESS was already reported."""
+    psp_reference_details = ""
+    if psp_reference:
+        psp_reference_details = f" Reported `pspReference`: {psp_reference}."
+    return (
+        "Event with `AUTHORIZATION_SUCCESS` already "
+        "reported for the transaction."
+        f"{psp_reference_details} Use "
+        "`AUTHORIZATION_ADJUSTMENT` to change the "
+        "authorization amount."
+    )
+
+
 def deduplicate_event(
     event: TransactionEvent, app: App | None
 ) -> tuple[TransactionEvent, ErrorMsg | None]:
@@ -1168,9 +1197,8 @@ def deduplicate_event(
     already_existing_event = get_already_existing_event(event)
     if already_existing_event:
         if already_existing_event.amount != event.amount:
-            error_message = (
-                "The transaction with provided `pspReference` and "
-                "`type` already exists with different amount."
+            error_message = get_event_amount_mismatch_error_message(
+                event, already_existing_event
             )
         event = already_existing_event
 
@@ -1179,11 +1207,8 @@ def deduplicate_event(
             event.transaction_id
         )
         if already_existing_authorization:
-            error_message = (
-                "Event with `AUTHORIZATION_SUCCESS` already "
-                "reported for the transaction. Use "
-                "`AUTHORIZATION_ADJUSTMENT` to change the "
-                "authorization amount."
+            error_message = get_authorization_success_already_exists_error_message(
+                psp_reference=event.psp_reference
             )
     if error_message:
         logger.warning(


### PR DESCRIPTION
Enrich duplicate/conflict transaction event errors with pspReference, type, and amounts for clearer API feedback.
Fixes #13951