### PR TITLE
Release 3.22.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.65",
+  "version": "3.22.66",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.65",
+      "version": "3.22.66",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.65",
+  "version": "3.22.66",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.22.65"
+version = "3.22.66"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.65"
+__version__ = "3.22.66"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2565,7 +2565,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.22.65"
+version = "3.22.66"
 source = { virtual = "." }
 dependencies = [
     { name = "adyen" },


### PR DESCRIPTION
* Release 3.22.66 (bea5aba4c0)
* Fix a bug where resolver would incorrectly returned all attributes (#19654) (#19662) (5c6d0fd143)
* chore: bump uv to v0.12.1 (#19648) (29d1e55357)
* Fix pageAttributeAssign crash on nonexistent attribute IDs and fix productAttributeAssign's existence check (#19564) (#19611) (17085025e2)
