### PR TITLE
Limit updateMetadata and deleteMetadata list inputs to 100 (#19210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Limited `updateMetadata` / `deleteMetadata` list inputs (`input` / `keys`) to a maximum of 100 items, returning an `INVALID` error when exceeded - #19210 by @richardmilles
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/meta/mutations/delete_metadata.py
+++ b/saleor/graphql/meta/mutations/delete_metadata.py
@@ -7,7 +7,12 @@ from ...core import ResolveInfo
 from ...core.types import MetadataError, NonNullList
 from ..permissions import PUBLIC_META_PERMISSION_MAP
 from .base import BaseMetadataMutation
-from .utils import delete_metadata_keys, get_valid_metadata_instance
+from .utils import (
+    METADATA_LIST_INPUT_LIMIT,
+    delete_metadata_keys,
+    get_valid_metadata_instance,
+    validate_metadata_list_input_limit,
+)
 
 
 class DeleteMetadata(BaseMetadataMutation):
@@ -27,7 +32,9 @@ class DeleteMetadata(BaseMetadataMutation):
         )
         keys = NonNullList(
             graphene.String,
-            description="Metadata keys to delete.",
+            description=(
+                f"Metadata keys to delete. Max {METADATA_LIST_INPUT_LIMIT} items."
+            ),
             required=True,
         )
 
@@ -35,6 +42,7 @@ class DeleteMetadata(BaseMetadataMutation):
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, id: str, keys: list[str]
     ):
+        validate_metadata_list_input_limit(keys, field_name="keys")
         instance = cast(models.ModelWithMetadata, cls.get_instance(info, id=id))
         if instance:
             meta_instance = get_valid_metadata_instance(instance)

--- a/saleor/graphql/meta/mutations/update_metadata.py
+++ b/saleor/graphql/meta/mutations/update_metadata.py
@@ -8,7 +8,12 @@ from ...core.types import MetadataError, NonNullList
 from ..inputs import MetadataInput, MetadataInputDescription
 from ..permissions import PUBLIC_META_PERMISSION_MAP
 from .base import BaseMetadataMutation
-from .utils import get_valid_metadata_instance, update_metadata
+from .utils import (
+    METADATA_LIST_INPUT_LIMIT,
+    get_valid_metadata_instance,
+    update_metadata,
+    validate_metadata_list_input_limit,
+)
 
 
 class UpdateMetadata(BaseMetadataMutation):
@@ -28,7 +33,10 @@ class UpdateMetadata(BaseMetadataMutation):
         )
         input = NonNullList(
             MetadataInput,
-            description="Fields required to update the object's metadata.",
+            description=(
+                "Fields required to update the object's metadata. "
+                f"Max {METADATA_LIST_INPUT_LIMIT} items."
+            ),
             required=True,
         )
 
@@ -36,6 +44,7 @@ class UpdateMetadata(BaseMetadataMutation):
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, id: str, input: list
     ):
+        validate_metadata_list_input_limit(input, field_name="input")
         instance = cast(models.ModelWithMetadata, cls.get_instance(info, id=id))
         if instance:
             meta_instance = get_valid_metadata_instance(instance)

--- a/saleor/graphql/meta/mutations/utils.py
+++ b/saleor/graphql/meta/mutations/utils.py
@@ -11,6 +11,21 @@ from ....core.db.connection import allow_writer
 from ....core.db.expressions import PostgresJsonConcatenate
 from ....core.error_codes import MetadataErrorCode
 from ....core.models import ModelWithMetadata
+from ...core.validators import validate_limit_of_list_input
+
+# Maximum number of metadata items accepted in a single metadata mutation input.
+METADATA_LIST_INPUT_LIMIT = 100
+
+
+def validate_metadata_list_input_limit(items, field_name: str) -> None:
+    """Reject oversized metadata list inputs early."""
+    if not items:
+        return
+    try:
+        validate_limit_of_list_input(items, METADATA_LIST_INPUT_LIMIT, field_name)
+    except ValidationError as error:
+        error.code = MetadataErrorCode.INVALID.value
+        raise ValidationError({field_name: error}) from error
 
 
 def get_valid_metadata_instance(instance) -> ModelWithMetadata:

--- a/saleor/graphql/meta/tests/mutations/test_metadata_list_input_limit.py
+++ b/saleor/graphql/meta/tests/mutations/test_metadata_list_input_limit.py
@@ -1,0 +1,85 @@
+from unittest.mock import patch
+
+import graphene
+
+from .....core.error_codes import MetadataErrorCode
+from ....tests.utils import get_graphql_content
+
+LIMIT_PATCH = "saleor.graphql.meta.mutations.utils.METADATA_LIST_INPUT_LIMIT"
+
+UPDATE_METADATA_MUTATION = """
+mutation UpdatePublicMetadata($id: ID!, $input: [MetadataInput!]!) {
+    updateMetadata(id: $id, input: $input) {
+        errors {
+            field
+            code
+            message
+        }
+        item {
+            ... on Checkout {
+                id
+            }
+        }
+    }
+}
+"""
+
+DELETE_METADATA_MUTATION = """
+mutation DeletePublicMetadata($id: ID!, $keys: [String!]!) {
+    deleteMetadata(id: $id, keys: $keys) {
+        errors {
+            field
+            code
+            message
+        }
+        item {
+            ... on Checkout {
+                id
+            }
+        }
+    }
+}
+"""
+
+
+@patch(LIMIT_PATCH, 1)
+def test_update_metadata_rejects_oversized_input(api_client, checkout):
+    # given
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {
+        "id": checkout_id,
+        "input": [
+            {"key": "key0", "value": "value0"},
+            {"key": "key1", "value": "value1"},
+        ],
+    }
+
+    # when
+    response = api_client.post_graphql(UPDATE_METADATA_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    error = content["data"]["updateMetadata"]["errors"][0]
+    assert error["field"] == "input"
+    assert error["code"] == MetadataErrorCode.INVALID.name
+    assert "1" in error["message"]
+
+
+@patch(LIMIT_PATCH, 1)
+def test_delete_metadata_rejects_oversized_keys(api_client, checkout):
+    # given
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {
+        "id": checkout_id,
+        "keys": ["key0", "key1"],
+    }
+
+    # when
+    response = api_client.post_graphql(DELETE_METADATA_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    error = content["data"]["deleteMetadata"]["errors"][0]
+    assert error["field"] == "keys"
+    assert error["code"] == MetadataErrorCode.INVALID.name
+    assert "1" in error["message"]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19766,7 +19766,7 @@ type Mutation {
     """ID or token (for Order and Checkout) of an object to update."""
     id: ID!
 
-    """Metadata keys to delete."""
+    """Metadata keys to delete. Max 100 items."""
     keys: [String!]!
   ): DeleteMetadata
 
@@ -19790,7 +19790,7 @@ type Mutation {
     """ID or token (for Order and Checkout) of an object to update."""
     id: ID!
 
-    """Fields required to update the object's metadata."""
+    """Fields required to update the object's metadata. Max 100 items."""
     input: [MetadataInput!]!
   ): UpdateMetadata
 


### PR DESCRIPTION
Cap updateMetadata/deleteMetadata inputs at 100 items and return INVALID before writes.
Fixes #19210