### PR TITLE
feat(images): add size limits

### DIFF
--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -155,17 +155,30 @@ def prepare_unique_attribute_value_slug(attribute: "Attribute", slug: str):
     return prepare_unique_slug(slug, value_slugs)
 
 
-def create_file_from_response(response: Response, filename: str) -> File:
+def create_file_from_response(
+    response: Response, filename: str, max_file_size: int
+) -> File:
     """Create a Django File object from an HTTP response.
 
     HTTP response should contain the file content. Response should use streaming.
     https://requests.readthedocs.io/en/latest/user/advanced/#body-content-workflow
     """
-    # Create a BytesIO object to store the file content
+    content_length = response.headers.get("content-length")
+
+    try:
+        declared_file_size = int(content_length) if content_length is not None else None
+    except ValueError as exc:
+        raise ValueError("Received an invalid content-length header") from exc
+
+    if declared_file_size is not None and declared_file_size > max_file_size:
+        raise ValueError(f"File too big. Maximal file size is {max_file_size}.")
+
     file_data = BytesIO()
-    # Write the response content to the BytesIO object
-    file_data.write(response.content)
-    # Move the cursor to the beginning of the BytesIO object
+    for chunk in response.iter_content(chunk_size=File.DEFAULT_CHUNK_SIZE):
+        if not chunk:
+            continue
+        if file_data.tell() + len(chunk) > max_file_size:
+            raise ValueError(f"File too big. Maximal file size is {max_file_size}.")
+        file_data.write(chunk)
     file_data.seek(0)
-    # Create a Django File object from the BytesIO object
     return File(file_data, filename)

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -449,7 +449,23 @@ def fetch_product_media_image_task(product_media_id: int):
         validate_status_code(response.status_code)
         mime_type = get_mime_type(response.headers.get("content-type"))
         validate_content_type_header(product_media, mime_type)
-        image = create_image(product_media, mime_type, response)
+        try:
+            image = create_image(product_media, mime_type, response)
+        except ValueError as error:
+            logger.warning(
+                "Image fetched for product media %s was rejected: %s",
+                product_media.pk,
+                error,
+                extra={
+                    "image_source": sanitize_url_for_logging(
+                        product_media.external_url
+                    ),
+                    "object_type": "ProductMedia",
+                    "object_pk": product_media.pk,
+                    "file_error": str(error),
+                },
+            )
+            raise
 
     validate_image_mime_type(image)
     try:

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -456,15 +456,10 @@ def fetch_product_media_image_task(product_media_id: int):
                 "Image fetched for product media %s was rejected: %s",
                 product_media.pk,
                 error,
-                extra={
-                    "image_source": sanitize_url_for_logging(
-                        product_media.external_url
-                    ),
-                    "object_type": "ProductMedia",
-                    "object_pk": product_media.pk,
-                    "file_error": str(error),
-                },
             )
+            # NOTE: we do not wish to retry on this error hence why this exception
+            #       isn't listed in `app.task(autoretry_for=...)` as this is a
+            #       permanent error which will never be fixed upon retrying.
             raise
 
     validate_image_mime_type(image)

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -11,7 +11,6 @@ from faker import Faker
 from PIL import Image
 from requests.exceptions import HTTPError, InvalidSchema, RequestException
 
-from ...core.utils.url import sanitize_url_for_logging
 from ...discount import PromotionType, RewardValueType
 from ...discount.models import Promotion, PromotionRule
 from ...thumbnail.exceptions import ImageTooLargeError
@@ -32,6 +31,15 @@ from ..tasks import (
     update_variants_names,
 )
 from ..utils.variants import fetch_variants_for_promotion_rules
+
+
+def _create_1px_image() -> bytes:
+    image_buffer = BytesIO()
+    Image.new("RGB", (1, 1)).save(image_buffer, format="JPEG")
+    return image_buffer.getvalue()
+
+
+IMAGE_1PX = _create_1px_image()
 
 
 @contextmanager
@@ -73,12 +81,6 @@ def assert_product_media_fetch_rejected(caplog, product_media, expected_error):
         f"Image fetched for product media {product_media.pk} was rejected: "
         f"{expected_error}"
     )
-    assert rejection_record.image_source == sanitize_url_for_logging(
-        product_media.external_url
-    )
-    assert rejection_record.object_type == "ProductMedia"
-    assert rejection_record.object_pk == product_media.pk
-    assert rejection_record.file_error == expected_error
 
     # Clean-up log
     assert failure_record.levelno == logging.WARNING
