### PR TITLE
Validate transaction field lengths to avoid 500 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- Fixed `transactionCreate` and `transactionUpdate` returning a 500 error when `pspReference`, `message` or `name` exceeded 512 characters. The mutations now return an `INVALID` validation error instead - #12696
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -46,11 +46,32 @@ if TYPE_CHECKING:
     pass
 
 
-class TransactionCreateInput(BaseInputObjectType):
-    name = graphene.String(description="Payment name of the transaction.")
-    message = graphene.String(description="The message of the transaction.")
+# Match DB CharField(max_length=512) on TransactionItem / TransactionEvent.
+TRANSACTION_FIELD_MAX_LENGTH = payment_models.TransactionItem._meta.get_field(  # type: ignore[assignment]
+    "psp_reference"
+).max_length
 
-    psp_reference = graphene.String(description="PSP Reference of the transaction.")
+
+class TransactionCreateInput(BaseInputObjectType):
+    name = graphene.String(
+        description=(
+            "Payment name of the transaction. "
+            f"Maximum length is {TRANSACTION_FIELD_MAX_LENGTH} characters."
+        )
+    )
+    message = graphene.String(
+        description=(
+            "The message of the transaction. "
+            f"Maximum length is {TRANSACTION_FIELD_MAX_LENGTH} characters."
+        )
+    )
+
+    psp_reference = graphene.String(
+        description=(
+            "PSP Reference of the transaction. "
+            f"Maximum length is {TRANSACTION_FIELD_MAX_LENGTH} characters."
+        )
+    )
     available_actions = graphene.List(
         graphene.NonNull(TransactionActionEnum),
         description="List of all possible actions for the transaction",
@@ -90,9 +111,19 @@ class TransactionCreateInput(BaseInputObjectType):
 
 
 class TransactionEventInput(BaseInputObjectType):
-    psp_reference = graphene.String(description="PSP Reference related to this action.")
+    psp_reference = graphene.String(
+        description=(
+            "PSP Reference related to this action. "
+            f"Maximum length is {TRANSACTION_FIELD_MAX_LENGTH} characters."
+        )
+    )
 
-    message = graphene.String(description="The message related to the event.")
+    message = graphene.String(
+        description=(
+            "The message related to the event. Longer messages are truncated "
+            f"to {TRANSACTION_FIELD_MAX_LENGTH} characters."
+        )
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_PAYMENTS
@@ -135,6 +166,66 @@ class TransactionCreate(BaseMutation):
                     )
                 }
             ) from e
+
+    @classmethod
+    def validate_input_string_length(
+        cls,
+        value: str | None,
+        *,
+        field_name: str,
+        error_code: str,
+        error_field: str = "transaction",
+    ):
+        """Reject values that exceed the DB CharField max length.
+
+        Prevents an Integrity/DataError 500 when the value is written to the DB.
+        """
+        if value is not None and len(value) > TRANSACTION_FIELD_MAX_LENGTH:
+            raise ValidationError(
+                {
+                    error_field: ValidationError(
+                        f"`{field_name}` cannot exceed "
+                        f"{TRANSACTION_FIELD_MAX_LENGTH} characters.",
+                        code=error_code,
+                    )
+                }
+            )
+
+    @classmethod
+    def validate_transaction_input_lengths(
+        cls, transaction_data: dict | None, error_code: str
+    ):
+        if not transaction_data:
+            return
+        cls.validate_input_string_length(
+            transaction_data.get("psp_reference"),
+            field_name="pspReference",
+            error_code=error_code,
+        )
+        cls.validate_input_string_length(
+            transaction_data.get("message"),
+            field_name="message",
+            error_code=error_code,
+        )
+        cls.validate_input_string_length(
+            transaction_data.get("name"),
+            field_name="name",
+            error_code=error_code,
+        )
+
+    @classmethod
+    def validate_transaction_event_input(
+        cls, transaction_event: dict | None, error_code: str
+    ):
+        if not transaction_event:
+            return
+        # Event messages are truncated on write; pspReference is not.
+        cls.validate_input_string_length(
+            transaction_event.get("psp_reference"),
+            field_name="pspReference",
+            error_code=error_code,
+            error_field="transaction_event",
+        )
 
     # TODO This should be unified with metadata_manager and MetadataItemCollection
     # EXT-2054
@@ -260,6 +351,10 @@ class TransactionCreate(BaseMutation):
             transaction.get("external_url"),
             error_code=TransactionCreateErrorCode.INVALID.value,
         )
+        cls.validate_transaction_input_lengths(
+            transaction,
+            error_code=TransactionCreateErrorCode.INVALID.value,
+        )
         if payment_method_details := transaction.get("payment_method_details"):
             validate_payment_method_details_input(
                 payment_method_details, TransactionCreateErrorCode
@@ -343,6 +438,10 @@ class TransactionCreate(BaseMutation):
         )
         order_or_checkout_instance = cls.validate_input(
             order_or_checkout_instance, transaction=transaction
+        )
+        cls.validate_transaction_event_input(
+            transaction_event,
+            error_code=TransactionCreateErrorCode.INVALID.value,
         )
         payment_details_data: PaymentMethodDetails | None = None
         if payment_method_details := transaction.pop("payment_method_details", None):

--- a/saleor/graphql/payment/mutations/transaction/transaction_update.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_update.py
@@ -133,6 +133,10 @@ class TransactionUpdate(TransactionCreate):
             transaction_data.get("external_url"),
             error_code=TransactionCreateErrorCode.INVALID.value,
         )
