### PR TITLE
Include variant and line IDs in insufficient stock checkout errors (#14942)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Fixed `INSUFFICIENT_STOCK` checkout errors missing `variants` and `lines` IDs in `checkoutLinesUpdate` / `checkoutLinesAdd`. The error now includes the affected variant GraphQL IDs and, when the variant is already on the checkout, the related line IDs - #14942 by @richardmilles
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -35,6 +35,7 @@ from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_323
 from ...core.validators import validate_one_of_args_is_in_mutation
 from ..types import Checkout
+from ..utils import get_insufficient_stock_checkout_error_params
 
 if TYPE_CHECKING:
     from ...core.mutations import BaseMutation
@@ -152,6 +153,9 @@ def check_lines_quantity(
                 f"Could not add items {item.variant}. "
                 f"Only {max(item.available_quantity, 0)} remaining in stock.",
                 code=e.code.value,
+                params=get_insufficient_stock_checkout_error_params(
+                    item, existing_lines=existing_lines
+                ),
             )
             for item in e.items
         ]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -1668,6 +1668,30 @@ def test_checkout_lines_add_with_insufficient_stock(
     assert errors[0]["field"] == "quantity"
 
 
+def test_checkout_lines_add_insufficient_stock_includes_variant_id(
+    user_api_client, checkout_with_item, stock
+):
+    # given
+    variant = stock.product_variant
+    checkout = checkout_with_item
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "lines": [{"variantId": variant_id, "quantity": 49}],
+        "channelSlug": checkout.channel.slug,
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
+
+    # then
+    content = get_graphql_content(response)
+    error = content["data"]["checkoutLinesAdd"]["errors"][0]
+    assert error["code"] == CheckoutErrorCode.INSUFFICIENT_STOCK.name
+    assert error["field"] == "quantity"
+    assert error["variants"] == [variant_id]
+
+
 def test_checkout_lines_add_with_reserved_insufficient_stock(
     site_settings_with_reservations,
     user_api_client,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -464,6 +464,36 @@ def test_checkout_lines_update_only_stock_in_cc_warehouse_delivery_method_set(
     assert data["errors"][0]["field"] == "quantity"
 
 
+def test_checkout_lines_update_insufficient_stock_includes_variant_and_line_ids(
+    user_api_client, checkout_with_item
+):
+    # given
+    checkout = checkout_with_item
+    line = checkout.lines.first()
+    variant = line.variant
+    stock = variant.stocks.first()
+    stock.quantity = 0
+    stock.save(update_fields=["quantity"])
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "lines": [{"variantId": variant_id, "quantity": 1}],
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    error = content["data"]["checkoutLinesUpdate"]["errors"][0]
+    assert error["code"] == CheckoutErrorCode.INSUFFICIENT_STOCK.name
+    assert error["field"] == "quantity"
+    assert error["variants"] == [variant_id]
+    assert error["lines"] == [line_id]
+
+
 def test_checkout_lines_update_checkout_with_voucher(
     user_api_client, checkout_with_item, voucher_percentage
 ):

--- a/saleor/graphql/checkout/utils.py
+++ b/saleor/graphql/checkout/utils.py
@@ -1,20 +1,55 @@
 import graphene
 from django.core.exceptions import ValidationError
 
-from ...core.exceptions import CircularSubscriptionSyncEvent
+from ...core.exceptions import CircularSubscriptionSyncEvent, InsufficientStockData
 from ...webhook.event_types import WebhookEventSyncType
+
+
+def get_insufficient_stock_checkout_error_params(
+    item: InsufficientStockData, existing_lines=None
+) -> dict:
+    """Build CheckoutError params for an insufficient-stock item.
+
+    Always includes the variant GraphQL ID when available. Includes checkout line
+    IDs when the stock error is tied to an existing checkout line.
+    """
+    params: dict = {}
+    if item.variant and item.variant.pk is not None:
+        params["variants"] = [
+            graphene.Node.to_global_id("ProductVariant", item.variant.pk)
+        ]
+
+    checkout_line = item.checkout_line
+    if checkout_line is None and existing_lines and item.variant:
+        for line_info in existing_lines:
+            if line_info.variant.pk == item.variant.pk:
+                checkout_line = line_info.line
+                break
+
+    if checkout_line is not None and checkout_line.pk is not None:
+        params["lines"] = [
+            graphene.Node.to_global_id("CheckoutLine", checkout_line.pk)
+        ]
+    return params
 
 
 def prepare_insufficient_stock_checkout_validation_error(exc):
     variants = [str(item.variant) for item in exc.items]
-    variant_ids = [
-        graphene.Node.to_global_id("ProductVariant", item.variant.pk)
-        for item in exc.items
-    ]
+    variant_ids = []
+    line_ids = []
+    for item in exc.items:
+        params = get_insufficient_stock_checkout_error_params(item)
+        variant_ids.extend(params.get("variants", []))
+        line_ids.extend(params.get("lines", []))
+    error_params: dict = {}
+    if variant_ids:
+        error_params["variants"] = variant_ids
+    if line_ids:
+        error_params["lines"] = line_ids
     return ValidationError(
         f"Insufficient product stock: {', '.join(variants)}",
         code=exc.code.value,
-        params={"variants": variant_ids},
+        params=error_params,
     )
 
 


### PR DESCRIPTION
Include variants and lines GraphQL IDs on INSUFFICIENT_STOCK errors from checkout line quantity checks.
Fixes #14942