### PR TITLE
Reject GraphQL subscription operations sent over HTTP

### DIFF
--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -757,3 +757,32 @@ def test_real_public_mutation_blocked_when_disabled(
     # then
     assert response.status_code == 401
     assert response.json() == EXPECTED_STOREFRONT_TRAFFIC_ERROR
+
+
+def test_subscription_operation_is_rejected(api_client, caplog):
+    # given
+    query = """
+        subscription {
+            event {
+                ... on ProductCreated {
+                    product { id }
+                }
+            }
+        }
+    """
+
+    # when
+    with caplog.at_level(logging.ERROR, logger="saleor.graphql.errors.unhandled"):
+        response = api_client.post_graphql(query, check_no_permissions=False)
+
+    # then
+    assert response.status_code == 400
+    content = get_graphql_content_from_response(response)
+    errors = content["errors"]
+    assert len(errors) == 1
+    assert errors[0]["message"] == (
+        "Subscriptions are supported only as webhooks. See "
+        "https://docs.saleor.io/developer/extending/webhooks/overview"
+    )
+    assert errors[0]["extensions"]["exception"]["code"] == "GraphQLError"
+    assert caplog.records == []

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -451,6 +451,30 @@ class GraphQLView(View):
                     saleor_attributes.SALEOR_SOURCE_SERVICE_NAME, source_service_name
                 )
 
+            if operation_type == "subscription":
+                # The schema exposes a `Subscription` type only so apps can define
+                # webhook subscription documents. The synchronous executor used here
+                # cannot run them and raises a bare `Exception`, which surfaces as an
+                # unhandled error. Reject with a proper GraphQL error instead.
+                subscription_error = GraphQLError(
+                    "Subscriptions are supported only as webhooks. See "
+                    "https://docs.saleor.io/developer/extending/webhooks/overview"
+                )
+                span.set_status(
+                    status=StatusCode.ERROR, description=str(subscription_error)
+                )
+                error_type = subscription_error.__class__.__name__
+                record_graphql_query_count(
+                    operation_type=operation_type, error_type=error_type
+                )
+                record_graphql_query_cost(
+                    QUERY_COST_FAILED_OPERATION,
+                    operation_type=operation_type,
+                    error_type=error_type,
+                )
+                query_duration_attrs[error_attributes.ERROR_TYPE] = error_type
+                return ExecutionResult(errors=[subscription_error], invalid=True)
+
             query_cost, cost_errors = validate_query(
                 schema=schema,
                 document_ast=document.document_ast,


### PR DESCRIPTION
A `subscription` operation POSTed to /graphql/ parsed and validated fine (the schema exposes a `Subscription` type so apps can define webhook subscription documents), but the synchronous executor refused to run it and raised a bare `Exception("Subscriptions are not allowed...")`. That was logged as an unhandled query failure and returned to the client as "Internal Server Error".

Reject the operation before execution with a proper `GraphQLError` pointing at the webhooks docs, recording the same span status and query count/cost metrics as the other early-return branches.

Fixes SALEOR-CORE-8CW
