### PR TITLE
Fix orderBulkCreate failing to resolve variants by variantSku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Fixed `orderBulkCreate` failing to resolve product variants by `variantSku` due to an incorrect object storage key - #17452 by @richardmilles
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -820,7 +820,7 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
         for variant in variants:
             object_storage[f"ProductVariant.id.{variant.id}"] = variant
             if variant.sku:
-                object_storage[f"ProductVariant.id.{variant.sku}"] = variant
+                object_storage[f"ProductVariant.sku.{variant.sku}"] = variant
             if variant.external_reference:
                 object_storage[
                     f"ProductVariant.external_reference.{variant.external_reference}"

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -2728,6 +2728,49 @@ def test_order_bulk_create_error_note_exceeds_character_limit(
     assert OrderEvent.objects.count() == events_count
 
 
+def test_order_bulk_create_resolve_variant_by_sku(
+    staff_api_client,
+    permission_manage_orders,
+    permission_manage_orders_import,
+    permission_manage_users,
+    order_bulk_input,
+    variant,
+):
+    # given
+    orders_count = Order.objects.count()
+    assert variant.sku
+
+    order = order_bulk_input
+    order["lines"][0]["variantId"] = None
+    order["lines"][0]["variantSku"] = variant.sku
+    order["fulfillments"][0]["lines"][0]["variantId"] = None
+    order["fulfillments"][0]["lines"][0]["variantSku"] = variant.sku
+
+    staff_api_client.user.user_permissions.add(
+        permission_manage_orders_import,
+        permission_manage_orders,
+        permission_manage_users,
+    )
+    variables = {
+        "orders": [order],
+        "stockUpdatePolicy": StockUpdatePolicyEnum.SKIP.name,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_BULK_CREATE, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["orderBulkCreate"]["count"] == 1
+    result = content["data"]["orderBulkCreate"]["results"][0]
+    assert not result["errors"]
+    assert result["order"]["lines"][0]["variant"]["id"] == graphene.Node.to_global_id(
+        "ProductVariant", variant.id
+    )
+    assert Order.objects.count() == orders_count + 1
+    assert OrderLine.objects.get().variant_id == variant.id
+
+
 def test_order_bulk_create_error_non_existing_instance(
     staff_api_client,
     permission_manage_orders,


### PR DESCRIPTION
Fix orderBulkCreate variantSku lookup key (ProductVariant.sku.<sku>) so SKU resolution works.
Closes #17452