### PR TITLE
Deprecate the preorder GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,3 +129,10 @@ Validation is now performed on the frontend (Dashboard). This change increases v
 - Deprecate export mutations (`exportProducts`, `exportGiftCards`, `exportVoucherCodes`). All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.
 - Deprecate the export webhook event types emitted by those mutations: `PRODUCT_EXPORT_COMPLETED`, `GIFT_CARD_EXPORT_COMPLETED` and `VOUCHER_CODE_EXPORT_COMPLETED` (`WebhookEventTypeEnum`, `WebhookEventTypeAsyncEnum`, `WebhookSampleEventTypeEnum`), along with the `ProductExportCompleted`, `GiftCardExportCompleted` and `VoucherCodeExportCompleted` subscription types.
 - Deprecate `voucher` input field on `DraftOrderInput` and `DraftOrderCreateInput`. Use `voucherCode` instead.
+- Deprecate the preorder API. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to `false` to sell without a stock limit. The following are deprecated:
+  - Mutation `productVariantPreorderDeactivate`.
+  - Types `PreorderData` (and `ProductVariant.preorder`) and `PreorderThreshold` (and `ProductVariantChannelListing.preorderThreshold`).
+  - Input `PreorderSettingsInput` and the `preorder` field on `ProductVariantInput`, `ProductVariantCreateInput`, `ProductVariantBulkCreateInput` and `ProductVariantBulkUpdateInput`.
+  - Input field `preorderThreshold` on `ProductVariantChannelListingAddInput` and `ChannelListingUpdateInput`.
+  - Filters `hasPreorderedVariants` (`ProductFilterInput`, `ProductWhereInput`) and `isPreorder` (`ProductVariantFilterInput`, `OrderFilterInput`).
+  - Error code `PREORDER_VARIANT_CANNOT_BE_DEACTIVATED` on `ProductErrorCode`.

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -31,6 +31,21 @@ DEPRECATED_LEGACY_PAYMENTS = (
 
 DEPRECATED_LEGACY_PAYMENTS_TYPE_DESCRIPTION = "\n\n" + DEPRECATED_LEGACY_PAYMENTS
 
+DEPRECATED_PREORDER = (
+    "Preorder is deprecated and will be removed. "
+    "Model pre-sales with regular stock instead: create the planned quantity in a "
+    "warehouse, or set `trackInventory` to false to sell without a stock limit."
+)
+
+# Used on type descriptions, where GraphQL has no `@deprecated` directive. Must not
+# embed DEPRECATED_IN_3X_INPUT: `schema_printer.print_description` truncates a
+# description at that marker, which would drop the reason entirely.
+DEPRECATED_PREORDER_TYPE_DESCRIPTION = "\n\nDEPRECATED: " + DEPRECATED_PREORDER
+
+# `schema_printer.print_input_value` turns this into a real `@deprecated` directive,
+# but only when the description carries the DEPRECATED_IN_3X_INPUT marker verbatim.
+DEPRECATED_PREORDER_INPUT = f"{DEPRECATED_IN_3X_INPUT} {DEPRECATED_PREORDER}"
+
 
 PREVIEW_FEATURE = (
     "\n\nNote: this API is currently in Feature Preview and can be subject to "

--- a/saleor/graphql/core/enums.py
+++ b/saleor/graphql/core/enums.py
@@ -35,6 +35,7 @@ from ...translations import error_codes as translatable_error_codes
 from ...warehouse import error_codes as warehouse_error_codes
 from ...webhook import error_codes as webhook_error_codes
 from ..notifications import error_codes as external_notifications_error_codes
+from .descriptions import DEPRECATED_PREORDER
 from .doc_category import (
     DOC_CATEGORY_APPS,
     DOC_CATEGORY_ATTRIBUTES,
@@ -432,8 +433,19 @@ PermissionGroupErrorCode: Final[graphene.Enum] = graphene.Enum.from_enum(
 )
 PermissionGroupErrorCode.doc_category = DOC_CATEGORY_USERS
 
+
+def product_error_code_deprecation_reason(enum):
+    preorder_code = (
+        product_error_codes.ProductErrorCode.PREORDER_VARIANT_CANNOT_BE_DEACTIVATED
+    )
+    if enum == preorder_code:
+        return DEPRECATED_PREORDER
+    return None
+
+
 ProductErrorCode: Final[graphene.Enum] = graphene.Enum.from_enum(
-    product_error_codes.ProductErrorCode
+    product_error_codes.ProductErrorCode,
+    deprecation_reason=product_error_code_deprecation_reason,
 )
 ProductErrorCode.doc_category = DOC_CATEGORY_PRODUCTS
 

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -21,7 +21,7 @@ from ...product.models import ProductVariant
 from ...warehouse.models import Stock, Warehouse
 from ..account.filters import AddressFilterInput, filter_address
 from ..channel.filters import get_currency_from_filter_data
-from ..core.descriptions import ADDED_IN_322
+from ..core.descriptions import ADDED_IN_322, DEPRECATED_PREORDER_INPUT
 from ..core.doc_category import DOC_CATEGORY_ORDERS
 from ..core.filters import (
     GlobalIDMultipleChoiceFilter,
@@ -402,7 +402,13 @@ class OrderFilter(DraftOrderFilter):
     is_click_and_collect = django_filters.BooleanFilter(
         method=filter_is_click_and_collect
     )
-    is_preorder = django_filters.BooleanFilter(method=filter_is_preorder)
+    is_preorder = django_filters.BooleanFilter(
+        method=filter_is_preorder,
+        help_text=(
+            "Filter by orders containing a variant that is currently in preorder."
+            f"{DEPRECATED_PREORDER_INPUT}"
+        ),
+    )
     ids = GlobalIDMultipleChoiceFilter(method=filter_order_by_id)
     checkout_tokens = ListObjectTypeFilter(
         input_class=UUIDScalar, method=filter_by_checkout_tokens

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -17,6 +17,7 @@ from ....warehouse.management import delete_stocks, stock_bulk_update
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.utils import get_webhooks_for_event
 from ...attribute.utils.attribute_assignment import AttributeAssignmentMixin
+from ...core.descriptions import DEPRECATED_PREORDER_INPUT
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.enums import ErrorPolicyEnum
 from ...core.mutations import BaseMutation, DeprecatedModelMutation
@@ -67,7 +68,9 @@ class ChannelListingUpdateInput(BaseInputObjectType):
     cost_price = PositiveDecimal(description="Cost price of the variant in channel.")
     prior_price = PositiveDecimal(description="Price of the variant before discount.")
     preorder_threshold = graphene.Int(
-        description="The threshold for preorder variant in channel."
+        description=(
+            f"The threshold for preorder variant in channel.{DEPRECATED_PREORDER_INPUT}"
+        )
     )
 
     class Meta:

--- a/saleor/graphql/product/filters/product.py
+++ b/saleor/graphql/product/filters/product.py
@@ -11,6 +11,7 @@ from ....product.models import (
     ProductVariantChannelListing,
 )
 from ...channel.filters import get_channel_slug_from_filter_data
+from ...core.descriptions import DEPRECATED_PREORDER_INPUT
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.filters import (
     BooleanWhereFilter,
@@ -144,7 +145,10 @@ class ProductFilter(MetadataFilterBase):
     )
     ids = GlobalIDMultipleChoiceFilter(method=filter_by_id("Product"))
     has_preordered_variants = django_filters.BooleanFilter(
-        method=filter_has_preordered_variants
+        method=filter_has_preordered_variants,
+        help_text=(
+            f"Filter by product with preordered variants.{DEPRECATED_PREORDER_INPUT}"
+        ),
     )
     slugs = ListObjectTypeFilter(input_class=graphene.String, method=filter_slug_list)
 
@@ -313,7 +317,9 @@ class ProductWhere(MetadataWhereFilterBase):
     )
     has_preordered_variants = BooleanWhereFilter(
         method=where_filter_has_preordered_variants,
-        help_text="Filter by product with preordered variants.",
+        help_text=(
+            f"Filter by product with preordered variants.{DEPRECATED_PREORDER_INPUT}"
+        ),
     )
     updated_at = ObjectTypeWhereFilter(
         input_class=DateTimeFilterInput,

--- a/saleor/graphql/product/filters/product_variant.py
+++ b/saleor/graphql/product/filters/product_variant.py
@@ -15,7 +15,7 @@ from ...attribute.shared_filters import (
     filter_objects_by_attributes,
     validate_attribute_value_input,
 )
-from ...core.descriptions import ADDED_IN_322
+from ...core.descriptions import ADDED_IN_322, DEPRECATED_PREORDER_INPUT
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.filters import (
     FilterInputObjectType,
@@ -87,7 +87,13 @@ def filter_variants_by_attributes(
 class ProductVariantFilter(MetadataFilterBase):
     search = django_filters.CharFilter(method="product_variant_filter_search")
     sku = ListObjectTypeFilter(input_class=graphene.String, method=filter_sku_list)
-    is_preorder = django_filters.BooleanFilter(method=filter_is_preorder)
+    is_preorder = django_filters.BooleanFilter(
+        method=filter_is_preorder,
+        help_text=(
+            "Filter by variants that are currently in preorder."
+            f"{DEPRECATED_PREORDER_INPUT}"
+        ),
+    )
     updated_at = ObjectTypeFilter(
         input_class=DateTimeRangeInput, method=filter_updated_at_range
     )

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -22,7 +22,11 @@ from ...channel.mutations import BaseChannelListingMutation
 from ...channel.types import Channel
 from ...core import ResolveInfo
 from ...core.context import ChannelContext
-from ...core.descriptions import ADDED_IN_321, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import (
+    ADDED_IN_321,
+    DEPRECATED_IN_3X_INPUT,
+    DEPRECATED_PREORDER_INPUT,
+)
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.mutations import BaseMutation
 from ...core.scalars import Date, DateTime, PositiveDecimal
@@ -394,7 +398,9 @@ class ProductVariantChannelListingAddInput(BaseInputObjectType):
         "directive." + ADDED_IN_321
     )
     preorder_threshold = graphene.Int(
-        description="The threshold for preorder variant in channel."
+        description=(
+            f"The threshold for preorder variant in channel.{DEPRECATED_PREORDER_INPUT}"
+        )
     )
 
     class Meta:

--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -15,6 +15,10 @@ from ....attribute.utils.attribute_assignment import (
 from ....attribute.utils.shared import AttrValuesInput
 from ....core import ResolveInfo
 from ....core.context import ChannelContext
+from ....core.descriptions import (
+    DEPRECATED_PREORDER_INPUT,
+    DEPRECATED_PREORDER_TYPE_DESCRIPTION,
+)
 from ....core.doc_category import DOC_CATEGORY_PRODUCTS
 from ....core.mutations import DeprecatedModelMutation
 from ....core.scalars import DateTime, WeightScalar
@@ -37,12 +41,20 @@ T_INPUT_MAP = list[tuple[attribute_models.Attribute, AttrValuesInput]]
 
 class PreorderSettingsInput(BaseInputObjectType):
     global_threshold = graphene.Int(
-        description="The global threshold for preorder variant."
+        description=(
+            f"The global threshold for preorder variant.{DEPRECATED_PREORDER_INPUT}"
+        )
     )
-    end_date = DateTime(description="The end date for preorder.")
+    end_date = DateTime(
+        description=f"The end date for preorder.{DEPRECATED_PREORDER_INPUT}"
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_PRODUCTS
+        description = (
+            "Preorder settings for a product variant."
+            + DEPRECATED_PREORDER_TYPE_DESCRIPTION
+        )
 
 
 class ProductVariantInput(BaseInputObjectType):
@@ -62,7 +74,9 @@ class ProductVariantInput(BaseInputObjectType):
     )
     weight = WeightScalar(description="Weight of the Product Variant.", required=False)
     preorder = PreorderSettingsInput(
-        description="Determines if variant is in preorder."
+        description=(
+            f"Determines if variant is in preorder.{DEPRECATED_PREORDER_INPUT}"
+        )
     )
     quantity_limit_per_customer = graphene.Int(
         required=False,

--- a/saleor/graphql/product/mutations/product_variant/product_variant_preorder_deactivate.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_preorder_deactivate.py
@@ -9,6 +9,7 @@ from .....product.error_codes import ProductErrorCode
 from .....warehouse.management import deactivate_preorder_for_variant
 from ....core import ResolveInfo
 from ....core.context import ChannelContext
+from ....core.descriptions import DEPRECATED_PREORDER_TYPE_DESCRIPTION
 from ....core.doc_category import DOC_CATEGORY_PRODUCTS
 from ....core.mutations import BaseMutation
 from ....core.types import ProductError
@@ -31,6 +32,7 @@ class ProductVariantPreorderDeactivate(BaseMutation):
         description = (
             "Deactivates product variant preorder. "
             "It changes all preorder allocation into regular allocation."
+            + DEPRECATED_PREORDER_TYPE_DESCRIPTION
         )
         doc_category = DOC_CATEGORY_PRODUCTS
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -17,6 +17,7 @@ from ..core.descriptions import (
     ADDED_IN_322,
     DEFAULT_DEPRECATION_REASON,
     DEPRECATED_IN_3X_INPUT,
+    DEPRECATED_PREORDER,
 )
 from ..core.doc_category import DOC_CATEGORY_PRODUCTS
 from ..core.enums import LanguageCodeEnum, ReportingPeriod
@@ -699,7 +700,9 @@ class ProductMutations(graphene.ObjectType):
     product_variant_reorder_attribute_values = (
         ProductVariantReorderAttributeValues.Field()
     )
-    product_variant_preorder_deactivate = ProductVariantPreorderDeactivate.Field()
+    product_variant_preorder_deactivate = ProductVariantPreorderDeactivate.Field(
+        deprecation_reason=DEPRECATED_PREORDER
+    )
 
     variant_media_assign = VariantMediaAssign.Field()
     variant_media_unassign = VariantMediaUnassign.Field()

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -21,7 +21,11 @@ from ....tax.utils import (
 from ...account import types as account_types
 from ...channel.dataloaders.by_self import ChannelByIdLoader
 from ...channel.types import Channel
-from ...core.descriptions import ADDED_IN_321
+from ...core.descriptions import (
+    ADDED_IN_321,
+    DEPRECATED_PREORDER,
+    DEPRECATED_PREORDER_TYPE_DESCRIPTION,
+)
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.fields import PermissionsField
 from ...core.scalars import Date, DateTime
@@ -294,15 +298,20 @@ class PreorderThreshold(BaseObjectType):
     quantity = graphene.Int(
         required=False,
         description="Preorder threshold for product variant in this channel.",
+        deprecation_reason=DEPRECATED_PREORDER,
     )
     sold_units = graphene.Int(
         required=True,
         description="Number of sold product variant in this channel.",
+        deprecation_reason=DEPRECATED_PREORDER,
     )
 
     class Meta:
         doc_category = DOC_CATEGORY_PRODUCTS
-        description = "Represents preorder variant data for channel."
+        description = (
+            "Represents preorder variant data for channel."
+            + DEPRECATED_PREORDER_TYPE_DESCRIPTION
+        )
 
 
 class ProductVariantChannelListing(
@@ -334,6 +343,7 @@ class ProductVariantChannelListing(
         PreorderThreshold,
         required=False,
         description="Preorder variant data.",
+        deprecation_reason=DEPRECATED_PREORDER,
     )
 
     class Meta:

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -69,6 +69,8 @@ from ...core.descriptions import (
     ADDED_IN_321,
     ADDED_IN_322,
     DEPRECATED_IN_3X_INPUT,
+    DEPRECATED_PREORDER,
+    DEPRECATED_PREORDER_TYPE_DESCRIPTION,
     RICH_CONTENT,
 )
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
@@ -288,18 +290,27 @@ class PreorderData(BaseObjectType):
         required=False,
         description="The global preorder threshold for product variant.",
         permissions=[ProductPermissions.MANAGE_PRODUCTS],
+        deprecation_reason=DEPRECATED_PREORDER,
     )
     global_sold_units = PermissionsField(
         graphene.Int,
         required=True,
         description="Total number of sold product variant during preorder.",
         permissions=[ProductPermissions.MANAGE_PRODUCTS],
+        deprecation_reason=DEPRECATED_PREORDER,
     )
-    end_date = DateTime(required=False, description="Preorder end date.")
+    end_date = DateTime(
+        required=False,
+        description="Preorder end date.",
+        deprecation_reason=DEPRECATED_PREORDER,
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_PRODUCTS
-        description = "Represents preorder settings for product variant."
+        description = (
+            "Represents preorder settings for product variant."
+            + DEPRECATED_PREORDER_TYPE_DESCRIPTION
+        )
 
     @staticmethod
     def resolve_global_threshold(root, _info):
@@ -461,6 +472,7 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
         PreorderData,
         required=False,
         description="Preorder data for product variant.",
+        deprecation_reason=DEPRECATED_PREORDER,
     )
     created = DateTime(
         required=True,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4534,7 +4534,9 @@ input ProductFilterInput @doc(category: "Products") {
   """Filter on whether product is a gift card or not."""
   giftCard: Boolean
   ids: [ID!]
-  hasPreorderedVariants: Boolean
+
+  """Filter by product with preordered variants."""
+  hasPreorderedVariants: Boolean @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
   slugs: [String!]
 
   """Specifies the channel by which the data should be filtered."""
@@ -4790,7 +4792,7 @@ input ProductWhereInput @doc(category: "Products") {
   giftCard: Boolean
 
   """Filter by product with preordered variants."""
-  hasPreorderedVariants: Boolean
+  hasPreorderedVariants: Boolean @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """Filter by when was the most recent update."""
   updatedAt: DateTimeFilterInput
@@ -7536,7 +7538,7 @@ type ProductVariant implements Node & ObjectWithMetadata & ObjectWithAttributes 
   ): Int
 
   """Preorder data for product variant."""
-  preorder: PreorderData
+  preorder: PreorderData @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """The date and time when the product variant was created."""
   created: DateTime!
@@ -7579,7 +7581,7 @@ type ProductVariantChannelListing implements Node @doc(category: "Products") {
   margin: Int
 
   """Preorder variant data."""
-  preorderThreshold: PreorderThreshold
+  preorderThreshold: PreorderThreshold @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 }
 
 """Represents channel."""
@@ -9498,13 +9500,17 @@ type TaxConfigurationPerCountry @doc(category: "Taxes") {
   useWeightedTaxForShipping: Boolean
 }
 
-"""Represents preorder variant data for channel."""
+"""
+Represents preorder variant data for channel.
+
+DEPRECATED: Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.
+"""
 type PreorderThreshold @doc(category: "Products") {
   """Preorder threshold for product variant in this channel."""
-  quantity: Int
+  quantity: Int @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """Number of sold product variant in this channel."""
-  soldUnits: Int!
+  soldUnits: Int! @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 }
 
 """Represents availability of a variant in the storefront."""
@@ -9942,24 +9948,28 @@ type ProductVariantTranslatableContent implements Node @doc(category: "Products"
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
-"""Represents preorder settings for product variant."""
+"""
+Represents preorder settings for product variant.
+
+DEPRECATED: Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.
+"""
 type PreorderData @doc(category: "Products") {
   """
   The global preorder threshold for product variant.
   
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
-  globalThreshold: Int
+  globalThreshold: Int @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """
   Total number of sold product variant during preorder.
   
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
-  globalSoldUnits: Int!
+  globalSoldUnits: Int! @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """Preorder end date."""
-  endDate: DateTime
+  endDate: DateTime @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 }
 
 """Represents availability of a product in the storefront."""
@@ -10105,7 +10115,9 @@ input ProductVariantFilterInput @doc(category: "Products") {
   search: String
   sku: [String!]
   metadata: [MetadataFilter!]
-  isPreorder: Boolean
+
+  """Filter by variants that are currently in preorder."""
+  isPreorder: Boolean @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
   updatedAt: DateTimeRangeInput
 }
 
@@ -16193,7 +16205,9 @@ input OrderFilterInput @doc(category: "Orders") {
   chargeStatus: [OrderChargeStatusEnum!]
   updatedAt: DateTimeRangeInput
   isClickAndCollect: Boolean
-  isPreorder: Boolean
+
+  """Filter by orders containing a variant that is currently in preorder."""
+  isPreorder: Boolean @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
   ids: [ID!]
   checkoutTokens: [UUID!]
   giftCardUsed: Boolean
@@ -19223,14 +19237,16 @@ type Mutation {
   ): ProductVariantReorderAttributeValues @doc(category: "Products")
 
   """
-  Deactivates product variant preorder. It changes all preorder allocation into regular allocation. 
+  Deactivates product variant preorder. It changes all preorder allocation into regular allocation.
+  
+  DEPRECATED: Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit. 
   
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantPreorderDeactivate(
     """ID of a variant which preorder should be deactivated."""
     id: ID!
-  ): ProductVariantPreorderDeactivate @doc(category: "Products")
+  ): ProductVariantPreorderDeactivate @doc(category: "Products") @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """
   Assign an media to a product variant. 
@@ -24581,7 +24597,7 @@ enum ProductErrorCode @doc(category: "Products") {
   CANNOT_MANAGE_PRODUCT_WITHOUT_VARIANT
   PRODUCT_NOT_ASSIGNED_TO_CHANNEL
   UNSUPPORTED_MEDIA_PROVIDER
-  PREORDER_VARIANT_CANNOT_BE_DEACTIVATED
+  PREORDER_VARIANT_CANNOT_BE_DEACTIVATED @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
   INVALID_FILE_TYPE
   UNSUPPORTED_MIME_TYPE
   FILE_SIZE_LIMIT_EXCEEDED
@@ -25393,7 +25409,7 @@ input ProductVariantBulkCreateInput @doc(category: "Products") {
   weight: WeightScalar
 
   """Determines if variant is in preorder."""
-  preorder: PreorderSettingsInput
+  preorder: PreorderSettingsInput @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
@@ -25482,12 +25498,17 @@ input BulkAttributeValueInput @doc(category: "Products") {
   dateTime: DateTime
 }
 
+"""
+Preorder settings for a product variant.
+
+DEPRECATED: Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.
+"""
 input PreorderSettingsInput @doc(category: "Products") {
   """The global threshold for preorder variant."""
-  globalThreshold: Int
+  globalThreshold: Int @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """The end date for preorder."""
-  endDate: DateTime
+  endDate: DateTime @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 }
 
 input StockInput @doc(category: "Products") {
@@ -25516,7 +25537,7 @@ input ProductVariantChannelListingAddInput @doc(category: "Products") {
   priorPrice: PositiveDecimal
 
   """The threshold for preorder variant in channel."""
-  preorderThreshold: Int
+  preorderThreshold: Int @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 }
 
 """
@@ -26001,7 +26022,7 @@ input ProductVariantCreateInput @doc(category: "Products") {
   weight: WeightScalar
 
   """Determines if variant is in preorder."""
-  preorder: PreorderSettingsInput
+  preorder: PreorderSettingsInput @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
@@ -26183,7 +26204,7 @@ input ProductVariantBulkUpdateInput @doc(category: "Products") {
   weight: WeightScalar
 
   """Determines if variant is in preorder."""
-  preorder: PreorderSettingsInput
+  preorder: PreorderSettingsInput @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
@@ -26261,7 +26282,7 @@ input ChannelListingUpdateInput @doc(category: "Products") {
   priorPrice: PositiveDecimal
 
   """The threshold for preorder variant in channel."""
-  preorderThreshold: Int
+  preorderThreshold: Int @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 }
 
 """
@@ -26421,7 +26442,7 @@ input ProductVariantInput @doc(category: "Products") {
   weight: WeightScalar
 
   """Determines if variant is in preorder."""
-  preorder: PreorderSettingsInput
+  preorder: PreorderSettingsInput @deprecated(reason: "Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit.")
 
   """
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
@@ -26557,7 +26578,9 @@ type ProductVariantReorderAttributeValues @doc(category: "Products") {
 }
 
 """
-Deactivates product variant preorder. It changes all preorder allocation into regular allocation. 
+Deactivates product variant preorder. It changes all preorder allocation into regular allocation.
+
+DEPRECATED: Preorder is deprecated and will be removed. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to false to sell without a stock limit. 
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """


### PR DESCRIPTION
Preorder API is legacy and not used according to our metrics. Time to deprecate it so we can remove it in next minor

[Dashboard leftovers removal](https://github.com/saleor/saleor-dashboard/pull/6837)