### PR TITLE
Limit checkout line list inputs to 100 items (#19209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Limited checkout line list inputs (`checkoutCreate`, `checkoutLinesAdd`, `checkoutLinesUpdate`, `checkoutLinesDelete`) to a maximum of 100 items, returning an `INVALID` error when exceeded - #19209 by @richardmilles
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -34,12 +34,14 @@ from ...product.types import ProductVariant
 from ...site.dataloaders import get_site_promise
 from ..types import Checkout
 from .utils import (
+    CHECKOUT_LINES_INPUT_LIMIT,
     PRICE_OVERRIDE_REASON_INPUT_DESCRIPTION,
     apply_gift_reward_if_applicable_on_checkout_creation,
     check_lines_quantity,
     check_permissions_for_custom_prices,
     get_variants_and_total_quantities,
     group_lines_input_on_add,
+    validate_checkout_lines_input_limit,
     validate_price_override_reason,
     validate_variants_are_published,
     validate_variants_available_for_purchase,
@@ -143,7 +145,7 @@ class CheckoutCreateInput(BaseInputObjectType):
         description=(
             "A list of checkout lines, each containing information about "
             "an item in the checkout. When omitted, a checkout with no lines "
-            "is created."
+            f"is created. Max {CHECKOUT_LINES_INPUT_LIMIT} items."
         ),
         required=False,
     )
@@ -445,6 +447,7 @@ class CheckoutCreate(DeprecatedModelMutation, I18nMixin):
         )
         lines = data.pop("lines", None)
         if lines:
+            validate_checkout_lines_input_limit(lines)
             (
                 cleaned_input["variants"],
                 cleaned_input["lines_data"],

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -29,12 +29,14 @@ from ...site.dataloaders import get_site_promise
 from ..types import Checkout
 from .checkout_create import CheckoutLineInput
 from .utils import (
+    CHECKOUT_LINES_INPUT_LIMIT,
     check_lines_quantity,
     check_permissions_for_custom_prices,
     get_checkout,
     get_variants_and_total_quantities,
     group_lines_input_on_add,
     mark_checkout_deliveries_as_stale_if_needed,
+    validate_checkout_lines_input_limit,
     validate_price_override_reason,
     validate_variants_are_published,
     validate_variants_available_for_purchase,
@@ -64,7 +66,7 @@ class CheckoutLinesAdd(BaseMutation):
             required=True,
             description=(
                 "A list of checkout lines, each containing information about "
-                "an item in the checkout."
+                f"an item in the checkout. Max {CHECKOUT_LINES_INPUT_LIMIT} items."
             ),
         )
 
@@ -223,6 +225,7 @@ class CheckoutLinesAdd(BaseMutation):
         id=None,
     ):
         app = get_app_promise(info.context).get()
+        validate_checkout_lines_input_limit(lines)
         check_permissions_for_custom_prices(app, lines)
 
         # Validate lines early, before clean input. This class pass to clean_input already modified payload

--- a/saleor/graphql/checkout/mutations/checkout_lines_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_delete.py
@@ -17,7 +17,12 @@ from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils import resolve_global_ids_to_primary_keys
 from ..types import Checkout
-from .utils import get_checkout, mark_checkout_deliveries_as_stale_if_needed
+from .utils import (
+    CHECKOUT_LINES_INPUT_LIMIT,
+    get_checkout,
+    mark_checkout_deliveries_as_stale_if_needed,
+    validate_checkout_lines_input_limit,
+)
 
 
 class CheckoutLinesDelete(BaseMutation):
@@ -35,7 +40,10 @@ class CheckoutLinesDelete(BaseMutation):
         lines_ids = NonNullList(
             graphene.ID,
             required=True,
-            description="A list of checkout lines.",
+            description=(
+                "A list of checkout lines. "
+                f"Max {CHECKOUT_LINES_INPUT_LIMIT} items."
+            ),
         )
 
     class Meta:
