### PR TITLE
Fix VoucherInfoByVoucherCodeLoader channel listings loading

### DIFF
--- a/saleor/discount/interface.py
+++ b/saleor/discount/interface.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import TYPE_CHECKING, NamedTuple, Optional
 
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
         PromotionRule,
         PromotionRuleTranslation,
         PromotionTranslation,
+        VoucherChannelListing,
     )
 
 
@@ -48,6 +49,7 @@ class VoucherInfo:
     variant_pks: list[int]
     collection_pks: list[int]
     category_pks: list[int]
+    channel_listings: list["VoucherChannelListing"] = field(default_factory=list)
 
 
 def fetch_voucher_info(

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -141,14 +141,21 @@ class Voucher(ModelWithMetadata):
     def promo_codes(self):
         return list(self.codes.values_list("code", flat=True))
 
-    def get_discount(self, channel: Channel):
+    def get_discount(self, channel: Channel, channel_listings=None):
         """Return proper discount amount for given channel.
 
-        It operates over all channel listings as assuming that we have prefetched them.
+        Prefer already-fetched ``channel_listings`` (e.g. from a dataloader) to avoid
+        extra queries. Falls back to the related manager, which should be prefetched
+        when listings are not passed explicitly.
         """
         voucher_channel_listing = None
+        listings = (
+            channel_listings
+            if channel_listings is not None
+            else self.channel_listings.all()
+        )
 
-        for channel_listing in self.channel_listings.all():
+        for channel_listing in listings:
             if channel.id == channel_listing.channel_id:
                 voucher_channel_listing = channel_listing
                 break
@@ -168,8 +175,10 @@ class Voucher(ModelWithMetadata):
             )
         raise NotImplementedError("Unknown discount type")
 
-    def get_discount_amount_for(self, price: Money, channel: Channel) -> Money:
-        discount = self.get_discount(channel)
+    def get_discount_amount_for(
+        self, price: Money, channel: Channel, channel_listings=None
+    ) -> Money:
+        discount = self.get_discount(channel, channel_listings=channel_listings)
         after_discount = discount(price)
         if after_discount.amount < 0:
             return price

--- a/saleor/graphql/discount/dataloaders.py
+++ b/saleor/graphql/discount/dataloaders.py
@@ -165,18 +165,19 @@ class VoucherInfoByVoucherCodeLoader(DataLoader[str, VoucherInfo | None]):
     context_key = "voucher_info_by_voucher_code"
 
     def batch_load(self, keys):
-        # FIXME dataloader should not operate on prefetched data. The channel
-        #  listings are used in Voucher's model to calculate a discount amount.
-        #  This is a workaround that we should solve by fetching channel_listings
-        #  via data loader and passing it to calculate a discount amount.
         voucher_codes_map = (
             VoucherCode.objects.using(self.database_connection_name)
-            .prefetch_related("voucher__channel_listings")
+            .select_related("voucher")
             .filter(code__in=keys)
             .in_bulk(field_name="code")
         )
 
