### PR TITLE
Make the tests not depend on the constant but rather the function

### DIFF
--- a/saleor/core/db/locks.py
+++ b/saleor/core/db/locks.py
@@ -5,7 +5,7 @@ from django.db import transaction
 from django.utils.module_loading import import_string
 
 # Arbitrary 32-bit integer identifying Saleor's advisory locks globally within a database.
-ADVISORY_LOCK_NAMESPACE = 21_218
+_ADVISORY_LOCK_NAMESPACE = 21_218
 
 
 class AdvisoryLock(IntEnum):
@@ -18,7 +18,7 @@ class AdvisoryLock(IntEnum):
 def get_advisory_lock_namespace() -> int:
     if settings.ADVISORY_LOCK_NAMESPACE_IMPORT is not None:
         return import_string(settings.ADVISORY_LOCK_NAMESPACE_IMPORT)()
-    return ADVISORY_LOCK_NAMESPACE
+    return _ADVISORY_LOCK_NAMESPACE
 
 
 def acquire_advisory_xact_lock(lock: AdvisoryLock) -> None:

--- a/saleor/core/db/tests/test_locks.py
+++ b/saleor/core/db/tests/test_locks.py
@@ -2,7 +2,11 @@ import pytest
 from django.db import connection, transaction
 from django.test.utils import CaptureQueriesContext
 
-from ..locks import ADVISORY_LOCK_NAMESPACE, AdvisoryLock, acquire_advisory_xact_lock
+from ..locks import (
+    AdvisoryLock,
+    acquire_advisory_xact_lock,
+    get_advisory_lock_namespace,
+)
 
 
 @pytest.mark.parametrize("lock", list(AdvisoryLock))
@@ -20,7 +24,7 @@ def test_emits_lock_query_with_namespace_and_key(lock, db):
         if "pg_advisory_xact_lock" in query["sql"]
     ]
     assert len(lock_queries) == 1
-    assert f"{ADVISORY_LOCK_NAMESPACE}, {lock.value}" in lock_queries[0]
+    assert f"{get_advisory_lock_namespace()}, {lock.value}" in lock_queries[0]
 
 
 @pytest.mark.django_db(transaction=True)
@@ -39,7 +43,7 @@ def get_custom_namespace() -> int:
 
 def test_namespace_import_setting_overrides_default(db, settings):
     # given
-    assert CUSTOM_NAMESPACE != ADVISORY_LOCK_NAMESPACE
+    assert get_custom_namespace() != get_advisory_lock_namespace()
     settings.ADVISORY_LOCK_NAMESPACE_IMPORT = (
         "saleor.core.db.tests.test_locks.get_custom_namespace"
     )


### PR DESCRIPTION
This way the tests will keep passing on environments where ADVISORY_LOCK_NAMESPACE_IMPORT is already set.