### PR TITLE
Deprecate remaining API surface of the storefront attributes presentation

### DIFF
--- a/saleor/graphql/attribute/descriptions.py
+++ b/saleor/graphql/attribute/descriptions.py
@@ -1,5 +1,10 @@
 from ..core.descriptions import RICH_CONTENT
 
+STOREFRONT_FLAG_DEPRECATION_REASON = (
+    "This flag is not used by Saleor. Keep the logic in the storefront or use "
+    "`Attribute` metadata instead."
+)
+
 
 class AttributeDescriptions:
     INPUT_TYPE = "The input type to use for entering attribute values in the dashboard."

--- a/saleor/graphql/attribute/descriptions.py
+++ b/saleor/graphql/attribute/descriptions.py
@@ -5,6 +5,11 @@ STOREFRONT_FLAG_DEPRECATION_REASON = (
     "`Attribute` metadata instead."
 )
 
+DASHBOARD_FLAG_DEPRECATION_REASON = (
+    "This flag is not used by Saleor. Keep the logic in the dashboard or use "
+    "`Attribute` metadata instead."
+)
+
 
 class AttributeDescriptions:
     INPUT_TYPE = "The input type to use for entering attribute values in the dashboard."

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -39,7 +39,11 @@ from ..core.types.common import NonNullList
 from ..core.utils import from_global_id_or_error
 from ..utils import get_user_or_app_from_context
 from ..utils.filters import filter_by_ids, filter_slug_list, filter_where_by_value_field
-from .descriptions import STOREFRONT_FLAG_DEPRECATION_REASON, AttributeDescriptions
+from .descriptions import (
+    DASHBOARD_FLAG_DEPRECATION_REASON,
+    STOREFRONT_FLAG_DEPRECATION_REASON,
+    AttributeDescriptions,
+)
 from .enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 
 
@@ -150,6 +154,12 @@ class AttributeFilter(MetadataFilterBase):
             f"{DEPRECATED_IN_3X_INPUT} {STOREFRONT_FLAG_DEPRECATION_REASON}"
         )
     )
+    filterable_in_dashboard = django_filters.BooleanFilter(
+        help_text=(
+            f"{AttributeDescriptions.FILTERABLE_IN_DASHBOARD}"
+            f"{DEPRECATED_IN_3X_INPUT} {DASHBOARD_FLAG_DEPRECATION_REASON}"
+        )
+    )
 
     class Meta:
         model = Attribute
@@ -157,7 +167,6 @@ class AttributeFilter(MetadataFilterBase):
             "value_required",
             "is_variant_only",
             "visible_in_storefront",
-            "filterable_in_dashboard",
         ]
 
     def filter_in_collection(self, qs, name, value):
@@ -300,7 +309,12 @@ class AttributeWhere(MetadataWhereFilterBase):
     in_category = GlobalIDWhereFilter(method="filter_in_category")
     value_required = BooleanWhereFilter()
     visible_in_storefront = BooleanWhereFilter()
-    filterable_in_dashboard = BooleanWhereFilter()
+    filterable_in_dashboard = BooleanWhereFilter(
+        help_text=(
+            f"{AttributeDescriptions.FILTERABLE_IN_DASHBOARD}"
+            f"{DEPRECATED_IN_3X_INPUT} {DASHBOARD_FLAG_DEPRECATION_REASON}"
+        )
+    )
 
     class Meta:
         model = Attribute

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -11,6 +11,7 @@ from ...permission.utils import has_one_of_permissions
 from ...product import models as product_models
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ..channel.filters import get_channel_slug_from_filter_data
+from ..core.descriptions import DEPRECATED_IN_3X_INPUT
 from ..core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ..core.enums import MeasurementUnitsEnum
 from ..core.filters import (
@@ -38,6 +39,7 @@ from ..core.types.common import NonNullList
 from ..core.utils import from_global_id_or_error
 from ..utils import get_user_or_app_from_context
 from ..utils.filters import filter_by_ids, filter_slug_list, filter_where_by_value_field
+from .descriptions import STOREFRONT_FLAG_DEPRECATION_REASON, AttributeDescriptions
 from .enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 
 
@@ -136,6 +138,18 @@ class AttributeFilter(MetadataFilterBase):
     in_collection = GlobalIDFilter(method="filter_in_collection")
     in_category = GlobalIDFilter(method="filter_in_category")
     slugs = ListObjectTypeFilter(input_class=graphene.String, method=filter_slug_list)
+    filterable_in_storefront = django_filters.BooleanFilter(
+        help_text=(
+            f"{AttributeDescriptions.FILTERABLE_IN_STOREFRONT}"
+            f"{DEPRECATED_IN_3X_INPUT} {STOREFRONT_FLAG_DEPRECATION_REASON}"
+        )
+    )
+    available_in_grid = django_filters.BooleanFilter(
+        help_text=(
+            f"{AttributeDescriptions.AVAILABLE_IN_GRID}"
+            f"{DEPRECATED_IN_3X_INPUT} {STOREFRONT_FLAG_DEPRECATION_REASON}"
+        )
+    )
 
     class Meta:
         model = Attribute
@@ -143,9 +157,7 @@ class AttributeFilter(MetadataFilterBase):
             "value_required",
             "is_variant_only",
             "visible_in_storefront",
-            "filterable_in_storefront",
             "filterable_in_dashboard",
-            "available_in_grid",
         ]
 
     def filter_in_collection(self, qs, name, value):

