### PR TITLE
Handle PaymentError in orderConfirm (#15244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Fixed `orderConfirm` raising an unhandled exception when payment capture fails. The mutation now returns a `PAYMENT_ERROR` and records a payment-failed order event - #15244 by @richardmilles
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -27,6 +27,7 @@ from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Order
+from .utils import try_payment_action
 
 
 class OrderConfirm(DeprecatedModelMutation):
@@ -81,14 +82,29 @@ class OrderConfirm(DeprecatedModelMutation):
         manager = get_plugin_manager_promise(info.context).get()
         app = get_app_promise(info.context).get()
         webhook_events = WEBHOOK_EVENTS_FOR_ORDER_CONFIRMED
-        webhook_event_map = None
+        authorized_payment = None
+        site = None
+
+        # Capture outside the atomic block so PaymentError handling (and the
+        # payment-failed order event) is not rolled back with the transaction.
+        if payment and payment.is_authorized and payment.can_capture():
+            authorized_payment = payment
+            try_payment_action(
+                order,
+                user,
+                app,
+                payment,
+                gateway.capture,
+                payment,
+                manager,
+                channel_slug=order.channel.slug,
+            )
+            site = get_site_promise(info.context).get()
+            webhook_events = webhook_events.union(WEBHOOK_EVENTS_FOR_ORDER_CHARGED)
+
         with traced_atomic_transaction():
-            if payment and payment.is_authorized and payment.can_capture():
-                authorized_payment = payment
-                gateway.capture(payment, manager, channel_slug=order.channel.slug)
-                site = get_site_promise(info.context).get()
-                webhook_events = webhook_events.union(WEBHOOK_EVENTS_FOR_ORDER_CHARGED)
-                webhook_event_map = get_webhooks_for_multiple_events(webhook_events)
+            webhook_event_map = get_webhooks_for_multiple_events(webhook_events)
+            if authorized_payment is not None:
                 transaction.on_commit(
                     lambda: order_charged(
                         order_info,
@@ -98,12 +114,10 @@ class OrderConfirm(DeprecatedModelMutation):
                         authorized_payment,
                         manager,
                         site.settings,
-                        payment.gateway,
+                        authorized_payment.gateway,
                         webhook_event_map=webhook_event_map,
                     )
                 )
-            if webhook_event_map is None:
-                webhook_event_map = get_webhooks_for_multiple_events(webhook_events)
 
             transaction.on_commit(
                 lambda: order_confirmed(

--- a/saleor/graphql/order/tests/mutations/test_order_confirm.py
+++ b/saleor/graphql/order/tests/mutations/test_order_confirm.py
@@ -22,6 +22,7 @@ from .....order.fetch import fetch_order_info
 from .....order.models import OrderEvent
 from .....order.notifications import get_default_order_payload
 from .....order.utils import updates_amounts_for_order
+from .....payment import PaymentError
 from .....product.models import ProductVariant
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.transport.asynchronous.transport import generate_deferred_payloads
@@ -331,6 +332,44 @@ def test_order_confirm_wont_call_capture_for_non_active_payment(
         type=order_events.OrderEvents.CONFIRMED,
     ).exists()
     assert not capture_mock.called
+
+
+@patch("saleor.payment.gateway.capture")
+def test_order_confirm_payment_error(
+    capture_mock,
+    staff_api_client,
+    order_unconfirmed,
+    permission_group_manage_orders,
+    payment_txn_preauth,
+):
+    # given
+    message = "Capture failed"
+    capture_mock.side_effect = PaymentError(message)
+    payment_txn_preauth.order = order_unconfirmed
+    payment_txn_preauth.save(update_fields=["order"])
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    assert not OrderEvent.objects.exists()
+
+    # when
+    response = staff_api_client.post_graphql(
+        ORDER_CONFIRM_MUTATION,
+        {"id": graphene.Node.to_global_id("Order", order_unconfirmed.id)},
+    )
+
+    # then
+    content = get_graphql_content(response)["data"]["orderConfirm"]
+    assert content["order"] is None
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["field"] == "payment"
+    assert content["errors"][0]["code"] == OrderErrorCode.PAYMENT_ERROR.name
+    assert OrderEvent.objects.filter(
+        order=order_unconfirmed,
+        user=staff_api_client.user,
+        type=order_events.OrderEvents.PAYMENT_FAILED,
+    ).exists()
+    capture_mock.assert_called_once_with(
+        payment_txn_preauth, ANY, channel_slug=order_unconfirmed.channel.slug
+    )
 
 
 def test_order_confirm_update_display_gross_prices(


### PR DESCRIPTION
Wrap orderConfirm capture with try_payment_action so failures return PAYMENT_ERROR instead of a 500.
Fixes #15244