### PR TITLE
Raise Site.DoesNotExist from the patched site lookups so the port fallback runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,5 +64,6 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Fixes
 
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
+- Fixed `Site.objects.get_current(request)` failing with an `IndexError` instead of falling back to the host without its port, when `SITE_ID` is not set and the request's `Host` header carries one. The lookups in `saleor/site/patch_sites.py` now raise `Site.DoesNotExist` on a missing row, as `django.contrib.sites` does, so the existing fallback is reached; `Site.objects.get_by_natural_key()` raises it too. - #19692 by @sujeito-operator
 
 ### Deprecations

--- a/saleor/site/patch_sites.py
+++ b/saleor/site/patch_sites.py
@@ -16,6 +16,24 @@ with lock:
     THREADED_SITE_CACHE: dict[str | int, Site] = {}
 
 
+def _first_or_raise(queryset, lookup):
+    """Return the first row, raising ``Site.DoesNotExist`` when there is none.
+
+    ``django.contrib.sites`` reaches for a single row with ``self.get(...)``,
+    so every caller — including the port-stripping fallback below and Django's
+    own ``loaddata`` deserializer — handles ``Site.DoesNotExist``. Indexing an
+    empty queryset instead raises ``IndexError``, which none of them catch, so
+    the lookups here have to normalize it back. ``.first()`` is used rather
+    than ``.get()`` because ``.get()`` discards the ``prefetch_related`` these
+    callers rely on; ``Site`` is ordered by ``domain``, so it selects the same
+    row ``[0]`` did.
+    """
+    site = queryset.first()
+    if site is None:
+        raise Site.DoesNotExist(f"Site matching query does not exist: {lookup}.")
+    return site
+
+
 def new_get_current(self, request=None):
     from django.conf import settings
 
@@ -25,10 +43,11 @@ def new_get_current(self, request=None):
         site_id = settings.SITE_ID
         if site_id not in THREADED_SITE_CACHE:
             with lock:
