### PR TITLE
Fix a bug where resolver would incorrectly returned all attributes instead of no attributes when all actually available attributes were already assigned to a product type

### DIFF
--- a/saleor/graphql/attribute/resolvers.py
+++ b/saleor/graphql/attribute/resolvers.py
@@ -4,8 +4,9 @@ from ..utils import get_user_or_app_from_context
 
 
 def resolve_attributes(info, qs=None):
-    requestor = get_user_or_app_from_context(info.context)
-    qs = qs or models.Attribute.objects.using(
-        get_database_connection_name(info.context)
-    ).get_visible_to_user(requestor)
+    if qs is None:
+        requestor = get_user_or_app_from_context(info.context)
+        qs = models.Attribute.objects.using(
+            get_database_connection_name(info.context)
+        ).get_visible_to_user(requestor)
     return qs

--- a/saleor/graphql/product/tests/queries/test_product_type_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_type_query.py
@@ -448,6 +448,42 @@ def test_product_type_get_unassigned_product_type_attributes(
     assert received_ids == expected_ids
 
 
+def test_product_type_no_available_attributes_when_all_are_assigned(
+    staff_api_client, permission_manage_products
+):
+    # given a product type that has every product type attribute assigned
+    product_type = ProductType.objects.create(
+        name="Fully assigned", slug="fully-assigned", kind=ProductTypeKind.NORMAL
+    )
+    product_attribute, variant_attribute = Attribute.objects.bulk_create(
+        [
+            Attribute(slug="color", name="Color", type=AttributeType.PRODUCT_TYPE),
+            Attribute(slug="size", name="Size", type=AttributeType.PRODUCT_TYPE),
+        ]
+    )
+    product_type.product_attributes.add(product_attribute)
+    product_type.variant_attributes.add(variant_attribute)
+    assert not Attribute.objects.get_unassigned_product_type_attributes(
+        product_type.pk
+    ).exists()
+
+    # when
+    available_attributes = get_graphql_content(
+        staff_api_client.post_graphql(
+            QUERY_AVAILABLE_ATTRIBUTES,
+            {
+                "productTypeId": graphene.Node.to_global_id(
+                    "ProductType", product_type.pk
+                )
+            },
+            permissions=[permission_manage_products],
+        )
+    )["data"]["productType"]["availableAttributes"]["edges"]
+
+    # then
+    assert available_attributes == []
+
+
 def test_product_type_filter_unassigned_attributes(
     staff_api_client, permission_manage_products, product_type_attribute_list
 ):


### PR DESCRIPTION
> [!NOTE]
> To be backported. 