### PR TITLE
Track voucher used count even without usage limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,5 +62,6 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Fixes
 
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
+- Fixed voucher `used` count not being updated when a voucher has no usage limit. Usage is now tracked for all vouchers, including unlimited ones. - #18085
 
 ### Deprecations

--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -230,17 +230,15 @@ def release_voucher_code_usage_of_draft_orders(
     single_use_vouchers = Voucher.objects.filter(single_use=True)
     codes.filter(voucher__in=single_use_vouchers).update(is_active=True)
 
-    # decrease usage for vouchers with usage limit
-    voucher_with_usage_limit = Voucher.objects.filter(usage_limit__isnull=False)
-    codes_to_release = codes.filter(voucher__in=voucher_with_usage_limit)
+    # decrease usage for voucher codes
     code_counter = Counter(voucher_codes)
-    for voucher_code in codes_to_release:
+    for voucher_code in codes:
         usage_decrease = code_counter[voucher_code.code]
         if voucher_code.used < usage_decrease:
             voucher_code.used = 0
         else:
             voucher_code.used = F("used") - usage_decrease
-    VoucherCode.objects.bulk_update(codes_to_release, ["used"])
+    VoucherCode.objects.bulk_update(codes, ["used"])
 
     # drop customer usage
     lookup = Q()
@@ -277,7 +275,7 @@ def decrease_voucher_codes_usage_task(voucher_code_ids, codes):
         .only("voucher", "used", "is_active")
     ):
         for voucher_code in voucher_codes:
-            if voucher_code.voucher.usage_limit and voucher_code.used > 0:
+            if voucher_code.used > 0:
                 used_in_draft_orders = len(
                     list(filter(lambda x: voucher_code.code == x, codes))
                 )

--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -30,7 +30,9 @@ from ..utils.voucher import (
     decrease_voucher_code_usage_value,
     get_the_cheapest_line,
     increase_voucher_code_usage_value,
+    increase_voucher_usage,
     is_order_level_voucher,
+    release_voucher_code_usage,
     remove_voucher_usage_by_customer,
     validate_voucher,
 )
@@ -211,6 +213,77 @@ def test_increase_voucher_usage(channel_USD):
         discount=Money(10, channel_USD.currency_code),
     )
     increase_voucher_code_usage_value(code_instance)
+    code_instance.refresh_from_db(fields=["used"])
+    assert code_instance.used == 1
+
+
+def test_increase_voucher_usage_without_usage_limit(channel_USD):
+    # given
+    voucher = Voucher.objects.create(
+        type=VoucherType.ENTIRE_ORDER,
+        discount_value_type=DiscountValueType.FIXED,
+        usage_limit=None,
+    )
+    code_instance = VoucherCode.objects.create(code="unlimited", voucher=voucher)
+    VoucherChannelListing.objects.create(
+        voucher=voucher,
+        channel=channel_USD,
+        discount=Money(10, channel_USD.currency_code),
+    )
+    assert voucher.usage_limit is None
+    assert code_instance.used == 0
+
+    # when
+    increase_voucher_usage(voucher, code_instance, customer_email=None)
+
+    # then
+    code_instance.refresh_from_db(fields=["used"])
+    assert code_instance.used == 1
+
+
+def test_increase_voucher_usage_with_usage_limit(channel_USD):
+    # given
+    voucher = Voucher.objects.create(
+        type=VoucherType.ENTIRE_ORDER,
+        discount_value_type=DiscountValueType.FIXED,
+        usage_limit=100,
+    )
+    code_instance = VoucherCode.objects.create(code="limited", voucher=voucher)
+    VoucherChannelListing.objects.create(
+        voucher=voucher,
+        channel=channel_USD,
+        discount=Money(10, channel_USD.currency_code),
+    )
+
+    # when
+    increase_voucher_usage(voucher, code_instance, customer_email=None)
+
+    # then
+    code_instance.refresh_from_db(fields=["used"])
+    assert code_instance.used == 1
+
+
+def test_release_voucher_code_usage_without_usage_limit(channel_USD):
+    # given
+    voucher = Voucher.objects.create(
+        type=VoucherType.ENTIRE_ORDER,
+        discount_value_type=DiscountValueType.FIXED,
+        usage_limit=None,
+    )
+    code_instance = VoucherCode.objects.create(
+        code="unlimited", voucher=voucher, used=2
+    )
+    VoucherChannelListing.objects.create(
+        voucher=voucher,
+        channel=channel_USD,
+        discount=Money(10, channel_USD.currency_code),
+    )
+    assert voucher.usage_limit is None
+
+    # when
+    release_voucher_code_usage(code_instance, voucher, user_email=None)
+
+    # then
     code_instance.refresh_from_db(fields=["used"])
     assert code_instance.used == 1
 