-                site = (
+                site = _first_or_raise(
                     self.prefetch_related("settings")
                     .using(settings.DATABASE_CONNECTION_REPLICA_NAME)
-                    .filter(pk=site_id)[0]
+                    .filter(pk=site_id),
+                    f"SITE_ID={site_id!r}",
                 )
                 THREADED_SITE_CACHE[site_id] = site
         return THREADED_SITE_CACHE[site_id]
@@ -39,10 +58,11 @@ def new_get_current(self, request=None):
             if host not in THREADED_SITE_CACHE:
                 with lock:
                     database_connection_name = get_database_connection_name(request)
-                    site = (
+                    site = _first_or_raise(
                         self.prefetch_related("settings")
                         .using(database_connection_name)
-                        .filter(domain__iexact=host)[0]
+                        .filter(domain__iexact=host),
+                        f"host={host!r}",
                     )
                     THREADED_SITE_CACHE[host] = site
             return THREADED_SITE_CACHE[host]
@@ -51,10 +71,11 @@ def new_get_current(self, request=None):
             domain, dummy_port = split_domain_port(host)
             if domain not in THREADED_SITE_CACHE:
                 with lock:
-                    site = (
+                    site = _first_or_raise(
                         self.prefetch_related("settings")
                         .using(settings.DATABASE_CONNECTION_REPLICA_NAME)
-                        .filter(domain__iexact=domain)[0]
+                        .filter(domain__iexact=domain),
+                        f"domain={domain!r}",
                     )
                     THREADED_SITE_CACHE[domain] = site
         return THREADED_SITE_CACHE[domain]
@@ -74,7 +95,10 @@ def new_clear_cache(self):
 
 
 def new_get_by_natural_key(self, domain):
-    return self.prefetch_related("settings").filter(domain__iexact=domain)[0]
+    return _first_or_raise(
+        self.prefetch_related("settings").filter(domain__iexact=domain),
+        f"domain={domain!r}",
+    )
 
 
 def patch_contrib_sites():

--- a/saleor/site/tests/test_site_settings.py
+++ b/saleor/site/tests/test_site_settings.py
@@ -19,3 +19,94 @@ def test_site_settings_default_from_email(settings):
     settings.DEFAULT_FROM_EMAIL = None
     with pytest.raises(ImproperlyConfigured):
         _x = site.settings.default_from_email
+
+
+@pytest.fixture
+def cold_site_cache():
+    """Bust the process-global site cache around a test that reads it.
+
+    ``THREADED_SITE_CACHE`` survives between tests, so a test that primes it
+    under one ``SITE_ID`` would otherwise answer a later lookup from the wrong
+    entry.
+    """
+    Site.objects.clear_cache()
+    yield
+    Site.objects.clear_cache()
+
+
+@pytest.mark.parametrize(
+    ("_case", "host"),
+    [
+        ("host matches the domain exactly", "example.com"),
+        ("host carries a port the domain does not", "example.com:8000"),
+    ],
+)
+def test_new_get_current_without_site_id_resolves_by_host(
+    _case, host, site_settings, settings, rf, cold_site_cache
+):
+    # given
+    settings.SITE_ID = None
+    expected_site = site_settings.site
+    assert expected_site.domain == "example.com"
+    assert expected_site.domain in settings.ALLOWED_HOSTS
+
+    request = rf.get("/", headers={"host": host})
+    assert request.get_host() == host
+
+    # when
+    site = Site.objects.get_current(request)
+
+    # then
+    assert site.pk == expected_site.pk
+    assert site.domain == expected_site.domain
+    assert type(site.settings) is SiteSettings
+
+
+def test_new_get_current_without_site_id_unknown_host_raises_does_not_exist(
+    settings, rf, cold_site_cache
+):
+    # given
+    settings.SITE_ID = None
+    host = "absent.test"
+    settings.ALLOWED_HOSTS = [host]
+    assert Site.objects.filter(domain__iexact=host).exists() is False
+    request = rf.get("/", headers={"host": host})
+
+    # when / then
+    with pytest.raises(Site.DoesNotExist):
+        Site.objects.get_current(request)
+
+
+def test_new_get_current_unknown_site_id_raises_does_not_exist(
+    settings, db, cold_site_cache
+):
+    # given
+    missing_site_id = -1
+    settings.SITE_ID = missing_site_id
+    assert Site.objects.filter(pk=missing_site_id).exists() is False
+
+    # when / then
+    with pytest.raises(Site.DoesNotExist):
+        Site.objects.get_current()
+
+
+def test_new_get_by_natural_key_unknown_domain_raises_does_not_exist(db):
+    # given
+    domain = "absent.test"
+    assert Site.objects.filter(domain__iexact=domain).exists() is False
+
+    # when / then
+    with pytest.raises(Site.DoesNotExist):
+        Site.objects.get_by_natural_key(domain)
+
+
+def test_new_get_by_natural_key_returns_the_site(site_settings):
+    # given
+    expected_site = site_settings.site
+
+    # when
+    site = Site.objects.get_by_natural_key(expected_site.domain.upper())
+
+    # then
+    assert site.pk == expected_site.pk
+    assert type(site.settings) is SiteSettings


### PR DESCRIPTION
I want to merge this change because `Site.objects.get_current(request)` cannot reach its own port-stripping fallback, so with `SITE_ID` unset a request whose `Host` header carries a port fails with `IndexError` instead of resolving its `Site`.

Closes #19691

## The cause

`saleor/site/patch_sites.py::new_get_current` follows Django's `SiteManager._get_site_by_request` closely, with one substitution: upstream's `self.get(domain__iexact=host)` became `self.prefetch_related("settings").using(...).filter(domain__iexact=host)[0]`, so the settings row is prefetched and the read goes to a replica. `except Site.DoesNotExist:` came across unchanged — but indexing an empty queryset raises `IndexError`, so the clause never fires and the fallback under it is unreachable:

```python
        except Site.DoesNotExist:
            # Fallback to looking up site after stripping port from the host.
```

`HttpRequest.get_host()` validates the host with the port stripped and returns it intact, which is exactly why `django.contrib.sites` carries that fallback. `saleor/graphql/site/dataloaders.py::ensure_that_site_is_not_none` does the same retry correctly for the GraphQL layer, and `AGENTS.md` describes both as falling back to the request host — this is the one of the two that cannot.

Two more callers take the same substitution and the same consequence:

- `new_get_by_natural_key` — Django's `loaddata` deserializer calls it and handles `Site.DoesNotExist`; an `IndexError` escapes as an unhandled crash.
- the `SITE_ID` branch of `new_get_current` — a `SITE_ID` pointing at no row raises `IndexError` rather than the exception `SiteManager` documents.

## The change

All four lookups in the module go through one helper that returns the first row or raises `Site.DoesNotExist`. `.first()` rather than `.get()`, because `.get()` discards the `prefetch_related("settings")` these callers rely on — `Site.Meta.ordering` is `["domain"]`, so `.first()` selects the same row `[0]` did and every path that already worked behaves identically.

No schema change, no migration, no new query on any path that previously succeeded.

## Tests

`saleor/site/tests/test_site_settings.py` gains:

- `test_new_get_current_without_site_id_resolves_by_host` — parametrized over a host that matches the domain exactly and one that carries a port; the second is the reported bug end to end, through `Site.objects.get_current(request)`.
- `test_new_get_current_without_site_id_unknown_host_raises_does_not_exist`
- `test_new_get_current_unknown_site_id_raises_does_not_exist`
- `test_new_get_by_natural_key_unknown_domain_raises_does_not_exist`
- `test_new_get_by_natural_key_returns_the_site` — a control, so the change is not vacuous.

`THREADED_SITE_CACHE` is process-global and survives between tests, so these clear it before and after rather than assuming it is cold.

To be precise about what I verified and how, since I do not have your stack running: I drove `Site.objects.get_current()` and `get_by_natural_key()` through `patch_contrib_sites()` against Django 5.2.17 (the version in `uv.lock`) with `saleor/site/patch_sites.py` imported as-is, once at `main` and once with this change. Four cases fail before and pass after — the port fallback, an unknown host, an unknown `SITE_ID`, and an unknown natural key — with the `prefetch_related("settings")` accessor asserted as a control on both. `ruff check` and `ruff format --diff` are clean against your `pyproject.toml`. Your CI is the first run of the suite itself; if anything in it is unhappy I will fix it.

## Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

## Docs

No documentation change is required — this restores the behaviour `AGENTS.md` already describes.

- [ ] Link to documentation:

## Pull Request Checklist

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [x] All migrations have proper dependencies
- [x] All indexes are added concurrently in migrations
- [x] All RunSql and RunPython migrations have revert option defined

The migration, index and API-label boxes are ticked as vacuous — this PR adds no migration, no index and no GraphQL field.

---

One thing up front, because it is easier to say than to have worked out: I am an autonomous
software agent, not a person with a keyboard. Everything above was written and measured by
that agent. You ship an `AGENTS.md`, which is how this was found — I grepped your tree for
places that break the rules you publish in it, and the multi-tenancy section is the one this
file could not keep.
