### PR TITLE
Reduce checkout and shipping dataclass representations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other changes
 
+- Reduced the default representations of checkout and shipping data classes to keep error reports focused on diagnostic identifiers and counts - #15123
 - Dropped the database leftovers of the legacy digital content feature removed in 3.23: the `product_digitalcontent` and `product_digitalcontenturl` tables, and the `automatic_fulfillment_digital_products`, `default_digital_max_downloads` and `default_digital_url_valid_days` columns of `site_sitesettings`. Files uploaded through the legacy API are not removed from the media storage — the `digital_contents/` directory can be deleted manually.
 - `ProductType.is_digital` was removed from the ORM model; the column itself will be dropped in 3.25.
 - Removed the `is_digital` field from the `populatedb` sample data.

--- a/saleor/checkout/delivery_context.py
+++ b/saleor/checkout/delivery_context.py
@@ -81,6 +81,14 @@ class ShippingMethodInfo(DeliveryMethodBase):
     shipping_address: Optional["Address"]
     store_as_customer_address: bool = True
 
+    def __repr__(self):
+        shipping_address_id = getattr(self.shipping_address, "pk", None)
+        return (
+            f"ShippingMethodInfo(delivery_method={self.delivery_method!r}, "
+            f"shipping_address_id={shipping_address_id!r}, "
+            f"store_as_customer_address={self.store_as_customer_address!r})"
+        )
+
     @property
     def delivery_method_name(self) -> dict[str, str | None]:
         return {"shipping_method_name": str(self.delivery_method.name)}

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -62,6 +62,14 @@ class CheckoutLineInfo(LineInfo):
 
     tax_class: Optional["TaxClass"] = field(default=None, repr=False)
 
+    def __repr__(self):
+        return (
+            f"CheckoutLineInfo(line_id={getattr(self.line, 'pk', None)!r}, "
+            f"variant_id={getattr(self.variant, 'pk', None)!r}, "
+            f"quantity={getattr(self.line, 'quantity', None)!r}, "
+            f"discounts={len(self.discounts)!r})"
+        )
+
     @cached_property
     def variant_discounted_price(self) -> Money:
         """Return the discounted variant price.
@@ -129,6 +137,14 @@ class CheckoutInfo:
     database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME
 
     allow_sync_webhooks: bool = True
+
+    def __repr__(self):
+        return (
+            f"CheckoutInfo(checkout_id={getattr(self.checkout, 'pk', None)!r}, "
+            f"user_id={getattr(self.user, 'pk', None)!r}, "
+            f"channel_id={getattr(self.channel, 'pk', None)!r}, "
+            f"lines={len(self.lines)!r}, discounts={len(self.discounts)!r})"
+        )
 
     @cached_property
     def valid_pick_up_points(self) -> Iterable["Warehouse"]:

--- a/saleor/checkout/tests/test_repr.py
+++ b/saleor/checkout/tests/test_repr.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from prices import Money
+
+from ...shipping.interface import ShippingMethodData
+from ..delivery_context import ShippingMethodInfo
+from ..fetch import CheckoutInfo, CheckoutLineInfo
+
+
+def test_shipping_method_data_repr_omits_metadata():
+    shipping_method = ShippingMethodData(
+        id="shipping-1",
+        name="Express",
+        price=Money("12.00", "USD"),
+        metadata={"internal": "value"},
+    )
+
+    result = repr(shipping_method)
+
+    assert result == (
+        "ShippingMethodData(id='shipping-1', name='Express', price=12.00 USD, "
+        "active=True)"
+    )
+    assert "internal" not in result
+
+
+def test_shipping_method_info_repr_uses_address_id():
+    shipping_method = ShippingMethodData("shipping-1", Money("12.00", "USD"))
+
+    result = repr(ShippingMethodInfo(shipping_method, SimpleNamespace(pk=42)))
+
+    assert result == (
+        "ShippingMethodInfo(delivery_method=ShippingMethodData(id='shipping-1', "
+        "name=None, price=12.00 USD, active=True), shipping_address_id=42, "
+        "store_as_customer_address=True)"
+    )
+
+
+def test_checkout_info_repr_is_compact():
+    checkout_info = CheckoutInfo.__new__(CheckoutInfo)
+    checkout_info.checkout = SimpleNamespace(pk=10)
+    checkout_info.user = SimpleNamespace(pk=11)
+    checkout_info.channel = SimpleNamespace(pk=12)
+    checkout_info.lines = [object(), object()]
+    checkout_info.discounts = [object()]
+
+    assert repr(checkout_info) == (
+        "CheckoutInfo(checkout_id=10, user_id=11, channel_id=12, lines=2, discounts=1)"
+    )
+
+
+def test_checkout_line_info_repr_is_compact():
+    checkout_line_info = CheckoutLineInfo.__new__(CheckoutLineInfo)
+    checkout_line_info.line = SimpleNamespace(pk=20, quantity=3)
+    checkout_line_info.variant = SimpleNamespace(pk=21)
+    checkout_line_info.discounts = [object(), object()]
+
+    assert repr(checkout_line_info) == (
+        "CheckoutLineInfo(line_id=20, variant_id=21, quantity=3, discounts=2)"
+    )

--- a/saleor/shipping/interface.py
+++ b/saleor/shipping/interface.py
@@ -34,6 +34,12 @@ class ShippingMethodData:
     active: bool = True
     message: str = ""
 
+    def __repr__(self):
+        return (
+            f"ShippingMethodData(id={self.id!r}, name={self.name!r}, "
+            f"price={self.price}, active={self.active!r})"
+        )
+
     @property
     def is_external(self) -> bool:
         try:


### PR DESCRIPTION
Add compact __repr__ for checkout/shipping info objects to keep Sentry useful without dumping full models or metadata.
Fixes #15123