@@ -485,13 +487,9 @@ def test_fetch_product_media_image_success(
     assert product_media.external_url
     assert not product_media.image
 
-    image_buffer = BytesIO()
-    Image.new("RGB", (1, 1)).save(image_buffer, format="JPEG")
-    image_bytes = image_buffer.getvalue()
-
     # when
     with mock_http_response_for_product_task(
-        status_code=200, content_type="image/jpeg", content=image_bytes
+        status_code=200, content_type="image/jpeg", content=IMAGE_1PX
     ):
         fetch_product_media_image_task.apply(args=(product_media.pk,))
 
@@ -510,14 +508,11 @@ def test_fetch_product_media_image_pixel_count_exceeds_limit_sanitizes_url(
     product_media.external_url = "https://username:password@example.com/image.jpg"
     product_media.save(update_fields=("external_url",))
     pillow_error = "Image exceeds the pixel limit."
-    image_buffer = BytesIO()
-    Image.new("RGB", (1, 1)).save(image_buffer, format="JPEG")
-    image_bytes = image_buffer.getvalue()
 
     # when
     with (
         mock_http_response_for_product_task(
-            status_code=200, content_type="image/jpeg", content=image_bytes
+            status_code=200, content_type="image/jpeg", content=IMAGE_1PX
         ),
         patch(
             "saleor.product.tasks.validate_image_exif",
@@ -574,6 +569,7 @@ def test_fetch_product_media_image_declared_file_size_exceeds_limit(
     ("_case", "content_length"),
     [
         ("missing", None),
+        ("negative", "-1"),  # advertized content-length is invalid
         ("understated", "1"),  # advertized content-length is spoofed or wrong
     ],
 )
@@ -606,6 +602,59 @@ def test_fetch_product_media_image_streamed_file_size_exceeds_limit(
     assert_product_media_fetch_rejected(caplog, product_media, expected_error)
 
 
+@pytest.mark.parametrize(
+    ("_case", "chunks", "is_valid"),
+    [
+        # NOTE: we need a valid image hence why we use IMAGE_1PX. Otherwise it will
+        #       be rejected by the API.
+        ("below max image size while image is in 1 chunk", [IMAGE_1PX], True),
+        (
+            "below max image size but image is split into 2 chunks",
+            [IMAGE_1PX[: len(IMAGE_1PX) // 2], IMAGE_1PX[len(IMAGE_1PX) // 2 :]],
+            True,
+        ),
+        ("greater than max image size while in 1 chunk", [IMAGE_1PX + b"\0"], False),
+        ("greater than max image size while in 2 chunks", [IMAGE_1PX, b"\0"], False),
+    ],
+)
+def test_fetch_product_media_image_streamed_allowed_when_under_limit(
+    _case,
+    chunks: list[bytes],
+    is_valid: bool,
+    product_media_image_not_yet_fetched,
+    settings,
+    caplog,
+):
+    """Ensures the images are allowed when `<=` the limit."""
+
+    # given
+    product_media = product_media_image_not_yet_fetched
+    max_file_size = len(IMAGE_1PX)
+    settings.MAX_IMAGE_FILE_SIZE = max_file_size
+    expected_error = f"File too big. Maximal file size is {max_file_size}."
+    caplog.set_level(logging.WARNING)
+
+    # when
+    with mock_http_response_for_product_task(
+        status_code=200,
+        content_type="image/jpeg",
+        content_chunks=chunks,
+    ):
+        fetch_product_media_image_task.apply(args=(product_media.pk,))
+
+    # then
+    exists = ProductMedia.objects.filter(pk=product_media.pk).exists()
+    if is_valid is True:
+        assert exists is True
+        records = [
+            record for record in caplog.records if record.name == "saleor.product.tasks"
+        ]
+        assert records == [], "shouldn't have logged any rejections or cleanups"
+    else:
+        assert exists is False
+        assert_product_media_fetch_rejected(caplog, product_media, expected_error)
+
+
 def test_fetch_product_media_image_invalid_content_length(
     product_media_image_not_yet_fetched,
     caplog,
@@ -631,40 +680,6 @@ def test_fetch_product_media_image_invalid_content_length(
     response.iter_content.assert_not_called()
     assert ProductMedia.objects.filter(pk=product_media.pk).exists() is False
     assert_product_media_fetch_rejected(caplog, product_media, expected_error)
-
-
-def test_fetch_product_media_image_file_size_at_limit(
-    product_media_image_not_yet_fetched,
-    media_root,
-    settings,
-    caplog,
-):
-    # given
-    product_media = product_media_image_not_yet_fetched
-    image_buffer = BytesIO()
-    Image.new("RGB", (1, 1)).save(image_buffer, format="JPEG")
-    image_bytes = image_buffer.getvalue()
-    max_file_size = len(image_bytes)
-    settings.MAX_IMAGE_FILE_SIZE = max_file_size
-    caplog.set_level(logging.WARNING)
-
-    # when
-    with mock_http_response_for_product_task(
-        status_code=200,
-        content_type="image/jpeg",
-        content=image_bytes,
-        content_length=str(max_file_size),
-    ):
-        fetch_product_media_image_task.apply(args=(product_media.pk,))
-
-    # then
-    product_media.refresh_from_db(fields=("external_url", "image"))
-    assert product_media.external_url is None
-    assert product_media.image
-    records = [
-        record for record in caplog.records if record.name == "saleor.product.tasks"
-    ]
-    assert records == [], "shouldn't have logged any rejections or cleanups"
 
 
 def test_fetch_product_media_image_unsupported_image_content_type(
@@ -774,14 +789,10 @@ def test_fetch_product_media_image_invalid_exif(
     product_media = product_media_image_not_yet_fetched
     assert not product_media.image
 
-    image_buffer = BytesIO()
-    Image.new("RGB", (1, 1)).save(image_buffer, format="JPEG")
-    image_bytes = image_buffer.getvalue()
-
     # when
     with (
         mock_http_response_for_product_task(
-            status_code=200, content_type="image/jpeg", content=image_bytes
+            status_code=200, content_type="image/jpeg", content=IMAGE_1PX
         ),
         patch("saleor.product.utils.tasks_utils.Image.open") as mock_image_open,
     ):

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -11,6 +11,7 @@ from faker import Faker
 from PIL import Image
 from requests.exceptions import HTTPError, InvalidSchema, RequestException
 
+from ...core.utils.url import sanitize_url_for_logging
 from ...discount import PromotionType, RewardValueType
 from ...discount.models import Promotion, PromotionRule
 from ...thumbnail.exceptions import ImageTooLargeError
@@ -35,19 +36,56 @@ from ..utils.variants import fetch_variants_for_promotion_rules
 
 @contextmanager
 def mock_http_response_for_product_task(
-    status_code=200, content_type=None, content=None
+    status_code: int = 200,
+    content_type: str | None = None,
+    content: bytes | None = None,
+    content_length: str | None = None,
+    content_chunks: list[bytes] | None = None,
 ):
     """Patch HTTPClient.send_request to return a response with the given attributes."""
     mock_response = MagicMock()
     mock_response.status_code = status_code
-    mock_response.headers.get.return_value = content_type
-    mock_response.content = content
+    mock_response.headers = {"content-type": content_type}
+    if content_length is not None:
+        mock_response.headers["content-length"] = content_length
+    if content_chunks is None:
+        content_chunks = [content] if content is not None else []
+    mock_response.iter_content.return_value = content_chunks
 
     with patch("saleor.product.tasks.HTTPClient") as mock_client:
         mock_client.send_request.return_value.__enter__ = MagicMock(
             return_value=mock_response
         )
-        yield mock_client
+        yield mock_response
+
+
+def assert_product_media_fetch_rejected(caplog, product_media, expected_error):
+    """Assert the media fetch rejection using captured logs."""
+    records = [
+        record for record in caplog.records if record.name == "saleor.product.tasks"
+    ]
+    assert len(records) == 2
+    rejection_record, failure_record = records
+
+    # Rejection log
+    assert rejection_record.levelno == logging.WARNING
+    assert rejection_record.getMessage() == (
+        f"Image fetched for product media {product_media.pk} was rejected: "
+        f"{expected_error}"
+    )
+    assert rejection_record.image_source == sanitize_url_for_logging(
+        product_media.external_url
+    )
+    assert rejection_record.object_type == "ProductMedia"
+    assert rejection_record.object_pk == product_media.pk
+    assert rejection_record.file_error == expected_error
+
+    # Clean-up log
+    assert failure_record.levelno == logging.WARNING
+    assert failure_record.getMessage() == (
+        "Failed to fetch image for product media with id: "
+        f"{product_media.pk}. Removing product media."
+    )
 
 
 @patch(
@@ -500,6 +538,133 @@ def test_fetch_product_media_image_pixel_count_exceeds_limit_sanitizes_url(
     assert caplog.records[0].object_type == "ProductMedia"
     assert caplog.records[0].object_pk == product_media.pk
     assert caplog.records[0].pillow_error == pillow_error
+
+
+def test_fetch_product_media_image_declared_file_size_exceeds_limit(
+    product_media_image_not_yet_fetched,
+    settings,
+    caplog,
+):
+    # given
+    product_media = product_media_image_not_yet_fetched
+    product_media.external_url = "https://username:password@example.com/image.jpg"
+    product_media.save(update_fields=("external_url",))
+
+    max_file_size = 1
+    settings.MAX_IMAGE_FILE_SIZE = max_file_size
+    content_length = str(max_file_size + 1)
+    expected_error = f"File too big. Maximal file size is {max_file_size}."
+    caplog.set_level(logging.WARNING)
+
+    # when
+    with mock_http_response_for_product_task(
+        status_code=200,
+        content_type="image/jpeg",
+        content_length=content_length,
+    ) as response:
+        fetch_product_media_image_task.apply(args=(product_media.pk,))
+
+    # then
+    response.iter_content.assert_not_called()
+    assert ProductMedia.objects.filter(pk=product_media.pk).exists() is False
+    assert_product_media_fetch_rejected(caplog, product_media, expected_error)
+
+
+@pytest.mark.parametrize(
+    ("_case", "content_length"),
+    [
+        ("missing", None),
+        ("understated", "1"),  # advertized content-length is spoofed or wrong
+    ],
+)
+def test_fetch_product_media_image_streamed_file_size_exceeds_limit(
+    _case,
+    content_length,
+    product_media_image_not_yet_fetched,
+    settings,
+    caplog,
+):
+    # given
+    product_media = product_media_image_not_yet_fetched
+    max_file_size = 1
+    settings.MAX_IMAGE_FILE_SIZE = max_file_size
+    content_chunks = [b"a", b"b"]
+    expected_error = f"File too big. Maximal file size is {max_file_size}."
+    caplog.set_level(logging.WARNING)
+
+    # when
+    with mock_http_response_for_product_task(
+        status_code=200,
+        content_type="image/jpeg",
+        content_length=content_length,
+        content_chunks=content_chunks,
+    ):
+        fetch_product_media_image_task.apply(args=(product_media.pk,))
+
+    # then
+    assert ProductMedia.objects.filter(pk=product_media.pk).exists() is False
+    assert_product_media_fetch_rejected(caplog, product_media, expected_error)
+
+
+def test_fetch_product_media_image_invalid_content_length(
+    product_media_image_not_yet_fetched,
+    caplog,
+):
+    """Ensure invalid Content-Length headers are rejected."""
+
+    # given
+    product_media = product_media_image_not_yet_fetched
+    content_length = "invalid"
+    expected_error = "Received an invalid content-length header"
+    caplog.set_level(logging.WARNING)
+
+    # when
+    with mock_http_response_for_product_task(
+        status_code=200,
+        content_type="image/jpeg",
+        content_length=content_length,
+        content_chunks=[b"a"],
+    ) as response:
+        fetch_product_media_image_task.apply(args=(product_media.pk,))
+
+    # then
+    response.iter_content.assert_not_called()
+    assert ProductMedia.objects.filter(pk=product_media.pk).exists() is False
+    assert_product_media_fetch_rejected(caplog, product_media, expected_error)
+
+
+def test_fetch_product_media_image_file_size_at_limit(
+    product_media_image_not_yet_fetched,
+    media_root,
+    settings,
+    caplog,
+):
+    # given
+    product_media = product_media_image_not_yet_fetched
+    image_buffer = BytesIO()
+    Image.new("RGB", (1, 1)).save(image_buffer, format="JPEG")
+    image_bytes = image_buffer.getvalue()
+    max_file_size = len(image_bytes)
+    settings.MAX_IMAGE_FILE_SIZE = max_file_size
+    caplog.set_level(logging.WARNING)
+
+    # when
+    with mock_http_response_for_product_task(
+        status_code=200,
+        content_type="image/jpeg",
+        content=image_bytes,
+        content_length=str(max_file_size),
+    ):
+        fetch_product_media_image_task.apply(args=(product_media.pk,))
+
+    # then
+    product_media.refresh_from_db(fields=("external_url", "image"))
+    assert product_media.external_url is None
+    assert product_media.image
+    records = [
+        record for record in caplog.records if record.name == "saleor.product.tasks"
+    ]
+    assert records == [], "shouldn't have logged any rejections or cleanups"
 
 
 def test_fetch_product_media_image_unsupported_image_content_type(

--- a/saleor/product/utils/tasks_utils.py
+++ b/saleor/product/utils/tasks_utils.py
@@ -1,5 +1,6 @@
 from typing import IO
 
+from django.conf import settings
 from PIL import Image, UnidentifiedImageError
 from requests.exceptions import HTTPError
 
@@ -27,7 +28,9 @@ def validate_content_type_header(product_media, mime_type):
 
 def create_image(product_media, mime_type, response):
     filename = get_filename_from_url(product_media.external_url, mime_type)
-    return create_file_from_response(response, filename)
+    return create_file_from_response(
+        response, filename, max_file_size=settings.MAX_IMAGE_FILE_SIZE
+    )
 
 
 def validate_image_mime_type(image: IO[bytes]):


### PR DESCRIPTION
This adds support for limiting the size of images uploaded prior to loading them. This is a further improvement to #19678 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: N/A - this only fills a gap and re-uses the existing `MAX_IMAGE_FILE_SIZE` setting

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