-        vouchers = {code.voucher for code in voucher_codes_map.values()}
+        vouchers_by_id = {
+            code.voucher_id: code.voucher for code in voucher_codes_map.values()
+        }
+        vouchers = list(vouchers_by_id.values())
+        voucher_ids = list(vouchers_by_id.keys())
+
         voucher_products = (
             Voucher.products.through.objects.using(self.database_connection_name)
             .filter(voucher__in=vouchers)
@@ -210,23 +211,47 @@ class VoucherInfoByVoucherCodeLoader(DataLoader[str, VoucherInfo | None]):
         for voucher_id, collection_id in voucher_collections:
             collection_pks_map[voucher_id].append(collection_id)
 
-        voucher_infos: list[VoucherInfo | None] = []
-        for code in keys:
-            voucher_code = voucher_codes_map.get(code)
-            if not voucher_code:
-                voucher_infos.append(None)
-                continue
-            voucher_infos.append(
-                VoucherInfo(
-                    voucher=voucher_code.voucher,
-                    voucher_code=voucher_code.code,
-                    product_pks=product_pks_map.get(voucher_code.voucher_id, []),
-                    variant_pks=variant_pks_map.get(voucher_code.voucher_id, []),
-                    category_pks=category_pks_map.get(voucher_code.voucher_id, []),
-                    collection_pks=collection_pks_map.get(voucher_code.voucher_id, []),
-                )
+        def with_channel_listings(channel_listings_lists):
+            listings_by_voucher_id = dict(
+                zip(voucher_ids, channel_listings_lists, strict=False)
             )
-        return voucher_infos
+            # Ensure voucher.channel_listings.all() uses dataloader results
+            # for callers that still rely on the related manager.
+            for voucher_code in voucher_codes_map.values():
+                voucher_code.voucher._prefetched_objects_cache = {
+                    "channel_listings": listings_by_voucher_id.get(
+                        voucher_code.voucher_id, []
+                    )
+                }
+
+            voucher_infos: list[VoucherInfo | None] = []
+            for code in keys:
+                voucher_code = voucher_codes_map.get(code)
+                if not voucher_code:
+                    voucher_infos.append(None)
+                    continue
+                voucher_infos.append(
+                    VoucherInfo(
+                        voucher=voucher_code.voucher,
+                        voucher_code=voucher_code.code,
+                        product_pks=product_pks_map.get(voucher_code.voucher_id, []),
+                        variant_pks=variant_pks_map.get(voucher_code.voucher_id, []),
+                        category_pks=category_pks_map.get(voucher_code.voucher_id, []),
+                        collection_pks=collection_pks_map.get(
+                            voucher_code.voucher_id, []
+                        ),
+                        channel_listings=listings_by_voucher_id.get(
+                            voucher_code.voucher_id, []
+                        ),
+                    )
+                )
+            return voucher_infos
+
+        return (
+            VoucherChannelListingsByVoucherIdLoader(self.context)
+            .load_many(voucher_ids)
+            .then(with_channel_listings)
+        )
 
 
 class OrderDiscountsByOrderIDLoader(DataLoader[UUID, list[OrderDiscount]]):

--- a/saleor/graphql/discount/tests/test_dataloaders.py
+++ b/saleor/graphql/discount/tests/test_dataloaders.py
@@ -1,0 +1,126 @@
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from prices import Money
+
+from ....discount.models import NotApplicable, Voucher
+from ...context import SaleorContext
+from ..dataloaders import VoucherInfoByVoucherCodeLoader
+
+
+def test_voucher_info_by_voucher_code_loader_loads_channel_listings(
+    voucher, channel_USD
+):
+    # given
+    code = voucher.codes.first().code
+    context = SaleorContext()
+    expected_listing_ids = set(voucher.channel_listings.values_list("id", flat=True))
+
+    # when
+    voucher_info = VoucherInfoByVoucherCodeLoader(context).load(code).get()
+
+    # then
+    assert voucher_info is not None
+    assert voucher_info.voucher_code == code
+    assert voucher_info.voucher.id == voucher.id
+    assert {listing.id for listing in voucher_info.channel_listings} == (
+        expected_listing_ids
+    )
+    assert {
+        listing.id for listing in voucher_info.voucher.channel_listings.all()
+    } == expected_listing_ids
+
+    with CaptureQueriesContext(connection) as queries:
+        discount = voucher_info.voucher.get_discount(
+            channel_USD, channel_listings=voucher_info.channel_listings
+        )
+        assert discount(Money(100, channel_USD.currency_code)) == Money(
+            80, channel_USD.currency_code
+        )
+    assert not any("channel" in query["sql"].lower() for query in queries)
+
+
+def test_voucher_info_by_voucher_code_loader_unknown_code():
+    # given
+    context = SaleorContext()
+
+    # when
+    voucher_info = VoucherInfoByVoucherCodeLoader(context).load("unknown-code").get()
+
+    # then
+    assert voucher_info is None
+
+
+def test_voucher_info_by_voucher_code_loader_batches_channel_listings(
+    voucher, voucher_percentage, channel_USD
+):
+    # given
+    codes = [
+        voucher.codes.first().code,
+        voucher_percentage.codes.first().code,
+    ]
+    context = SaleorContext()
+
+    # when
+    with CaptureQueriesContext(connection) as queries:
+        voucher_infos = VoucherInfoByVoucherCodeLoader(context).load_many(codes).get()
+
+    # then
+    assert len(voucher_infos) == 2
+    assert all(info is not None for info in voucher_infos)
+    for voucher_info in voucher_infos:
+        assert len(voucher_info.channel_listings) == 1
+        voucher_info.voucher.get_discount(
+            channel_USD, channel_listings=voucher_info.channel_listings
+        )
+
+    channel_listing_queries = [
+        query["sql"]
+        for query in queries
+        if "discount_voucherchannellisting" in query["sql"].lower()
+    ]
+    assert len(channel_listing_queries) == 1
+
+
+def test_voucher_get_discount_accepts_channel_listings(voucher, channel_USD):
+    # given
+    listings = list(voucher.channel_listings.all())
+    voucher = Voucher.objects.get(pk=voucher.pk)
+
+    # when
+    with CaptureQueriesContext(connection) as queries:
+        discount = voucher.get_discount(channel_USD, channel_listings=listings)
+        discounted = discount(Money(50, channel_USD.currency_code))
+
+    # then
+    assert discounted == Money(30, channel_USD.currency_code)
+    assert not any("channel" in query["sql"].lower() for query in queries)
+
+
+def test_voucher_get_discount_with_channel_listings_not_assigned(
+    voucher, channel_PLN
+):
+    # given
+    listings = list(voucher.channel_listings.all())
+    voucher = Voucher.objects.get(pk=voucher.pk)
+
+    # when / then
+    with CaptureQueriesContext(connection) as queries:
+        with pytest.raises(NotApplicable):
+            voucher.get_discount(channel_PLN, channel_listings=listings)
+    assert not any("channel" in query["sql"].lower() for query in queries)
+
+
+def test_voucher_get_discount_amount_for_with_channel_listings(voucher, channel_USD):
+    # given
+    listings = list(voucher.channel_listings.all())
+    voucher = Voucher.objects.get(pk=voucher.pk)
+    price = Money(50, channel_USD.currency_code)
+
+    # when
+    discount_amount = voucher.get_discount_amount_for(
+        price, channel_USD, channel_listings=listings
+    )
+
+    # then
+    assert discount_amount == Money(20, channel_USD.currency_code)


### PR DESCRIPTION
Load voucher channel listings through VoucherChannelListingsByVoucherIdLoader instead of prefetch_related in VoucherInfoByVoucherCodeLoader, and allow Voucher.get_discount to use already fetched listings. Fixes #13751
