### PR TITLE
Release 3.22.68

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.22.67",
+  "version": "3.22.68",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.22.67",
+      "version": "3.22.68",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.22.67",
+  "version": "3.22.68",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.22.67"
+version = "3.22.68"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.22.67"
+__version__ = "3.22.68"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2565,7 +2565,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.22.67"
+version = "3.22.68"
 source = { virtual = "." }
 dependencies = [
     { name = "adyen" },


### PR DESCRIPTION
* Release 3.22.68 (b61ef726af)
* Map JSON log `levelname` field to `level` field (#19701) (d870e56e20)
* Fix the migration that created a Category with incorrect MPTT values (#19697) (028fb42519)
* Make the tests not depend on the constant but rather the function (#19689) (a984bc48d1)