--- a/saleor/graphql/attribute/mutations/attribute_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_create.py
@@ -16,6 +16,7 @@ from ...core.types import AttributeError, BaseInputObjectType, NonNullList
 from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..descriptions import (
+    DASHBOARD_FLAG_DEPRECATION_REASON,
     STOREFRONT_FLAG_DEPRECATION_REASON,
     AttributeDescriptions,
     AttributeValueDescriptions,
@@ -86,6 +87,9 @@ class AttributeCreateInput(BaseInputObjectType):
     )
     filterable_in_dashboard = graphene.Boolean(
         description=AttributeDescriptions.FILTERABLE_IN_DASHBOARD
+        + DEPRECATED_IN_3X_INPUT
+        + " "
+        + DASHBOARD_FLAG_DEPRECATION_REASON
     )
     storefront_search_position = graphene.Int(
         required=False,

--- a/saleor/graphql/attribute/mutations/attribute_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_create.py
@@ -15,7 +15,11 @@ from ...core.mutations import DeprecatedModelMutation
 from ...core.types import AttributeError, BaseInputObjectType, NonNullList
 from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
-from ..descriptions import AttributeDescriptions, AttributeValueDescriptions
+from ..descriptions import (
+    STOREFRONT_FLAG_DEPRECATION_REASON,
+    AttributeDescriptions,
+    AttributeValueDescriptions,
+)
 from ..enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 from ..types import Attribute
 from .mixins import REFERENCE_TYPES_LIMIT, AttributeMixin
@@ -77,6 +81,8 @@ class AttributeCreateInput(BaseInputObjectType):
     filterable_in_storefront = graphene.Boolean(
         description=AttributeDescriptions.FILTERABLE_IN_STOREFRONT
         + DEPRECATED_IN_3X_INPUT
+        + " "
+        + STOREFRONT_FLAG_DEPRECATION_REASON
     )
     filterable_in_dashboard = graphene.Boolean(
         description=AttributeDescriptions.FILTERABLE_IN_DASHBOARD
@@ -84,11 +90,16 @@ class AttributeCreateInput(BaseInputObjectType):
     storefront_search_position = graphene.Int(
         required=False,
         description=AttributeDescriptions.STOREFRONT_SEARCH_POSITION
-        + DEPRECATED_IN_3X_INPUT,
+        + DEPRECATED_IN_3X_INPUT
+        + " "
+        + STOREFRONT_FLAG_DEPRECATION_REASON,
     )
     available_in_grid = graphene.Boolean(
         required=False,
-        description=AttributeDescriptions.AVAILABLE_IN_GRID + DEPRECATED_IN_3X_INPUT,
+        description=AttributeDescriptions.AVAILABLE_IN_GRID
+        + DEPRECATED_IN_3X_INPUT
+        + " "
+        + STOREFRONT_FLAG_DEPRECATION_REASON,
     )
     external_reference = graphene.String(
         description="External ID of this attribute.", required=False

--- a/saleor/graphql/attribute/mutations/attribute_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_update.py
@@ -17,7 +17,11 @@ from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import AttributeError, BaseInputObjectType, NonNullList
 from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
-from ..descriptions import AttributeDescriptions, AttributeValueDescriptions
+from ..descriptions import (
+    STOREFRONT_FLAG_DEPRECATION_REASON,
+    AttributeDescriptions,
+    AttributeValueDescriptions,
+)
 from ..types import Attribute
 from .attribute_create import AttributeValueInput
 from .mixins import REFERENCE_TYPES_LIMIT, AttributeMixin
@@ -62,6 +66,8 @@ class AttributeUpdateInput(BaseInputObjectType):
     filterable_in_storefront = graphene.Boolean(
         description=AttributeDescriptions.FILTERABLE_IN_STOREFRONT
         + DEPRECATED_IN_3X_INPUT
+        + " "
+        + STOREFRONT_FLAG_DEPRECATION_REASON
     )
     filterable_in_dashboard = graphene.Boolean(
         description=AttributeDescriptions.FILTERABLE_IN_DASHBOARD
@@ -69,11 +75,16 @@ class AttributeUpdateInput(BaseInputObjectType):
     storefront_search_position = graphene.Int(
         required=False,
         description=AttributeDescriptions.STOREFRONT_SEARCH_POSITION
-        + DEPRECATED_IN_3X_INPUT,
+        + DEPRECATED_IN_3X_INPUT
+        + " "
+        + STOREFRONT_FLAG_DEPRECATION_REASON,
     )
     available_in_grid = graphene.Boolean(
         required=False,
-        description=AttributeDescriptions.AVAILABLE_IN_GRID + DEPRECATED_IN_3X_INPUT,
+        description=AttributeDescriptions.AVAILABLE_IN_GRID
+        + DEPRECATED_IN_3X_INPUT
+        + " "
+        + STOREFRONT_FLAG_DEPRECATION_REASON,
     )
     external_reference = graphene.String(
         description="External ID of this product.", required=False

--- a/saleor/graphql/attribute/mutations/attribute_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_update.py
@@ -18,6 +18,7 @@ from ...core.types import AttributeError, BaseInputObjectType, NonNullList
 from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..descriptions import (
+    DASHBOARD_FLAG_DEPRECATION_REASON,
     STOREFRONT_FLAG_DEPRECATION_REASON,
     AttributeDescriptions,
     AttributeValueDescriptions,
@@ -71,6 +72,9 @@ class AttributeUpdateInput(BaseInputObjectType):
     )
     filterable_in_dashboard = graphene.Boolean(
         description=AttributeDescriptions.FILTERABLE_IN_DASHBOARD
+        + DEPRECATED_IN_3X_INPUT
+        + " "
+        + DASHBOARD_FLAG_DEPRECATION_REASON
     )
     storefront_search_position = graphene.Int(
         required=False,

--- a/saleor/graphql/attribute/sorters.py
+++ b/saleor/graphql/attribute/sorters.py
@@ -1,5 +1,6 @@
 from ..core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ..core.types import BaseEnum, SortInputObjectType
+from .descriptions import STOREFRONT_FLAG_DEPRECATION_REASON
 
 
 class AttributeSortField(BaseEnum):
@@ -48,6 +49,18 @@ class AttributeSortField(BaseEnum):
         if self.name in descriptions:
             return descriptions[self.name]
         raise ValueError(f"Unsupported enum value: {self.value}")
+
+    @property
+    def deprecation_reason(self):
+        # pylint: disable=no-member
+        deprecated = {
+            AttributeSortField.FILTERABLE_IN_STOREFRONT.name,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
+            AttributeSortField.STOREFRONT_SEARCH_POSITION.name,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
+            AttributeSortField.AVAILABLE_IN_GRID.name,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
+        }
+        if self.name in deprecated:
+            return STOREFRONT_FLAG_DEPRECATION_REASON
+        return None
 
 
 class AttributeSortingInput(SortInputObjectType):

--- a/saleor/graphql/attribute/sorters.py
+++ b/saleor/graphql/attribute/sorters.py
@@ -1,6 +1,9 @@
 from ..core.doc_category import DOC_CATEGORY_ATTRIBUTES
 from ..core.types import BaseEnum, SortInputObjectType
-from .descriptions import STOREFRONT_FLAG_DEPRECATION_REASON
+from .descriptions import (
+    DASHBOARD_FLAG_DEPRECATION_REASON,
+    STOREFRONT_FLAG_DEPRECATION_REASON,
+)
 
 
 class AttributeSortField(BaseEnum):
@@ -53,14 +56,13 @@ class AttributeSortField(BaseEnum):
     @property
     def deprecation_reason(self):
         # pylint: disable=no-member
-        deprecated = {
-            AttributeSortField.FILTERABLE_IN_STOREFRONT.name,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
-            AttributeSortField.STOREFRONT_SEARCH_POSITION.name,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
-            AttributeSortField.AVAILABLE_IN_GRID.name,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
+        deprecations = {
+            AttributeSortField.FILTERABLE_IN_STOREFRONT.name: STOREFRONT_FLAG_DEPRECATION_REASON,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
+            AttributeSortField.STOREFRONT_SEARCH_POSITION.name: STOREFRONT_FLAG_DEPRECATION_REASON,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
+            AttributeSortField.AVAILABLE_IN_GRID.name: STOREFRONT_FLAG_DEPRECATION_REASON,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
+            AttributeSortField.FILTERABLE_IN_DASHBOARD.name: DASHBOARD_FLAG_DEPRECATION_REASON,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
         }
-        if self.name in deprecated:
-            return STOREFRONT_FLAG_DEPRECATION_REASON
-        return None
+        return deprecations.get(self.name)
 
 
 class AttributeSortingInput(SortInputObjectType):

--- a/saleor/graphql/attribute/tests/queries/test_attribute_filter.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_filter.py
@@ -122,6 +122,23 @@ def test_filter_attributes_if_available_in_grid(
     assert attributes[0]["node"]["slug"] == "size"
 
 
+def test_filter_attributes_if_filterable_in_storefront(
+    api_client, color_attribute, size_attribute
+):
+    color_attribute.filterable_in_storefront = False
+    color_attribute.save(update_fields=["filterable_in_storefront"])
+    assert size_attribute.filterable_in_storefront is True
+
+    variables = {"filters": {"filterableInStorefront": True}}
+
+    attributes = get_graphql_content(
+        api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    assert len(attributes) == 1
+    assert attributes[0]["node"]["slug"] == size_attribute.slug
+
+
 def test_filter_attributes_by_global_id_list(api_client, product_type_attribute_list):
     global_ids = [
         graphene.Node.to_global_id("Attribute", attribute.pk)

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -27,7 +27,6 @@ from ..core.context import (
 )
 from ..core.descriptions import (
     ADDED_IN_322,
-    DEFAULT_DEPRECATION_REASON,
     DEPRECATED_IN_3X_INPUT,
     NESTED_QUERY_LIMIT_DESCRIPTION,
 )
@@ -73,7 +72,11 @@ from .dataloaders.reference_types import (
     AttributeReferencePageTypesByAttributeIdAndLimitLoader,
     AttributeReferenceProductTypesByAttributeIdAndLimitLoader,
 )
-from .descriptions import AttributeDescriptions, AttributeValueDescriptions
+from .descriptions import (
+    STOREFRONT_FLAG_DEPRECATION_REASON,
+    AttributeDescriptions,
+    AttributeValueDescriptions,
+)
 from .enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 from .filters import (
     AttributeValueFilterInput,
@@ -346,7 +349,7 @@ class Attribute(ChannelContextType[models.Attribute]):
             f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.name}."
         ),
         required=True,
-        deprecation_reason=DEFAULT_DEPRECATION_REASON,
+        deprecation_reason=STOREFRONT_FLAG_DEPRECATION_REASON,
     )
     filterable_in_dashboard = graphene.Boolean(
         description=(
@@ -367,7 +370,7 @@ class Attribute(ChannelContextType[models.Attribute]):
             f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.name}."
         ),
         required=True,
-        deprecation_reason=DEFAULT_DEPRECATION_REASON,
+        deprecation_reason=STOREFRONT_FLAG_DEPRECATION_REASON,
     )
     storefront_search_position = graphene.Int(
         description=(
@@ -378,7 +381,7 @@ class Attribute(ChannelContextType[models.Attribute]):
             f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.name}."
         ),
         required=True,
-        deprecation_reason=DEFAULT_DEPRECATION_REASON,
+        deprecation_reason=STOREFRONT_FLAG_DEPRECATION_REASON,
     )
     translation = TranslationField(
         AttributeTranslation,

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -73,6 +73,7 @@ from .dataloaders.reference_types import (
     AttributeReferenceProductTypesByAttributeIdAndLimitLoader,
 )
 from .descriptions import (
+    DASHBOARD_FLAG_DEPRECATION_REASON,
     STOREFRONT_FLAG_DEPRECATION_REASON,
     AttributeDescriptions,
     AttributeValueDescriptions,
@@ -360,6 +361,7 @@ class Attribute(ChannelContextType[models.Attribute]):
             f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.name}."
         ),
         required=True,
+        deprecation_reason=DASHBOARD_FLAG_DEPRECATION_REASON,
     )
     available_in_grid = graphene.Boolean(
         description=(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3716,7 +3716,7 @@ type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes")
   """
   Whether the attribute can be filtered in dashboard. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
-  filterableInDashboard: Boolean!
+  filterableInDashboard: Boolean! @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the dashboard or use `Attribute` metadata instead.")
 
   """
   Whether the attribute can be displayed in the admin product list. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
@@ -10425,7 +10425,6 @@ input AttributeFilterInput @doc(category: "Attributes") {
   valueRequired: Boolean
   isVariantOnly: Boolean
   visibleInStorefront: Boolean
-  filterableInDashboard: Boolean
   metadata: [MetadataFilter!]
   search: String
   ids: [ID!]
@@ -10439,6 +10438,9 @@ input AttributeFilterInput @doc(category: "Attributes") {
 
   """Whether the attribute can be displayed in the admin product list."""
   availableInGrid: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
+
+  """Whether the attribute can be filtered in dashboard."""
+  filterableInDashboard: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the dashboard or use `Attribute` metadata instead.")
 
   """Specifies the channel by which the data should be filtered."""
   channel: String @deprecated(reason: "Use root-level channel argument instead.")
@@ -10465,7 +10467,9 @@ input AttributeWhereInput @doc(category: "Attributes") {
   inCategory: ID
   valueRequired: Boolean
   visibleInStorefront: Boolean
-  filterableInDashboard: Boolean
+
+  """Whether the attribute can be filtered in dashboard."""
+  filterableInDashboard: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the dashboard or use `Attribute` metadata instead.")
 
   """List of conditions that must be met."""
   AND: [AttributeWhereInput!]
@@ -17327,7 +17331,7 @@ enum AttributeSortField @doc(category: "Attributes") {
   FILTERABLE_IN_STOREFRONT @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """Sort attributes by the filterable in dashboard flag"""
-  FILTERABLE_IN_DASHBOARD
+  FILTERABLE_IN_DASHBOARD @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the dashboard or use `Attribute` metadata instead.")
 
   """Sort attributes by their position in storefront"""
   STOREFRONT_SEARCH_POSITION @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
@@ -31949,7 +31953,7 @@ input AttributeCreateInput @doc(category: "Attributes") {
   filterableInStorefront: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """Whether the attribute can be filtered in dashboard."""
-  filterableInDashboard: Boolean
+  filterableInDashboard: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the dashboard or use `Attribute` metadata instead.")
 
   """
   The position of the attribute in the storefront navigation (0 by default).
@@ -32066,7 +32070,7 @@ input AttributeUpdateInput @doc(category: "Attributes") {
   filterableInStorefront: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """Whether the attribute can be filtered in dashboard."""
-  filterableInDashboard: Boolean
+  filterableInDashboard: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the dashboard or use `Attribute` metadata instead.")
 
   """
   The position of the attribute in the storefront navigation (0 by default).

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3711,7 +3711,7 @@ type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes")
   """
   Whether the attribute can be filtered in storefront. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
-  filterableInStorefront: Boolean! @deprecated
+  filterableInStorefront: Boolean! @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """
   Whether the attribute can be filtered in dashboard. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
@@ -3721,12 +3721,12 @@ type Attribute implements Node & ObjectWithMetadata @doc(category: "Attributes")
   """
   Whether the attribute can be displayed in the admin product list. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
-  availableInGrid: Boolean! @deprecated
+  availableInGrid: Boolean! @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """
   The position of the attribute in the storefront navigation (0 by default). Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
-  storefrontSearchPosition: Int! @deprecated
+  storefrontSearchPosition: Int! @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """Returns translated attribute fields for the given language code."""
   translation(
@@ -10425,9 +10425,7 @@ input AttributeFilterInput @doc(category: "Attributes") {
   valueRequired: Boolean
   isVariantOnly: Boolean
   visibleInStorefront: Boolean
-  filterableInStorefront: Boolean
   filterableInDashboard: Boolean
-  availableInGrid: Boolean
   metadata: [MetadataFilter!]
   search: String
   ids: [ID!]
@@ -10435,6 +10433,12 @@ input AttributeFilterInput @doc(category: "Attributes") {
   inCollection: ID
   inCategory: ID
   slugs: [String!]
+
+  """Whether the attribute can be filtered in storefront."""
+  filterableInStorefront: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
+
+  """Whether the attribute can be displayed in the admin product list."""
+  availableInGrid: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """Specifies the channel by which the data should be filtered."""
   channel: String @deprecated(reason: "Use root-level channel argument instead.")
@@ -17320,18 +17324,18 @@ enum AttributeSortField @doc(category: "Attributes") {
   VISIBLE_IN_STOREFRONT
 
   """Sort attributes by the filterable in storefront flag"""
-  FILTERABLE_IN_STOREFRONT
+  FILTERABLE_IN_STOREFRONT @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """Sort attributes by the filterable in dashboard flag"""
   FILTERABLE_IN_DASHBOARD
 
   """Sort attributes by their position in storefront"""
-  STOREFRONT_SEARCH_POSITION
+  STOREFRONT_SEARCH_POSITION @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """
   Sort attributes based on whether they can be displayed or not in a product grid.
   """
-  AVAILABLE_IN_GRID
+  AVAILABLE_IN_GRID @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 }
 
 """Represents ongoing installation of app."""
@@ -31942,7 +31946,7 @@ input AttributeCreateInput @doc(category: "Attributes") {
   visibleInStorefront: Boolean
 
   """Whether the attribute can be filtered in storefront."""
-  filterableInStorefront: Boolean @deprecated
+  filterableInStorefront: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """Whether the attribute can be filtered in dashboard."""
   filterableInDashboard: Boolean
@@ -31950,10 +31954,10 @@ input AttributeCreateInput @doc(category: "Attributes") {
   """
   The position of the attribute in the storefront navigation (0 by default).
   """
-  storefrontSearchPosition: Int @deprecated
+  storefrontSearchPosition: Int @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """Whether the attribute can be displayed in the admin product list."""
-  availableInGrid: Boolean @deprecated
+  availableInGrid: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """External ID of this attribute."""
   externalReference: String
@@ -32059,7 +32063,7 @@ input AttributeUpdateInput @doc(category: "Attributes") {
   visibleInStorefront: Boolean
 
   """Whether the attribute can be filtered in storefront."""
-  filterableInStorefront: Boolean @deprecated
+  filterableInStorefront: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """Whether the attribute can be filtered in dashboard."""
   filterableInDashboard: Boolean
@@ -32067,10 +32071,10 @@ input AttributeUpdateInput @doc(category: "Attributes") {
   """
   The position of the attribute in the storefront navigation (0 by default).
   """
-  storefrontSearchPosition: Int @deprecated
+  storefrontSearchPosition: Int @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """Whether the attribute can be displayed in the admin product list."""
-  availableInGrid: Boolean @deprecated
+  availableInGrid: Boolean @deprecated(reason: "This flag is not used by Saleor. Keep the logic in the storefront or use `Attribute` metadata instead.")
 
   """External ID of this product."""
   externalReference: String


### PR DESCRIPTION
Saleor doesn't tell Storefront what to show, this field is deprecated for a long time. PR deprecates connected fields. In 3.24 we will remove them

Attributes contain metadata which can be use to pass extra meta to each attribute (or storefront can control it entirely)