### PR TITLE
Return accountRegister user id for MANAGE_USERS callers

### DIFF
--- a/saleor/graphql/account/mutations/account/account_register.py
+++ b/saleor/graphql/account/mutations/account/account_register.py
@@ -9,6 +9,7 @@ from .....account.error_codes import AccountErrorCode
 from .....account.tasks import finish_creating_user
 from .....account.utils import RequestorAwareContext
 from .....core.utils.url import validate_storefront_url
+from .....permission.enums import AccountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....channel.utils import clean_channel
 from ....core import ResolveInfo
@@ -19,6 +20,7 @@ from ....core.types import AccountError, NonNullList
 from ....core.utils import WebhookEventInfo
 from ....meta.inputs import MetadataInput, MetadataInputDescription
 from ....site.dataloaders import get_site_promise
+from ....utils import get_user_or_app_from_context
 from ...types import User
 from .base import AccountBaseInput
 
@@ -62,8 +64,9 @@ class AccountRegister(DeprecatedModelMutation):
         User,
         deprecation_reason=(
             "The field always returns a `User` object constructed from the input data. "
-            "The `user.id` is always empty. To determine whether the user exists "
-            "in Saleor, query via an external app with the required permissions."
+            "The `user.id` is empty for unauthenticated callers to prevent user "
+            "enumeration. Apps or staff with the `MANAGE_USERS` permission receive "
+            "the real id when a new user is created."
         ),
     )
 
@@ -109,9 +112,18 @@ class AccountRegister(DeprecatedModelMutation):
         response.requires_confirmation = (
             site.settings.enable_account_confirmation_by_email
         )
-        # we don't want to return id's as it will allow to deduce if user exists
+        # Hide ids from unauthenticated callers to prevent user enumeration.
+        # Trusted apps/staff with MANAGE_USERS may receive the real id when a
+        # user was actually created (instance has a primary key).
         if response.user:
-            response.user.NEWLY_CREATED_USER = True
+            requestor = get_user_or_app_from_context(info.context)
+            can_see_user_id = (
+                requestor
+                and requestor.has_perm(AccountPermissions.MANAGE_USERS)
+                and response.user.pk
+            )
+            if not can_see_user_id:
+                response.user.NEWLY_CREATED_USER = True
         return response
 
     @staticmethod

--- a/saleor/graphql/account/tests/mutations/account/test_account_register.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_register.py
@@ -1,6 +1,7 @@
 from unittest.mock import ANY, patch
 from urllib.parse import urlencode
 
+import graphene
 import pytest
 from django.test import override_settings
 from django.utils import timezone
@@ -468,6 +469,79 @@ def test_account_register_returns_empty_id(
 
     # when
     response = api_client.post_graphql(ACCOUNT_REGISTER_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountRegister"]
+    assert not data["errors"]
+    assert data["user"]["id"] == ""
+    assert data["user"]["email"] == customer_user.email
+
+
+@override_settings(ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL=False)
+def test_account_register_returns_user_id_for_app_with_manage_users(
+    app_api_client, permission_manage_users, site_settings
+):
+    # given
+    site_settings.enable_account_confirmation_by_email = False
+    site_settings.save(update_fields=["enable_account_confirmation_by_email"])
+    email = "app-customer@example.com"
+    variables = {"input": {"email": email, "password": "Password"}}
+
+    # when
+    response = app_api_client.post_graphql(
+        ACCOUNT_REGISTER_MUTATION, variables, permissions=[permission_manage_users]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountRegister"]
+    new_user = User.objects.get(email=email)
+    assert not data["errors"]
+    assert data["user"]["id"] == graphene.Node.to_global_id("User", new_user.pk)
+    assert data["user"]["email"] == email
+
+
+@override_settings(ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL=False)
+def test_account_register_returns_empty_id_for_app_without_manage_users(
+    app_api_client, site_settings
+):
+    # given
+    site_settings.enable_account_confirmation_by_email = False
+    site_settings.save(update_fields=["enable_account_confirmation_by_email"])
+    email = "app-customer-no-perm@example.com"
+    variables = {"input": {"email": email, "password": "Password"}}
+
+    # when
+    response = app_api_client.post_graphql(ACCOUNT_REGISTER_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["accountRegister"]
+    assert User.objects.filter(email=email).exists()
+    assert not data["errors"]
+    assert data["user"]["id"] == ""
+    assert data["user"]["email"] == email
+
+
+@override_settings(ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL=False)
+def test_account_register_returns_empty_id_for_app_when_user_already_exists(
+    app_api_client, permission_manage_users, site_settings, customer_user
+):
+    # given
+    site_settings.enable_account_confirmation_by_email = False
+    site_settings.save(update_fields=["enable_account_confirmation_by_email"])
+    variables = {
+        "input": {
+            "email": customer_user.email,
+            "password": "Password",
+        }
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        ACCOUNT_REGISTER_MUTATION, variables, permissions=[permission_manage_users]
+    )
     content = get_graphql_content(response)
 
     # then

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -33057,7 +33057,7 @@ Triggers the following webhook events:
 - ACCOUNT_CONFIRMATION_REQUESTED (async): An user confirmation was requested. This event is always sent regardless of settings.
 """
 type AccountRegister @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_CREATED, NOTIFY_USER, ACCOUNT_CONFIRMATION_REQUESTED], syncEvents: []) {
-  user: User @deprecated(reason: "The field always returns a `User` object constructed from the input data. The `user.id` is always empty. To determine whether the user exists in Saleor, query via an external app with the required permissions.")
+  user: User @deprecated(reason: "The field always returns a `User` object constructed from the input data. The `user.id` is empty for unauthenticated callers to prevent user enumeration. Apps or staff with the `MANAGE_USERS` permission receive the real id when a new user is created.")
 
   """Informs whether users need to confirm their email address."""
   requiresConfirmation: Boolean


### PR DESCRIPTION
Return the real user id from accountRegister when the caller has MANAGE_USERS, while keeping empty ids for unauthenticated clients to prevent enumeration. Fixes #17800