### PR TITLE
Release 3.23.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.23.26",
+  "version": "3.23.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.23.26",
+      "version": "3.23.27",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.23.26",
+  "version": "3.23.27",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.23.26"
+version = "3.23.27"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,7 +1,7 @@
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.23.26"
+__version__ = "3.23.27"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2528,7 +2528,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.23.26"
+version = "3.23.27"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION
* Complete deprecation of Export mutations (#19584) (b613f195b6)
* ci: attach schema.graphql to GitHub releases (#19585) (357e91ab97)
* Allow apps to reference their own webhooks by identifier (#19577) (fa63d7c23e)
* Fix a bug where resolver would incorrectly returned all attributes (#19654) (afee3aa05f)
* chore: bump uv to v0.12.1 (#19649) (9d4086b1a9)
* Fix pageAttributeAssign crash on nonexistent attribute IDs and fix productAttributeAssign's existence check (#19564) (#19610) (760947ff89)
