### PR TITLE
Release 3.23.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.23.28",
+  "version": "3.23.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.23.28",
+      "version": "3.23.29",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.23.28",
+  "version": "3.23.29",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.23.28"
+version = "3.23.29"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,7 +1,7 @@
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.23.28"
+__version__ = "3.23.29"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2528,7 +2528,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.23.28"
+version = "3.23.29"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION
* Release 3.23.29 (98b520b639)
* Map JSON log `levelname` field to `level` field (#19700) (4ae8616c68)
* Fix the migration that created a Category with incorrect MPTT values (#19696) (989d8e3895)
* Make the tests not depend on the constant but rather the function (#19690) (7c46cee71b)
