### PR TITLE
Fix paymentGatewayInitialize when gateway response is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Fixed `paymentGatewayInitialize` crashing with a TypeError when the payment gateway webhook did not respond or no plugin returned a list - #17891
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/payment/tests/mutations/test_payment_gateway_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_payment_gateway_initialize.py
@@ -1233,3 +1233,43 @@ def test_with_mutiple_payment_gateways_have_different_recipments(
     second_message = mock_send_webhook_using_http.mock_calls[1].args[1]
 
     assert json.loads(first_message) != json.loads(second_message)
+
+
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+@override_settings(PLUGINS=["saleor.plugins.webhook.plugin.WebhookPlugin"])
+def test_for_checkout_when_webhook_does_not_respond(
+    mocked_send_webhook_request_sync,
+    user_api_client,
+    checkout_with_prices,
+    permission_manage_payments,
+    payment_gateway_initialize_session_app,
+):
+    # given
+    mocked_send_webhook_request_sync.return_value = None
+    checkout = checkout_with_prices
+    app_identifier = payment_gateway_initialize_session_app.identifier
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "paymentGateways": [{"id": app_identifier}],
+    }
+
+    # when
+    response = user_api_client.post_graphql(PAYMENT_GATEWAY_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["paymentGatewayInitialize"]["errors"]
+    gateway_configs = content["data"]["paymentGatewayInitialize"]["gatewayConfigs"]
+    assert len(gateway_configs) == 1
+    assert gateway_configs[0]["id"] == app_identifier
+    assert gateway_configs[0]["data"] is None
+    assert len(gateway_configs[0]["errors"]) == 1
+    assert gateway_configs[0]["errors"][0]["code"] == (
+        PaymentGatewayConfigErrorCode.INVALID.name
+    )
+    assert (
+        gateway_configs[0]["errors"][0]["message"]
+        == "Unable to process a payment gateway response."
+    )
+    mocked_send_webhook_request_sync.assert_called_once()

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1533,7 +1533,7 @@ class PluginsManager(PaymentInterface):
         payment_gateways: list["PaymentGatewayData"] | None,
         source_object: Union["Order", "Checkout"],
     ) -> list["PaymentGatewayData"]:
-        default_value = None
+        default_value: list[PaymentGatewayData] = []
         return self.__run_method_on_plugins(
             "payment_gateway_initialize_session",
             default_value,

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1624,3 +1624,38 @@ def test_run_plugin_method_until_first_success_for_active_plugins_only(
     # then
     assert result is None
     assert mock_run_method.call_count == calls
+
+
+def test_manager_payment_gateway_initialize_session_returns_empty_list_without_plugins(
+    checkout,
+):
+    # given
+    manager = PluginsManager(plugins=[])
+
+    # when
+    response = manager.payment_gateway_initialize_session(
+        amount=Decimal("10.00"),
+        payment_gateways=None,
+        source_object=checkout,
+    )
+
+    # then
+    assert response == []
+
+
+def test_manager_payment_gateway_initialize_session_with_only_inactive_plugins(
+    checkout,
+):
+    # given
+    plugins = ["saleor.plugins.tests.sample_plugins.PluginInactive"]
+    manager = PluginsManager(plugins=plugins)
+
+    # when
+    response = manager.payment_gateway_initialize_session(
+        amount=Decimal("10.00"),
+        payment_gateways=None,
+        source_object=checkout,
+    )
+
+    # then
+    assert response == []

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -3246,7 +3246,7 @@ class WebhookPlugin(BasePlugin):
         previous_value,
     ) -> list[PaymentGatewayData]:
         if not self.active:
-            return previous_value
+            return previous_value if previous_value is not None else []
 
         event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
         response_gateway: dict[str, PaymentGatewayData] = {}

--- a/saleor/plugins/webhook/tests/test_payment_gateway_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_gateway_initialize_session_webhook.py
@@ -430,3 +430,41 @@ def test_gateway_initialize_session_for_order_with_request_data(
     _assert_with_subscription(
         order, data, amount, webhook, expected_data, response, mock_request
     )
+
+
+@freeze_time()
+@mock.patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
+def test_gateway_initialize_session_when_webhook_does_not_respond(
+    mock_request, webhook_plugin, webhook_app, checkout, permission_manage_payments
+):
+    # given
+    mock_request.return_value = None
+    plugin = webhook_plugin()
+
+    webhook_app.identifier = "saleor.app.payment.stripe"
+    webhook_app.save()
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+    amount = Decimal("10.00")
+
+    # when
+    response = plugin.payment_gateway_initialize_session(
+        amount=amount,
+        payment_gateways=[
+            PaymentGatewayData(app_identifier=webhook_app.identifier, data=None)
+        ],
+        source_object=checkout,
+        previous_value=None,
+    )
+
+    # then
+    assert isinstance(response, list)
+    assert len(response) == 1
+    assert response[0].app_identifier == webhook_app.identifier
+    assert response[0].data is None
+    assert response[0].error == "Unable to process a payment gateway response."


### PR DESCRIPTION
Fixes #17891 - keep payment_gateway_initialize_session returning a list when gateways are inactive or unresponsive.