### PR TITLE
Fix incorrect deprecation reasons for legacy tax fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Corrected deprecation reasons for legacy tax fields to point at the specific `Channel.taxConfiguration` subfields (`displayGrossPrices`, `chargeTaxes`) instead of the parent type alone - #11325 by @richardmilles
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/product/mutations/product/product_create.py
+++ b/saleor/graphql/product/mutations/product/product_create.py
@@ -33,8 +33,9 @@ class ProductInput(BaseInputObjectType):
     charge_taxes = graphene.Boolean(
         description=(
             "Determine if taxes are being charged for the product. "
-            f"{DEPRECATED_IN_3X_INPUT} Use `Channel.taxConfiguration` to configure "
-            "whether tax collection is enabled."
+            f"{DEPRECATED_IN_3X_INPUT} Use `Channel.taxConfiguration.chargeTaxes` "
+            "or the `taxConfigurationUpdate` mutation to configure whether tax "
+            "collection is enabled."
         )
     )
     collections = NonNullList(

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -933,7 +933,7 @@ class Product(ChannelContextType[models.Product]):
     )
     charge_taxes = graphene.Boolean(
         required=True,
-        deprecation_reason="Use `Channel.taxConfiguration` field to determine whether tax collection is enabled.",
+        deprecation_reason="Use `Channel.taxConfiguration.chargeTaxes` to determine whether tax collection is enabled.",
     )
     weight = graphene.Field(Weight, description="Weight of the product.")
     default_variant = graphene.Field(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6811,7 +6811,7 @@ type Product implements Node & ObjectWithMetadata & ObjectWithAttributes @doc(ca
 
   """The date and time when the product was last updated."""
   updatedAt: DateTime!
-  chargeTaxes: Boolean! @deprecated(reason: "Use `Channel.taxConfiguration` field to determine whether tax collection is enabled.")
+  chargeTaxes: Boolean! @deprecated(reason: "Use `Channel.taxConfiguration.chargeTaxes` to determine whether tax collection is enabled.")
 
   """Weight of the product."""
   weight: Weight
@@ -15109,7 +15109,7 @@ type Shop implements ObjectWithMetadata {
   includeTaxesInPrices: Boolean! @deprecated(reason: "Use `Channel.taxConfiguration.pricesEnteredWithTax` to determine whether prices are entered with tax.")
 
   """Display prices with tax in store."""
-  displayGrossPrices: Boolean! @deprecated(reason: "Use `Channel.taxConfiguration` to determine whether to display gross or net prices.")
+  displayGrossPrices: Boolean! @deprecated(reason: "Use `Channel.taxConfiguration.displayGrossPrices` to determine whether to display gross or net prices.")
 
   """Charge taxes on shipping."""
   chargeTaxesOnShipping: Boolean! @deprecated(reason: "Use `ShippingMethodType.taxClass` to determine whether taxes are calculated for shipping methods; if a tax class is set, the taxes will be calculated, otherwise no tax rate will be applied.")
@@ -24365,7 +24365,7 @@ input ProductCreateInput @doc(category: "Products") {
   category: ID
 
   """Determine if taxes are being charged for the product."""
-  chargeTaxes: Boolean @deprecated(reason: "Use `Channel.taxConfiguration` to configure whether tax collection is enabled.")
+  chargeTaxes: Boolean @deprecated(reason: "Use `Channel.taxConfiguration.chargeTaxes` or the `taxConfigurationUpdate` mutation to configure whether tax collection is enabled.")
 
   """List of IDs of collections that the product belongs to."""
   collections: [ID!]
@@ -24582,7 +24582,7 @@ input ProductBulkCreateInput @doc(category: "Products") {
   category: ID
 
   """Determine if taxes are being charged for the product."""
-  chargeTaxes: Boolean @deprecated(reason: "Use `Channel.taxConfiguration` to configure whether tax collection is enabled.")
+  chargeTaxes: Boolean @deprecated(reason: "Use `Channel.taxConfiguration.chargeTaxes` or the `taxConfigurationUpdate` mutation to configure whether tax collection is enabled.")
 
   """List of IDs of collections that the product belongs to."""
   collections: [ID!]
@@ -24858,7 +24858,7 @@ input ProductInput @doc(category: "Products") {
   category: ID
 
   """Determine if taxes are being charged for the product."""
-  chargeTaxes: Boolean @deprecated(reason: "Use `Channel.taxConfiguration` to configure whether tax collection is enabled.")
+  chargeTaxes: Boolean @deprecated(reason: "Use `Channel.taxConfiguration.chargeTaxes` or the `taxConfigurationUpdate` mutation to configure whether tax collection is enabled.")
 
   """List of IDs of collections that the product belongs to."""
   collections: [ID!]

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -470,7 +470,7 @@ class Shop(graphene.ObjectType):
     )
     display_gross_prices = graphene.Boolean(
         description="Display prices with tax in store.",
-        deprecation_reason="Use `Channel.taxConfiguration` to determine whether to display gross or net prices.",
+        deprecation_reason="Use `Channel.taxConfiguration.displayGrossPrices` to determine whether to display gross or net prices.",
         required=True,
     )
     charge_taxes_on_shipping = graphene.Boolean(


### PR DESCRIPTION
Point tax field deprecation reasons at Channel.taxConfiguration.displayGrossPrices / chargeTaxes.
Closes #11325