### PR TITLE
Fix Playground requesting non-secured GraphQL URL

### DIFF
--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -526,15 +526,17 @@ def test_graphql_view_clears_context(rf, staff_user, product, channel_USD):
 
 
 @pytest.mark.parametrize(
-    ("public_url", "expected_url_base"),
+    ("public_url", "enable_ssl", "expected_url_base"),
     [
-        (None, "http://testserver"),
-        ("http://some_custom_domain.com", "http://some_custom_domain.com"),
+        (None, False, "http://testserver"),
+        (None, True, "https://testserver"),
+        ("http://some_custom_domain.com", False, "http://some_custom_domain.com"),
+        ("https://some_custom_domain.com", True, "https://some_custom_domain.com"),
     ],
 )
 @patch("saleor.graphql.views.render", wraps=render)
 def test_playground_is_rendered_with_proper_api_url_if_public_url_is_set(
-    mocked_render, rf, settings, public_url, expected_url_base
+    mocked_render, rf, settings, public_url, enable_ssl, expected_url_base
 ):
     # given
     request = rf.get(
@@ -543,6 +545,7 @@ def test_playground_is_rendered_with_proper_api_url_if_public_url_is_set(
     request.app = None
     request.user = None
     settings.PUBLIC_URL = public_url
+    settings.ENABLE_SSL = enable_ssl
 
     # when
     view = GraphQLView.as_view(backend=backend, schema=schema)

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -4,7 +4,6 @@ import importlib
 import time
 from inspect import isclass
 from typing import Any, cast
-from urllib.parse import urljoin
 
 import orjson
 from django.conf import settings
@@ -33,6 +32,7 @@ from requests_hardened.ip_filter import InvalidIPAddress
 from .. import __version__ as saleor_version
 from ..core.exceptions import PermissionDenied
 from ..core.telemetry import Scope, SpanKind, saleor_attributes, tracer
+from ..core.utils import build_absolute_uri
 from ..webhook import observability
 from . import GraphQLOperationResult
 from .api import API_PATH, schema
@@ -172,12 +172,11 @@ class GraphQLView(View):
         return HttpResponseNotAllowed(["OPTIONS", "POST"])
 
     def render_playground(self, request):
-        if settings.PUBLIC_URL:
-            api_url = urljoin(settings.PUBLIC_URL, str(API_PATH))
-            plugins_url = urljoin(settings.PUBLIC_URL, "/plugins/")
-        else:
-            api_url = request.build_absolute_uri(str(API_PATH))
-            plugins_url = request.build_absolute_uri("/plugins/")
+        # Use Saleor's URL builder so ENABLE_SSL / PUBLIC_URL win over the
+        # plain HTTP scheme Django sees behind TLS-terminating proxies.
+        domain = request.get_host()
+        api_url = build_absolute_uri(str(API_PATH), domain=domain)
+        plugins_url = build_absolute_uri("/plugins/", domain=domain)
 
         return render(
             request,


### PR DESCRIPTION
Playground built GraphQL endpoint URLs with Django's request.build_absolute_uri, which yields http behind TLS-terminating proxies and triggers mixed content. This switches to Saleor's build_absolute_uri so ENABLE_SSL and PUBLIC_URL produce the secure endpoint.

Fixes #14983