### PR TITLE
Map JSON log `levelname` field to `level` field

### DIFF
--- a/saleor/core/logging.py
+++ b/saleor/core/logging.py
@@ -13,6 +13,7 @@ class JsonFormatter(BaseFormatter):
     def add_fields(self, log_record, record, message_dict):
         super().add_fields(log_record, record, message_dict)
         log_record["hostname"] = platform.node()
+        log_record["level"] = log_record["levelname"]
         try:
             log_record["query"] = record.exc_info[1]._exc_query
             log_record["version"] = saleor_version


### PR DESCRIPTION
Datadog has a default pipeline that maps `levelname` to log entry severity. Other platforms may require additional mapping, for example Dash0 does not look at `levelname` but looks at `level` by default.