@@ -90,6 +98,7 @@ class CheckoutLinesDelete(BaseMutation):
     ):
         checkout = get_checkout(cls, info, checkout_id=None, token=token, id=id)
 
+        validate_checkout_lines_input_limit(lines_ids, field_name="lines_ids")
         _, lines_to_delete = resolve_global_ids_to_primary_keys(
             lines_ids, graphene_type="CheckoutLine", raise_error=True
         )

--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -22,6 +22,7 @@ from ...utils import ERROR_COULD_NO_RESOLVE_GLOBAL_ID
 from ..types import Checkout
 from .checkout_lines_add import CheckoutLinesAdd
 from .utils import (
+    CHECKOUT_LINES_INPUT_LIMIT,
     PRICE_OVERRIDE_REASON_INPUT_DESCRIPTION,
     CheckoutLineData,
     check_lines_quantity,
@@ -97,7 +98,7 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
             required=True,
             description=(
                 "A list of checkout lines, each containing information about "
-                "an item in the checkout."
+                f"an item in the checkout. Max {CHECKOUT_LINES_INPUT_LIMIT} items."
             ),
         )
 

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -33,7 +33,10 @@ from ....product.models import ProductChannelListing, ProductVariant
 from ....warehouse.availability import check_stock_and_preorder_quantity_bulk
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_323
-from ...core.validators import validate_one_of_args_is_in_mutation
+from ...core.validators import (
+    validate_limit_of_list_input,
+    validate_one_of_args_is_in_mutation,
+)
 from ..types import Checkout
 
 if TYPE_CHECKING:
@@ -45,6 +48,20 @@ ERROR_CC_ADDRESS_CHANGE_FORBIDDEN = (
     "Can't change shipping address manually. "
     "For click and collect delivery, address is set to a warehouse address."
 )