--- a/saleor/discount/tests/test_tasks.py
+++ b/saleor/discount/tests/test_tasks.py
@@ -426,6 +426,27 @@ def test_release_voucher_code_usage_of_draft_orders_multiple_use(
     assert multiple_use_code.used == max(used - len(voucher_codes_with_emails), 0)
 
 
+def test_release_voucher_code_usage_of_draft_orders_without_usage_limit(voucher):
+    # given
+    code = voucher.codes.first()
+    voucher.usage_limit = None
+    voucher.save(update_fields=["usage_limit"])
+    code.used = 3
+    code.save(update_fields=["used"])
+
+    voucher_codes_with_emails = [
+        (code.code, "test@example.com"),
+        (code.code, "test2@example.com"),
+    ]
+
+    # when
+    release_voucher_code_usage_of_draft_orders(voucher_codes_with_emails)
+
+    # then
+    code.refresh_from_db()
+    assert code.used == 1
+
+
 def test_release_voucher_code_usage_of_draft_orders_clears_voucher_customers(
     voucher_single_use,
 ):

--- a/saleor/discount/utils/voucher.py
+++ b/saleor/discount/utils/voucher.py
@@ -72,8 +72,7 @@ def increase_voucher_usage(
     customer_email: str | None,
     increase_voucher_customer_usage: bool = True,
 ) -> None:
-    if voucher.usage_limit:
-        increase_voucher_code_usage_value(code)
+    increase_voucher_code_usage_value(code)
     if voucher.apply_once_per_customer and increase_voucher_customer_usage:
         add_voucher_usage_by_customer(code, customer_email)
     if voucher.single_use:
@@ -137,8 +136,7 @@ def release_voucher_code_usage(
 ):
     if not code:
         return
-    if voucher and voucher.usage_limit:
-        decrease_voucher_code_usage_value(code)
+    decrease_voucher_code_usage_value(code)
     if voucher and voucher.single_use:
         activate_voucher_code(code)
     if user_email:

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -882,6 +882,46 @@ def test_order_from_checkout_with_voucher(
 
 
 @pytest.mark.integration
+def test_order_from_checkout_with_voucher_without_usage_limit(
+    app_api_client,
+    permission_handle_checkouts,
+    checkout_with_voucher_percentage,
+    voucher_percentage,
+    address,
+    checkout_delivery,
+):
+    # given
+    code = voucher_percentage.codes.first()
+    voucher_used_count = code.used
+    voucher_percentage.usage_limit = None
+    voucher_percentage.save(update_fields=["usage_limit"])
+
+    checkout = checkout_with_voucher_percentage
+    checkout.shipping_address = address
+    checkout.assigned_delivery = checkout_delivery(checkout)
+    checkout.billing_address = address
+    checkout.save()
+
+    variables = {"id": graphene.Node.to_global_id("Checkout", checkout.pk)}
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_ORDER_CREATE_FROM_CHECKOUT,
+        variables,
+        permissions=[permission_handle_checkouts],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderCreateFromCheckout"]
+    assert not data["errors"]
+    assert data["order"] is not None
+
+    code.refresh_from_db()
+    assert code.used == voucher_used_count + 1
+
+
+@pytest.mark.integration
 def test_order_from_checkout_with_voucher_and_gift_card(
     app_api_client,
     permission_handle_checkouts,


### PR DESCRIPTION
Always increment and release voucher used counts even when no usage limit is set so GraphQL and the dashboard reflect actual usage. Fixes #18085