+        cls.validate_transaction_input_lengths(
+            transaction_data,
+            error_code=TransactionUpdateErrorCode.INVALID.value,
+        )
         if payment_method_details := transaction_data.get("payment_method_details"):
             validate_payment_method_details_input(
                 payment_method_details, TransactionUpdateErrorCode
@@ -219,6 +223,10 @@ class TransactionUpdate(TransactionCreate):
         previous_charged_value = instance.charged_value
         previous_refunded_value = instance.refunded_value
 
+        cls.validate_transaction_event_input(
+            transaction_event,
+            error_code=TransactionUpdateErrorCode.INVALID.value,
+        )
         if transaction:
             cls.validate_transaction_input(instance, transaction)
             cls.assign_app_to_transaction_data_if_missing(instance, transaction, app)

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -2891,3 +2891,107 @@ def test_transaction_create_checkout_completed_race_condition(
     assert order.status == OrderStatus.UNFULFILLED
     assert order.charge_status == OrderChargeStatus.NONE
     assert order.authorize_status == OrderAuthorizeStatus.FULL
+
+
+@pytest.mark.parametrize(
+    ("field", "input_key"),
+    [
+        ("pspReference", "pspReference"),
+        ("message", "message"),
+        ("name", "name"),
+    ],
+)
+def test_transaction_create_rejects_too_long_string_fields(
+    field, input_key, order_with_lines, permission_manage_payments, app_api_client
+):
+    # given
+    too_long_value = "x" * 513
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            input_key: too_long_value,
+            "amountAuthorized": {
+                "amount": Decimal(10),
+                "currency": "USD",
+            },
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert not content["data"]["transactionCreate"]["transaction"]
+    errors = content["data"]["transactionCreate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "transaction"
+    assert errors[0]["code"] == TransactionCreateErrorCode.INVALID.name
+    assert "512" in errors[0]["message"]
+    assert field in errors[0]["message"]
+    assert not TransactionItem.objects.filter(order_id=order_with_lines.pk).exists()
+
+
+def test_transaction_create_rejects_too_long_event_psp_reference(
+    order_with_lines, permission_manage_payments, app_api_client
+):
+    # given
+    too_long_psp_reference = "x" * 513
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "amountAuthorized": {
+                "amount": Decimal(10),
+                "currency": "USD",
+            },
+        },
+        "transaction_event": {
+            "pspReference": too_long_psp_reference,
+            "message": "Event message",
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert not content["data"]["transactionCreate"]["transaction"]
+    errors = content["data"]["transactionCreate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "transactionEvent"
+    assert errors[0]["code"] == TransactionCreateErrorCode.INVALID.name
+    assert "512" in errors[0]["message"]
+    assert not TransactionItem.objects.filter(order_id=order_with_lines.pk).exists()
+
+
+def test_transaction_create_accepts_max_length_psp_reference(
+    order_with_lines, permission_manage_payments, app_api_client
+):
+    # given
+    max_length_psp_reference = "x" * 512
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "pspReference": max_length_psp_reference,
+            "amountAuthorized": {
+                "amount": Decimal(10),
+                "currency": "USD",
+            },
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["transactionCreate"]
+    assert not data["errors"]
+    assert data["transaction"]["pspReference"] == max_length_psp_reference

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -3820,3 +3820,85 @@ def test_transaction_update_checkout_completed_race_condition(
     assert order.charge_status == OrderChargeStatus.FULL
     assert order.authorize_status == OrderAuthorizeStatus.FULL
     assert order.total_charged.amount == checkout.total.gross.amount
+
+
+@pytest.mark.parametrize(
+    ("field", "input_key"),
+    [
+        ("pspReference", "pspReference"),
+        ("message", "message"),
+        ("name", "name"),
+    ],
+)
+def test_transaction_update_rejects_too_long_string_fields(
+    field,
+    input_key,
+    transaction_item_created_by_app,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    transaction = transaction_item_created_by_app
+    original_psp_reference = transaction.psp_reference
+    original_message = transaction.message
+    original_name = transaction.name
+    too_long_value = "x" * 513
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction": {
+            input_key: too_long_value,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    data = content["data"]["transactionUpdate"]
+    assert not data["transaction"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "transaction"
+    assert errors[0]["code"] == TransactionUpdateErrorCode.INVALID.name
+    assert "512" in errors[0]["message"]
+    assert field in errors[0]["message"]
+    transaction.refresh_from_db()
+    assert transaction.psp_reference == original_psp_reference
+    assert transaction.message == original_message
+    assert transaction.name == original_name
+
+
+def test_transaction_update_rejects_too_long_event_psp_reference(
+    transaction_item_created_by_app, permission_manage_payments, app_api_client
+):
+    # given
+    transaction = transaction_item_created_by_app
+    too_long_psp_reference = "x" * 513
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.token),
+        "transaction_event": {
+            "pspReference": too_long_psp_reference,
+            "message": "Event message",
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_UPDATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    data = content["data"]["transactionUpdate"]
+    assert not data["transaction"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "transactionEvent"
+    assert errors[0]["code"] == TransactionUpdateErrorCode.INVALID.name
+    assert "512" in errors[0]["message"]
+    assert not TransactionEvent.objects.filter(
+        transaction=transaction, psp_reference=too_long_psp_reference
+    ).exists()


### PR DESCRIPTION
Fixes #12696 - return validation errors when transaction string fields exceed the 512-character DB limit.