+
+# Maximum number of line items accepted in a single checkout mutation input.
+CHECKOUT_LINES_INPUT_LIMIT = 100
+
+
+def validate_checkout_lines_input_limit(lines, field_name: str = "lines") -> None:
+    """Reject oversized checkout line list inputs early."""
+    if not lines:
+        return
+    try:
+        validate_limit_of_list_input(lines, CHECKOUT_LINES_INPUT_LIMIT, field_name)
+    except ValidationError as error:
+        error.code = CheckoutErrorCode.INVALID.value
+        raise ValidationError({field_name: error}) from error
 
 
 @dataclass

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_input_limit.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_input_limit.py
@@ -1,0 +1,157 @@
+from unittest.mock import patch
+
+import graphene
+
+from .....checkout.error_codes import CheckoutErrorCode
+from ....core.utils import to_global_id_or_none
+from ....tests.utils import get_graphql_content
+
+LIMIT_PATCH = "saleor.graphql.checkout.mutations.utils.CHECKOUT_LINES_INPUT_LIMIT"
+
+MUTATION_CHECKOUT_LINES_ADD = """
+mutation checkoutLinesAdd($id: ID, $lines: [CheckoutLineInput!]!) {
+  checkoutLinesAdd(id: $id, lines: $lines) {
+    errors {
+      field
+      code
+      message
+    }
+  }
+}
+"""
+
+MUTATION_CHECKOUT_LINES_UPDATE = """
+mutation checkoutLinesUpdate($id: ID, $lines: [CheckoutLineUpdateInput!]!) {
+  checkoutLinesUpdate(id: $id, lines: $lines) {
+    errors {
+      field
+      code
+      message
+    }
+  }
+}
+"""
+
+MUTATION_CHECKOUT_LINES_DELETE = """
+mutation checkoutLinesDelete($id: ID, $linesIds: [ID!]!) {
+  checkoutLinesDelete(id: $id, linesIds: $linesIds) {
+    errors {
+      field
+      code
+      message
+    }
+  }
+}
+"""
+
+MUTATION_CHECKOUT_CREATE = """
+mutation checkoutCreate($input: CheckoutCreateInput!) {
+  checkoutCreate(input: $input) {
+    errors {
+      field
+      code
+      message
+    }
+  }
+}
+"""
+
+
+@patch(LIMIT_PATCH, 1)
+def test_checkout_lines_add_rejects_oversized_lines_input(
+    user_api_client, checkout_with_item, stock
+):
+    # given
+    variant = stock.product_variant
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {
+        "id": to_global_id_or_none(checkout_with_item),
+        "lines": [
+            {"variantId": variant_id, "quantity": 1},
+            {"variantId": variant_id, "quantity": 1},
+        ],
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
+
+    # then
+    content = get_graphql_content(response)
+    error = content["data"]["checkoutLinesAdd"]["errors"][0]
+    assert error["field"] == "lines"
+    assert error["code"] == CheckoutErrorCode.INVALID.name
+    assert "1" in error["message"]
+
+
+@patch(LIMIT_PATCH, 1)
+def test_checkout_lines_update_rejects_oversized_lines_input(
+    user_api_client, checkout_with_item
+):
+    # given
+    line = checkout_with_item.lines.first()
+    variant_id = graphene.Node.to_global_id("ProductVariant", line.variant_id)
+    variables = {
+        "id": to_global_id_or_none(checkout_with_item),
+        "lines": [
+            {"variantId": variant_id, "quantity": 1},
+            {"variantId": variant_id, "quantity": 2},
+        ],
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    error = content["data"]["checkoutLinesUpdate"]["errors"][0]
+    assert error["field"] == "lines"
+    assert error["code"] == CheckoutErrorCode.INVALID.name
+
+
+@patch(LIMIT_PATCH, 1)
+def test_checkout_lines_delete_rejects_oversized_lines_input(
+    user_api_client, checkout_with_item
+):
+    # given
+    line = checkout_with_item.lines.first()
+    line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
+    variables = {
+        "id": to_global_id_or_none(checkout_with_item),
+        "linesIds": [line_id, line_id],
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_DELETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    error = content["data"]["checkoutLinesDelete"]["errors"][0]
+    assert error["field"] == "linesIds"
+    assert error["code"] == CheckoutErrorCode.INVALID.name
+
+
+@patch(LIMIT_PATCH, 1)
+def test_checkout_create_rejects_oversized_lines_input(
+    user_api_client, stock, channel_USD
+):
+    # given
+    variant = stock.product_variant
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {
+        "input": {
+            "channel": channel_USD.slug,
+            "lines": [
+                {"variantId": variant_id, "quantity": 1},
+                {"variantId": variant_id, "quantity": 1},
+            ],
+        }
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    error = content["data"]["checkoutCreate"]["errors"][0]
+    assert error["field"] == "lines"
+    assert error["code"] == CheckoutErrorCode.INVALID.name

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20940,7 +20940,7 @@ type Mutation {
     """The checkout's ID."""
     id: ID
 
-    """A list of checkout lines."""
+    """A list of checkout lines. Max 100 items."""
     linesIds: [ID!]!
 
     """Checkout token."""
@@ -20961,7 +20961,7 @@ type Mutation {
     id: ID
 
     """
-    A list of checkout lines, each containing information about an item in the checkout.
+    A list of checkout lines, each containing information about an item in the checkout. Max 100 items.
     """
     lines: [CheckoutLineInput!]!
 
@@ -20983,7 +20983,7 @@ type Mutation {
     id: ID
 
     """
-    A list of checkout lines, each containing information about an item in the checkout.
+    A list of checkout lines, each containing information about an item in the checkout. Max 100 items.
     """
     lines: [CheckoutLineUpdateInput!]!
 
@@ -30735,7 +30735,7 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   channel: String
 
   """
-  A list of checkout lines, each containing information about an item in the checkout. When omitted, a checkout with no lines is created.
+  A list of checkout lines, each containing information about an item in the checkout. When omitted, a checkout with no lines is created. Max 100 items.
   """
   lines: [CheckoutLineInput!]
 


### PR DESCRIPTION
Cap checkout line mutation inputs at 100 items and return INVALID before stock/pricing work.
Fixes #19209