### PR TITLE
Allow staff to update own profile without MANAGE_STAFF (#11691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Fixed `staffUpdate` requiring `MANAGE_STAFF` for a staff member to change their own basic profile (first name, last name, email, language). Staff can now update those fields on their own account without `MANAGE_STAFF`; privileged fields still require it. `StaffUpdateInput` also accepts `languageCode` - #11691 by @richardmilles
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/account/mutations/staff/staff_update.py
+++ b/saleor/graphql/account/mutations/staff/staff_update.py
@@ -5,15 +5,18 @@ from django.core.exceptions import ValidationError
 
 from .....account import models
 from .....account.error_codes import AccountErrorCode
+from .....core.exceptions import PermissionDenied
 from .....core.tracing import traced_atomic_transaction
 from .....giftcard.search import mark_gift_cards_search_index_as_dirty
 from .....giftcard.utils import assign_user_gift_cards, get_user_gift_cards
 from .....order.utils import match_orders_with_new_user
+from .....permission.auth_filters import AuthorizationFilters
 from .....permission.enums import AccountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....account.types import User
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
+from ....core.enums import LanguageCodeEnum
 from ....core.types import NonNullList, StaffError
 from ....core.utils import WebhookEventInfo
 from ....plugins.dataloaders import get_plugin_manager_promise
@@ -24,8 +27,17 @@ from ...utils import (
 )
 from .staff_create import StaffCreate, StaffInput
 
+# Personal fields a staff member may change on their own account without
+# MANAGE_STAFF (see saleor/saleor#11691).
+STAFF_SELF_UPDATE_FIELDS = frozenset(
+    {"first_name", "last_name", "email", "language_code"}
+)
+
 
 class StaffUpdateInput(StaffInput):
+    language_code = graphene.Field(
+        LanguageCodeEnum, required=False, description="User language code."
+    )
     remove_groups = NonNullList(
         graphene.ID,
         description=(
@@ -47,15 +59,22 @@ class StaffUpdate(StaffCreate):
         )
 
     class Meta:
+        auto_permission_message = False
         description = (
             "Updates an existing staff user. "
-            "Apps are not allowed to perform this mutation."
+            "Apps are not allowed to perform this mutation.\n\n"
+            "Requires one of the following permissions: MANAGE_STAFF.\n"
+            "Staff members can update their own first name, last name, email, "
+            "and language code without the MANAGE_STAFF permission."
         )
         doc_category = DOC_CATEGORY_USERS
         exclude = ["password"]
         model = models.User
         object_type = User
-        permissions = (AccountPermissions.MANAGE_STAFF,)
+        permissions = (
+            AccountPermissions.MANAGE_STAFF,
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+        )
         error_type_class = StaffError
         error_type_field = "staff_errors"
         support_meta_field = True
@@ -71,8 +90,10 @@ class StaffUpdate(StaffCreate):
     def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
         user = info.context.user
         user = cast(models.User, user)
+        if not user.has_perm(AccountPermissions.MANAGE_STAFF):
+            cls._validate_self_profile_update(user, instance, data)
         # check if user can manage this user
-        if not user.is_superuser and get_out_of_scope_users(user, [instance]):
+        elif not user.is_superuser and get_out_of_scope_users(user, [instance]):
             msg = "You can't manage this user."
             code = AccountErrorCode.OUT_OF_SCOPE_USER.value
             raise ValidationError({"id": ValidationError(msg, code=code)})
@@ -85,6 +106,18 @@ class StaffUpdate(StaffCreate):
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
 
         return cleaned_input
+
+    @classmethod
+    def _validate_self_profile_update(
+        cls, requestor: models.User, instance: models.User, data: dict
+    ):
+        """Allow staff without MANAGE_STAFF to edit only their own basic profile."""
+        if requestor.pk != instance.pk:
+            raise PermissionDenied(permissions=[AccountPermissions.MANAGE_STAFF])
+
+        provided_fields = {key for key, value in data.items() if value is not None}
+        if not provided_fields.issubset(STAFF_SELF_UPDATE_FIELDS):
+            raise PermissionDenied(permissions=[AccountPermissions.MANAGE_STAFF])
 
     @classmethod
     def clean_groups(cls, requestor: models.User, cleaned_input: dict, errors: dict):

--- a/saleor/graphql/account/tests/mutations/staff/test_staff_update.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_staff_update.py
@@ -39,6 +39,9 @@ STAFF_UPDATE_MUTATIONS = """
                 }
                 isActive
                 email
+                firstName
+                lastName
+                languageCode
                 metadata {
                     key
                     value
@@ -652,3 +655,95 @@ def test_staff_update_trigger_gift_card_search_vector_update(
     for card in gift_card_list:
         card.refresh_from_db()
         assert card.search_index_dirty is True
+
+
+def test_staff_update_own_profile_without_manage_staff(staff_api_client):
+    # given
+    user = staff_api_client.user
+    assert not user.has_perm(AccountPermissions.MANAGE_STAFF)
+    user_id = graphene.Node.to_global_id("User", user.id)
+    first_name = "Jane"
+    last_name = "Doe"
+    email = "jane.doe@example.com"
+    language_code = "PL"
+    variables = {
+        "id": user_id,
+        "input": {
+            "firstName": first_name,
+            "lastName": last_name,
+            "email": email,
+            "languageCode": language_code,
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(STAFF_UPDATE_MUTATIONS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["staffUpdate"]
+    assert data["errors"] == []
+    assert data["user"]["firstName"] == first_name
+    assert data["user"]["lastName"] == last_name
+    assert data["user"]["email"] == email
+    assert data["user"]["languageCode"] == language_code
+    user.refresh_from_db()
+    assert user.first_name == first_name
+    assert user.last_name == last_name
+    assert user.email == email
+    assert user.language_code == language_code.lower()
+
+
+def test_staff_update_another_user_without_manage_staff_denied(staff_api_client):
+    # given
+    other_staff = User.objects.create(email="other-staff@example.com", is_staff=True)
+    variables = {
+        "id": graphene.Node.to_global_id("User", other_staff.id),
+        "input": {"firstName": "Hacker"},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(STAFF_UPDATE_MUTATIONS, variables)
+
+    # then
+    assert_no_permission(response)
+    other_staff.refresh_from_db()
+    assert other_staff.first_name == ""
+
+
+def test_staff_update_own_privileged_fields_without_manage_staff_denied(
+    staff_api_client,
+):
+    # given
+    user = staff_api_client.user
+    variables = {
+        "id": graphene.Node.to_global_id("User", user.id),
+        "input": {"isActive": False},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(STAFF_UPDATE_MUTATIONS, variables)
+
+    # then
+    assert_no_permission(response)
+    user.refresh_from_db()
+    assert user.is_active is True
+
+
+def test_staff_update_own_groups_without_manage_staff_denied(
+    staff_api_client, permission_group_manage_users
+):
+    # given
+    user = staff_api_client.user
+    group_id = graphene.Node.to_global_id("Group", permission_group_manage_users.pk)
+    variables = {
+        "id": graphene.Node.to_global_id("User", user.id),
+        "input": {"addGroups": [group_id]},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(STAFF_UPDATE_MUTATIONS, variables)
+
+    # then
+    assert_no_permission(response)
+    assert not user.groups.filter(pk=permission_group_manage_users.pk).exists()


### PR DESCRIPTION
Allow staff to update their own name, email, and language via staffUpdate without MANAGE_STAFF; privileged fields still require it.
Fixes #11691