### PR TITLE
Enforce unique tax class names (#15181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Enforced unique names for tax classes. Creating or updating a tax class with a duplicate name now returns a `UNIQUE` error, and a migration renames existing duplicates before adding the database constraint - #15181 by @richardmilles
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22672,10 +22672,11 @@ enum TaxClassCreateErrorCode @doc(category: "Taxes") {
   GRAPHQL_ERROR
   INVALID
   NOT_FOUND
+  UNIQUE
 }
 
 input TaxClassCreateInput @doc(category: "Taxes") {
-  """Name of the tax class."""
+  """Name of the tax class. Must be unique."""
   name: String!
 
   """List of country-specific tax rates to create for this tax class."""
@@ -22752,10 +22753,11 @@ enum TaxClassUpdateErrorCode @doc(category: "Taxes") {
   GRAPHQL_ERROR
   INVALID
   NOT_FOUND
+  UNIQUE
 }
 
 input TaxClassUpdateInput @doc(category: "Taxes") {
-  """Name of the tax class."""
+  """Name of the tax class. Must be unique."""
   name: String
 
   """

--- a/saleor/graphql/tax/mutations/tax_class_create.py
+++ b/saleor/graphql/tax/mutations/tax_class_create.py
@@ -45,7 +45,9 @@ class CountryRateInput(BaseInputObjectType):
 
 
 class TaxClassCreateInput(BaseInputObjectType):
-    name = graphene.String(description="Name of the tax class.", required=True)
+    name = graphene.String(
+        description="Name of the tax class. Must be unique.", required=True
+    )
     create_country_rates = NonNullList(
         CountryRateInput,
         description="List of country-specific tax rates to create for this tax class.",

--- a/saleor/graphql/tax/mutations/tax_class_update.py
+++ b/saleor/graphql/tax/mutations/tax_class_update.py
@@ -48,7 +48,7 @@ class TaxClassUpdateError(Error):
 
 
 class TaxClassUpdateInput(BaseInputObjectType):
-    name = graphene.String(description="Name of the tax class.")
+    name = graphene.String(description="Name of the tax class. Must be unique.")
     update_country_rates = NonNullList(
         CountryRateUpdateInput,
         description=(

--- a/saleor/graphql/tax/tests/mutations/test_tax_class_create.py
+++ b/saleor/graphql/tax/tests/mutations/test_tax_class_create.py
@@ -1,3 +1,5 @@
+from .....tax.error_codes import TaxClassCreateErrorCode
+from .....tax.models import TaxClass
 from ....tests.utils import assert_no_permission, get_graphql_content
 from ..fragments import TAX_CLASS_FRAGMENT
 
@@ -75,3 +77,24 @@ def test_create_as_staff(staff_api_client, permission_manage_taxes):
 
 def test_create_as_app(app_api_client, permission_manage_taxes):
     _test_tax_class_create(app_api_client, permission_manage_taxes)
+
+
+def test_create_rejects_duplicate_name(staff_api_client, permission_manage_taxes):
+    # given
+    name = "Existing tax class"
+    TaxClass.objects.create(name=name)
+    variables = {"input": {"name": name}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION, variables, permissions=[permission_manage_taxes]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["taxClassCreate"]
+    assert data["taxClass"] is None
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["field"] == "name"
+    assert data["errors"][0]["code"] == TaxClassCreateErrorCode.UNIQUE.name
+    assert TaxClass.objects.filter(name=name).count() == 1

--- a/saleor/graphql/tax/tests/mutations/test_tax_class_update.py
+++ b/saleor/graphql/tax/tests/mutations/test_tax_class_update.py
@@ -247,3 +247,30 @@ def test_tax_class_update_zero_rate(staff_api_client, permission_manage_taxes):
     assert data["taxClass"]["name"] == new_name
     assert len(data["taxClass"]["countries"]) == 1
     assert data["taxClass"]["countries"][0]["rate"] == 0.0
+
+
+def test_tax_class_update_rejects_duplicate_name(
+    staff_api_client, permission_manage_taxes
+):
+    # given
+    existing = TaxClass.objects.create(name="Existing tax class")
+    tax_class = TaxClass.objects.create(name="Other tax class")
+    variables = {
+        "id": graphene.Node.to_global_id("TaxClass", tax_class.pk),
+        "input": {"name": existing.name},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION, variables, permissions=[permission_manage_taxes]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["taxClassUpdate"]
+    assert data["taxClass"] is None
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["field"] == "name"
+    assert data["errors"][0]["code"] == TaxClassUpdateErrorCode.UNIQUE.name
+    tax_class.refresh_from_db()
+    assert tax_class.name == "Other tax class"

--- a/saleor/tax/error_codes.py
+++ b/saleor/tax/error_codes.py
@@ -19,6 +19,7 @@ class TaxClassCreateErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     INVALID = "invalid"
     NOT_FOUND = "not_found"
+    UNIQUE = "unique"
 
 
 class TaxClassUpdateErrorCode(Enum):
@@ -26,6 +27,7 @@ class TaxClassUpdateErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     INVALID = "invalid"
     NOT_FOUND = "not_found"
+    UNIQUE = "unique"
 
 
 class TaxClassDeleteErrorCode(Enum):

--- a/saleor/tax/migrations/0012_taxclass_name_unique.py
+++ b/saleor/tax/migrations/0012_taxclass_name_unique.py
@@ -1,0 +1,40 @@
+# Generated manually for https://github.com/saleor/saleor/issues/15181
+
+from django.db import migrations, models
+from django.db.models import Count
+
+
+def make_tax_class_names_unique(apps, schema_editor):
+    TaxClass = apps.get_model("tax", "TaxClass")
+    duplicate_names = list(
+        TaxClass.objects.values("name")
+        .annotate(name_count=Count("id"))
+        .filter(name_count__gt=1)
+        .values_list("name", flat=True)
+    )
+    for name in duplicate_names:
+        duplicates = list(TaxClass.objects.filter(name=name).order_by("pk"))
+        for tax_class in duplicates[1:]:
+            new_name = f"{name} ({tax_class.pk})"
+            while TaxClass.objects.filter(name=new_name).exists():
+                new_name = f"{new_name}*"
+            tax_class.name = new_name
+            tax_class.save(update_fields=["name"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tax", "0011_merge_20250530_0929"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            make_tax_class_names_unique,
+            migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="taxclass",
+            name="name",
+            field=models.CharField(max_length=255, unique=True),
+        ),
+    ]

--- a/saleor/tax/models.py
+++ b/saleor/tax/models.py
@@ -8,7 +8,7 @@ from . import TaxCalculationStrategy
 
 
 class TaxClass(ModelWithMetadata):
-    name = models.CharField(max_length=255)
+    name = models.CharField(max_length=255, unique=True)
 
     class Meta:
         ordering = ("name", "pk")


### PR DESCRIPTION
Make tax class names unique at DB and API level, with a migration that renames existing duplicates first.
Fixes #15181