### PR TITLE
Deprecate export webhook events and subscription types

### DIFF
--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -19,6 +19,8 @@ DEPRECATED_EXPORT_MUTATIONS = (
     "All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools."
 )
 
+DEPRECATED_EXPORT_MUTATIONS_TYPE_DESCRIPTION = "\n\n" + DEPRECATED_EXPORT_MUTATIONS
+
 DEPRECATED_LEGACY_PAYMENTS = (
     "The legacy Payments API is deprecated and will be removed. "
     "Use the Transactions API instead."

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1887,7 +1887,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   GIFT_CARD_METADATA_UPDATED
 
   """A gift card export is completed."""
-  GIFT_CARD_EXPORT_COMPLETED
+  GIFT_CARD_EXPORT_COMPLETED @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 
   """A new menu created."""
   MENU_CREATED
@@ -2074,7 +2074,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   PRODUCT_METADATA_UPDATED
 
   """A product export is completed."""
-  PRODUCT_EXPORT_COMPLETED
+  PRODUCT_EXPORT_COMPLETED @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 
   """A new product type is created."""
   PRODUCT_TYPE_CREATED
@@ -2270,7 +2270,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   VOUCHER_METADATA_UPDATED
 
   """A voucher code export is completed."""
-  VOUCHER_CODE_EXPORT_COMPLETED
+  VOUCHER_CODE_EXPORT_COMPLETED @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 
   """An observability event is created."""
   OBSERVABILITY @deprecated(reason: "The observability feature is no longer supported. This event will be removed in Saleor 3.24.")
@@ -2517,7 +2517,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   GIFT_CARD_METADATA_UPDATED
 
   """A gift card export is completed."""
-  GIFT_CARD_EXPORT_COMPLETED
+  GIFT_CARD_EXPORT_COMPLETED @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 
   """A new menu created."""
   MENU_CREATED
@@ -2704,7 +2704,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   PRODUCT_METADATA_UPDATED
 
   """A product export is completed."""
-  PRODUCT_EXPORT_COMPLETED
+  PRODUCT_EXPORT_COMPLETED @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 
   """A new product type is created."""
   PRODUCT_TYPE_CREATED
@@ -2900,7 +2900,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   VOUCHER_METADATA_UPDATED
 
   """A voucher code export is completed."""
-  VOUCHER_CODE_EXPORT_COMPLETED
+  VOUCHER_CODE_EXPORT_COMPLETED @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 
   """An observability event is created."""
   OBSERVABILITY @deprecated(reason: "The observability feature is no longer supported. This event will be removed in Saleor 3.24.")
@@ -14309,7 +14309,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   GIFT_CARD_SENT
   GIFT_CARD_STATUS_CHANGED
   GIFT_CARD_METADATA_UPDATED
-  GIFT_CARD_EXPORT_COMPLETED
+  GIFT_CARD_EXPORT_COMPLETED @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
   MENU_CREATED
   MENU_UPDATED
   MENU_DELETED
@@ -14366,7 +14366,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   PRODUCT_UPDATED
   PRODUCT_DELETED
   PRODUCT_METADATA_UPDATED
-  PRODUCT_EXPORT_COMPLETED
+  PRODUCT_EXPORT_COMPLETED @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
   PRODUCT_TYPE_CREATED
   PRODUCT_TYPE_UPDATED
   PRODUCT_TYPE_DELETED
@@ -14424,7 +14424,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   VOUCHER_CODES_CREATED
   VOUCHER_CODES_DELETED
   VOUCHER_METADATA_UPDATED
-  VOUCHER_CODE_EXPORT_COMPLETED
+  VOUCHER_CODE_EXPORT_COMPLETED @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
   OBSERVABILITY @deprecated(reason: "The observability feature is no longer supported. This event will be removed in Saleor 3.24.")
   THUMBNAIL_CREATED
   SHOP_METADATA_UPDATED
@@ -36060,7 +36060,11 @@ type GiftCardMetadataUpdated implements Event @doc(category: "Gift cards") {
   giftCard: GiftCard
 }
 
-"""Event sent when gift card export is completed."""
+"""
+Event sent when gift card export is completed.
+
+Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.
+"""
 type GiftCardExportCompleted implements Event @doc(category: "Gift cards") {
   """Time of the event."""
   issuedAt: DateTime
@@ -36075,7 +36079,7 @@ type GiftCardExportCompleted implements Event @doc(category: "Gift cards") {
   recipient: App
 
   """The export file for gift cards."""
-  export: ExportFile
+  export: ExportFile @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 }
 
 """Event sent when new menu is created."""
@@ -36300,7 +36304,11 @@ type ProductMetadataUpdated implements Event @doc(category: "Products") {
   category: Category
 }
 
-"""Event sent when product export is completed."""
+"""
+Event sent when product export is completed.
+
+Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.
+"""
 type ProductExportCompleted implements Event @doc(category: "Products") {
   """Time of the event."""
   issuedAt: DateTime
@@ -36315,7 +36323,7 @@ type ProductExportCompleted implements Event @doc(category: "Products") {
   recipient: App
 
   """The export file for products."""
-  export: ExportFile
+  export: ExportFile @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 }
 
 """
@@ -37843,7 +37851,11 @@ type VoucherMetadataUpdated implements Event @doc(category: "Discounts") {
   ): Voucher
 }
 
-"""Event sent when voucher code export is completed."""
+"""
+Event sent when voucher code export is completed.
+
+Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.
+"""
 type VoucherCodeExportCompleted implements Event @doc(category: "Discounts") {
   """Time of the event."""
   issuedAt: DateTime
@@ -37858,7 +37870,7 @@ type VoucherCodeExportCompleted implements Event @doc(category: "Discounts") {
   recipient: App
 
   """The export file for voucher codes."""
-  export: ExportFile
+  export: ExportFile @deprecated(reason: "Export functionality is deprecated and will be removed. All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.")
 }
 
 """Event sent when new warehouse is created."""

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -4,6 +4,7 @@ from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..core.descriptions import (
     ADDED_IN_323,
     DEFAULT_DEPRECATION_REASON,
+    DEPRECATED_EXPORT_MUTATIONS,
     DEPRECATED_LEGACY_PAYMENTS,
 )
 from ..core.doc_category import DOC_CATEGORY_WEBHOOKS
@@ -286,6 +287,14 @@ def description(enum):
     return "Enum determining type of webhook."
 
 
+# Events emitted only by the deprecated export mutations, removed together with them.
+EXPORT_COMPLETED_EVENTS = {
+    WebhookEventAsyncType.PRODUCT_EXPORT_COMPLETED,
+    WebhookEventAsyncType.GIFT_CARD_EXPORT_COMPLETED,
+    WebhookEventAsyncType.VOUCHER_CODE_EXPORT_COMPLETED,
+}
+
+
 def deprecation_reason(enum):
     if enum.value == WebhookEventAsyncType.NOTIFY_USER:
         return (
@@ -297,6 +306,8 @@ def deprecation_reason(enum):
             "The observability feature is no longer supported. "
             "This event will be removed in Saleor 3.24."
         )
+    if enum.value in EXPORT_COMPLETED_EVENTS:
+        return DEPRECATED_EXPORT_MUTATIONS
     if enum.value == WebhookEventAsyncType.ANY:
         return DEFAULT_DEPRECATION_REASON
     if enum.value in WebhookEventSyncType.PAYMENT_EVENTS:

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -53,6 +53,8 @@ from ..core.descriptions import (
     ADDED_IN_322,
     ADDED_IN_323,
     ADDED_IN_324,
+    DEPRECATED_EXPORT_MUTATIONS,
+    DEPRECATED_EXPORT_MUTATIONS_TYPE_DESCRIPTION,
     DEPRECATED_IN_3X_EVENT,
     DEPRECATED_LEGACY_PAYMENTS,
     DEPRECATED_LEGACY_PAYMENTS_TYPE_DESCRIPTION,
@@ -754,13 +756,17 @@ class GiftCardExportCompleted(SubscriptionObjectType):
     export = graphene.Field(
         "saleor.graphql.csv.types.ExportFile",
         description="The export file for gift cards.",
+        deprecation_reason=DEPRECATED_EXPORT_MUTATIONS,
     )
 
     class Meta:
         root_type = "ExportFile"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when gift card export is completed."
+        description = (
+            "Event sent when gift card export is completed."
+            + DEPRECATED_EXPORT_MUTATIONS_TYPE_DESCRIPTION
+        )
         doc_category = DOC_CATEGORY_GIFT_CARDS
 
     @staticmethod
@@ -1268,13 +1274,17 @@ class ProductExportCompleted(SubscriptionObjectType):
     export = graphene.Field(
         "saleor.graphql.csv.types.ExportFile",
         description="The export file for products.",
+        deprecation_reason=DEPRECATED_EXPORT_MUTATIONS,
     )
 
     class Meta:
         root_type = "ExportFile"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when product export is completed."
+        description = (
+            "Event sent when product export is completed."
+            + DEPRECATED_EXPORT_MUTATIONS_TYPE_DESCRIPTION
+        )
         doc_category = DOC_CATEGORY_PRODUCTS
 
     @staticmethod
@@ -2628,13 +2638,17 @@ class VoucherCodeExportCompleted(SubscriptionObjectType):
     export = graphene.Field(
         "saleor.graphql.csv.types.ExportFile",
         description="The export file for voucher codes.",
+        deprecation_reason=DEPRECATED_EXPORT_MUTATIONS,
     )
 
     class Meta:
         root_type = "ExportFile"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when voucher code export is completed."
+        description = (
+            "Event sent when voucher code export is completed."
+            + DEPRECATED_EXPORT_MUTATIONS_TYPE_DESCRIPTION
+        )
         doc_category = DOC_CATEGORY_DISCOUNTS
 
     @staticmethod


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/19584, so deprecations are in sync

Later some of them will be [removed](https://github.com/saleor/saleor/pull/19583) but lets do it step by step