### PR TITLE
Release 3.23.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.23.27",
+  "version": "3.23.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.23.27",
+      "version": "3.23.28",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.23.27",
+  "version": "3.23.28",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.23.27"
+version = "3.23.28"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,7 +1,7 @@
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.23.27"
+__version__ = "3.23.28"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2528,7 +2528,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.23.27"
+version = "3.23.28"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION
* Release 3.23.28 (3446703f46)
* Serialize MPTT tree writes with a Postgres advisory lock (#19668) (#19684) (cb1bc510ba)
* Add missing code for handling CustomerType metadata (#19682) (7ab1f444a9)
* Allow manifest URLs up to 2048 characters (#19680) (b39686ce3b)
* Rename gift card validation param to source_object_user_id (#19677) (9f4a7930ee)
* Enforce gift card customer assignment in the transaction flow (#19667) (880df7ed6c)
* Deprecate remaining API surface of the storefront presentation attrib… (#19672) (9b1093c9c0)
* Deprecate the preorder GraphQL API (#19664) (e251075955)
