### PR TITLE
Fix orderBulkCreate SKU-based variant resolution (#17452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,5 +65,6 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Fixes
 
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
+- Fixed `orderBulkCreate` failing to resolve an order line by `variant_sku` due to a lookup-key mismatch - #19704 by @wakqasahmed
 
 ### Deprecations

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -820,7 +820,7 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
         for variant in variants:
             object_storage[f"ProductVariant.id.{variant.id}"] = variant
             if variant.sku:
-                object_storage[f"ProductVariant.id.{variant.sku}"] = variant
+                object_storage[f"ProductVariant.sku.{variant.sku}"] = variant
             if variant.external_reference:
                 object_storage[
                     f"ProductVariant.external_reference.{variant.external_reference}"

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -2769,6 +2769,46 @@ def test_order_bulk_create_error_non_existing_instance(
     assert Order.objects.count() == orders_count
 
 
+def test_order_bulk_create_resolve_variant_by_sku(
+    staff_api_client,
+    permission_manage_orders,
+    permission_manage_orders_import,
+    order_bulk_input,
+    variant,
+):
+    # given
+    orders_count = Order.objects.count()
+
+    order = order_bulk_input
+    order["lines"][0]["variantId"] = None
+    order["lines"][0]["variantSku"] = variant.sku
+
+    staff_api_client.user.user_permissions.add(
+        permission_manage_orders_import,
+        permission_manage_orders,
+    )
+    variables = {
+        "orders": [order],
+        "stockUpdatePolicy": StockUpdatePolicyEnum.SKIP.name,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_BULK_CREATE, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["orderBulkCreate"]["count"] == 1
+    result = content["data"]["orderBulkCreate"]["results"][0]
+    assert len(result["errors"]) == 0
+
+    line = result["order"]["lines"][0]
+    assert line["variant"]["id"] == graphene.Node.to_global_id(
+        "ProductVariant", variant.id
+    )
+
+    assert Order.objects.count() == orders_count + 1
+
+
 def test_order_bulk_create_error_instance_not_found(
     staff_api_client,
     permission_manage_orders,


### PR DESCRIPTION
I want to merge this change because `orderBulkCreate` can never resolve a line by `variant_sku`, even when the SKU exists — fixes #17452.

The lookup cache in `order_bulk_create.py` stores each variant under the key `f"ProductVariant.id.{variant.sku}"`, but the resolver in `bulk_mutations/utils.py` looks it up as `f"ProductVariant.sku.{sku}"`. The prefixes never match, so any line that identifies its variant by SKU fails with `ProductVariant instance with sku=X doesn't exist`, regardless of whether the SKU is valid. Changed the cache key's field segment from `id` to `sku` so it matches the lookup.

Added a test that creates an order line by `variantSku` only (no `variantId`) and asserts it resolves to the correct variant — this fails on current `main` and passes with the fix.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

- [x] Link to documentation: not required, this is a bugfix with no API/behavior contract change

# Pull Request Checklist

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [x] All migrations have proper dependencies
- [x] All indexes are added concurrently in migrations
- [x] All RunSql and RunPython migrations have revert option defined
