### PR TITLE
Validate products sortBy when only direction is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Fixed products query crashing when `sortBy` provided only a `direction` without `field` or `attributeId`; it now returns a GraphQL validation error - #12366 by @richardmilles
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/product/tests/test_product_sorting_attributes.py
+++ b/saleor/graphql/product/tests/test_product_sorting_attributes.py
@@ -254,6 +254,32 @@ def test_sort_products_cannot_sort_both_by_field_and_by_attribute(
     )
 
 
+def test_sort_products_requires_field_or_attribute(api_client, channel_USD):
+    """Test that sortBy with only direction returns a validation error."""
+    query = """
+    query ($channel: String!) {
+      products(first: 10, sortBy: {direction: ASC}, channel: $channel) {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+    """
+    variables = {"channel": channel_USD.slug}
+
+    response = api_client.post_graphql(query, variables)
+    response = get_graphql_content(response, ignore_errors=True)
+
+    errors = response.get("errors", [])
+
+    assert len(errors) == 1, response
+    assert errors[0]["message"] == (
+        "You must provide either `field` or `attributeId` to sort the products."
+    )
+
+
 # Ordered by the given attribute value, then by the product name.
 #
 # If the product doesn't have a value, it will be placed at the bottom of the products

--- a/saleor/graphql/utils/sorting.py
+++ b/saleor/graphql/utils/sorting.py
@@ -73,6 +73,10 @@ def sort_queryset(
         raise GraphQLError(
             "You must provide either `field` or `attributeId` to sort the products."
         )
+    if sorting_field is None and sorting_attribute is None:
+        raise GraphQLError(
+            "You must provide either `field` or `attributeId` to sort the products."
+        )
     if sorting_attribute is not None:  # empty string as sorting_attribute is valid
         return _sort_queryset_by_attribute(
             queryset, sorting_attribute, sorting_direction


### PR DESCRIPTION
Return a GraphQL validation error when product sortBy omits both field and attributeId instead of crashing.
Closes #12366