### PR TITLE
Allow manifest URLs up to 2048 characters

### DIFF
--- a/saleor/app/migrations/0041_widen_manifest_url.py
+++ b/saleor/app/migrations/0041_widen_manifest_url.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Widen ``manifest_url`` from varchar(200) to varchar(2048).
+
+    Increasing a varchar length limit is a catalog-only change in PostgreSQL
+    (>= 9.2) — no table rewrite, the ACCESS EXCLUSIVE lock is held momentarily.
+    """
+
+    dependencies = [
+        ("app", "0040_appextension_identifier_unique_constraint"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="app",
+            name="manifest_url",
+            field=models.URLField(blank=True, max_length=2048, null=True),
+        ),
+        migrations.AlterField(
+            model_name="appinstallation",
+            name="manifest_url",
+            field=models.URLField(max_length=2048),
+        ),
+    ]

--- a/saleor/app/models.py
+++ b/saleor/app/models.py
@@ -17,6 +17,9 @@ from .types import (
     DeprecatedAppExtensionHttpMethod,
 )
 
+URL_MAX_LENGTH = 2048
+"""Matches Django's ``URLValidator.max_length`` and the de facto browser cap."""
+
 
 class AppQueryset(models.QuerySet["App"]):
     def for_event_type(self, event_type: str):
@@ -69,7 +72,7 @@ class App(ModelWithMetadata):
     support_url = models.URLField(blank=True, null=True)
     configuration_url = models.URLField(blank=True, null=True)
     app_url = models.URLField(blank=True, null=True)
-    manifest_url = models.URLField(blank=True, null=True)
+    manifest_url = models.URLField(max_length=URL_MAX_LENGTH, blank=True, null=True)
     version = models.CharField(max_length=60, blank=True, null=True)
     audience = models.CharField(blank=True, null=True, max_length=256)
     is_installed = models.BooleanField(default=True)
@@ -229,7 +232,7 @@ class AppProblem(models.Model):
 class AppInstallation(Job):
     uuid = models.UUIDField(unique=True, default=uuid4)
     app_name = models.CharField(max_length=60)
-    manifest_url = models.URLField()
+    manifest_url = models.URLField(max_length=URL_MAX_LENGTH)
     permissions = models.ManyToManyField(
         Permission,
         blank=True,

--- a/saleor/graphql/app/tests/mutations/test_app_install.py
+++ b/saleor/graphql/app/tests/mutations/test_app_install.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock, patch
 
 import graphene
 
-from .....app.models import App, AppInstallation
+from .....app.models import URL_MAX_LENGTH, App, AppInstallation
 from .....app.tasks import install_app_task
 from .....core import JobStatus
 from ....core.enums import AppErrorCode, PermissionEnum
@@ -216,6 +216,36 @@ def test_install_app_mutation_with_invalid_manifest_url_returns_error(
     error = errors[0]
     assert error["field"] == "manifestUrl"
     assert error["code"] == AppErrorCode.INVALID_URL_FORMAT.name
+
+
+def test_install_app_mutation_with_long_manifest_url(
+    permission_manage_apps,
+    staff_api_client,
+    staff_user,
+    monkeypatch,
+):
+    # given
+    monkeypatch.setattr(
+        "saleor.graphql.app.mutations.app_install.install_app_task.delay", Mock()
+    )
+    staff_user.user_permissions.set([permission_manage_apps])
+    prefix = "http://localhost:3000/manifest?token="
+    manifest_url = prefix + "a" * (URL_MAX_LENGTH - len(prefix))
+    assert len(manifest_url) == URL_MAX_LENGTH
+    variables = {
+        "app_name": "New external integration",
+        "manifest_url": manifest_url,
+        "permissions": [],
+    }
+
+    # when
+    data = _mutate_app_install(staff_api_client, variables)
+
+    # then
+    assert data["errors"] == []
+    app_installation = AppInstallation.objects.get()
+    assert app_installation.manifest_url == manifest_url
+    assert data["appInstallation"]["manifestUrl"] == manifest_url
 
 
 def test_install_app_mutation_with_null_permissions(


### PR DESCRIPTION
Previous limit was unreasonable - restore standard GET limit. This allows app to provide configurable manifest with parameters

port https://github.com/saleor/saleor/pull/19681