### PR TITLE
Improve appFetchManifest TLS/SSL and connection error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Improved `appFetchManifest` (and app install connection failures) to surface TLS/SSL and connection error details instead of opaque `INVALID` / generic messages - #15919 by @richardmilles
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/app/tasks.py
+++ b/saleor/app/tasks.py
@@ -53,7 +53,8 @@ def install_app_task(job_id, activate=False):
     except RequestException as e:
         logger.warning("Failed to install app. Error: %s", e)
         app_installation.message = (
-            "Failed to connect to app. Try later or contact with app support."
+            f"Failed to connect to app. Details: {e}. "
+            "Try later or contact with app support."
         )
     except Exception as e:
         logger.error("Failed to install app. Error: %s", e, exc_info=e)

--- a/saleor/app/tests/test_app_tasks.py
+++ b/saleor/app/tests/test_app_tasks.py
@@ -67,7 +67,8 @@ def test_install_app_task_request_timeout(monkeypatch, app_installation):
     assert app_installation.status == JobStatus.FAILED
     assert (
         app_installation.message
-        == "Failed to connect to app. Try later or contact with app support."
+        == "Failed to connect to app. Details: Timeout. "
+        "Try later or contact with app support."
     )
 
 

--- a/saleor/graphql/app/mutations/app_fetch_manifest.py
+++ b/saleor/graphql/app/mutations/app_fetch_manifest.py
@@ -45,21 +45,43 @@ class AppFetchManifest(BaseMutation):
             raise ValidationError(
                 {"manifest_url": ValidationError(msg, code=code)}
             ) from e
+        except requests.SSLError as e:
+            msg = (
+                "Unable to fetch manifest data due to a TLS/SSL error. "
+                f"Details: {e}"
+            )
+            code = AppErrorCode.MANIFEST_URL_CANT_CONNECT.value
+            raise ValidationError(
+                {"manifest_url": ValidationError(msg, code=code)}
+            ) from e
         except requests.HTTPError as e:
             msg = "Unable to fetch manifest data."
             code = AppErrorCode.MANIFEST_URL_CANT_CONNECT.value
             raise ValidationError(
                 {"manifest_url": ValidationError(msg, code=code)}
             ) from e
+        except requests.ConnectionError as e:
+            msg = f"Unable to connect to the provided manifest URL. Details: {e}"
+            code = AppErrorCode.MANIFEST_URL_CANT_CONNECT.value
+            raise ValidationError(
+                {"manifest_url": ValidationError(msg, code=code)}
+            ) from e
         except ValueError as e:
+            # Catch before RequestException: JSONDecodeError subclasses both.
             msg = "Incorrect structure of manifest."
             code = AppErrorCode.INVALID_MANIFEST_FORMAT.value
             raise ValidationError(
                 {"manifest_url": ValidationError(msg, code=code)}
             ) from e
+        except requests.RequestException as e:
+            msg = f"Unable to fetch manifest data. Details: {e}"
+            code = AppErrorCode.MANIFEST_URL_CANT_CONNECT.value
+            raise ValidationError(
+                {"manifest_url": ValidationError(msg, code=code)}
+            ) from e
         except OSError as e:
-            msg = "Can't fetch manifest data. Please try later."
-            code = AppErrorCode.INVALID.value
+            msg = f"Can't fetch manifest data. Details: {e}"
+            code = AppErrorCode.MANIFEST_URL_CANT_CONNECT.value
             raise ValidationError(
                 {"manifest_url": ValidationError(msg, code=code)}
             ) from e

--- a/saleor/graphql/app/tests/mutations/test_app_fetch_manifest.py
+++ b/saleor/graphql/app/tests/mutations/test_app_fetch_manifest.py
@@ -290,10 +290,72 @@ def test_app_fetch_manifest_handle_exception(
 
     assert len(errors) == 1
     assert errors[0] == {
-        "code": "INVALID",
+        "code": "MANIFEST_URL_CANT_CONNECT",
         "field": "manifestUrl",
-        "message": "Can't fetch manifest data. Please try later.",
+        "message": "Can't fetch manifest data. Details: oops",
     }
+
+
+def test_app_fetch_manifest_ssl_error(
+    staff_user, staff_api_client, permission_manage_apps, monkeypatch
+):
+    ssl_message = (
+        "HTTPSConnectionPool(host='localhost', port=443): "
+        "Max retries exceeded with url: /manifest "
+        "(Caused by SSLError(SSLCertVerificationError("
+        "certificate verify failed: self-signed certificate)))"
+    )
+    mocked_get = Mock()
+    mocked_get.side_effect = requests.exceptions.SSLError(ssl_message)
+
+    monkeypatch.setattr(HTTPSession, "request", mocked_get)
+    manifest_url = "https://localhost:3000/manifest"
+    query = APP_FETCH_MANIFEST_MUTATION
+    variables = {
+        "manifest_url": manifest_url,
+    }
+    staff_user.user_permissions.set([permission_manage_apps])
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+    errors = content["data"]["appFetchManifest"]["errors"]
+
+    assert len(errors) == 1
+    assert errors[0]["code"] == "MANIFEST_URL_CANT_CONNECT"
+    assert errors[0]["field"] == "manifestUrl"
+    assert "TLS/SSL error" in errors[0]["message"]
+    assert "self-signed certificate" in errors[0]["message"]
+
+
+def test_app_fetch_manifest_connection_error(
+    staff_user, staff_api_client, permission_manage_apps, monkeypatch
+):
+    mocked_get = Mock()
+    mocked_get.side_effect = requests.exceptions.ConnectionError(
+        "Failed to establish a new connection: [Errno 111] Connection refused"
+    )
+
+    monkeypatch.setattr(HTTPSession, "request", mocked_get)
+    manifest_url = "http://localhost:3000/manifest"
+    query = APP_FETCH_MANIFEST_MUTATION
+    variables = {
+        "manifest_url": manifest_url,
+    }
+    staff_user.user_permissions.set([permission_manage_apps])
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+    errors = content["data"]["appFetchManifest"]["errors"]
+
+    assert len(errors) == 1
+    assert errors[0]["code"] == "MANIFEST_URL_CANT_CONNECT"
+    assert errors[0]["field"] == "manifestUrl"
+    assert "Unable to connect to the provided manifest URL" in errors[0]["message"]
+    assert "Connection refused" in errors[0]["message"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Surface SSL/connection details in appFetchManifest as MANIFEST_URL_CANT_CONNECT instead of a vague failure.
Closes #15919