### PR TITLE
Remove no-op discounted-price compat tasks

### DIFF
--- a/saleor/graphql/discount/tests/mutations/test_promotion_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_create.py
@@ -258,13 +258,11 @@ def test_promotion_create_by_app(
 
 
 @freeze_time("2020-03-18 12:00:00")
-@patch("saleor.product.tasks.update_products_discounted_prices_of_promotion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.promotion_started")
 @patch("saleor.plugins.manager.PluginsManager.promotion_created")
 def test_promotion_create_by_customer(
     promotion_created_mock,
     promotion_started_mock,
-    update_products_discounted_prices_of_promotion_task_mock,
     api_client,
     description_json,
     channel_USD,
@@ -312,7 +310,6 @@ def test_promotion_create_by_customer(
 
     promotion_created_mock.assert_not_called()
     promotion_started_mock.assert_not_called()
-    update_products_discounted_prices_of_promotion_task_mock.assert_not_called()
 
 
 @freeze_time("2020-03-18 12:00:00")
@@ -1558,13 +1555,11 @@ def test_promotion_create_exceeds_gifts_number_limit(
     assert errors[0]["giftsLimitExceedBy"] == len(gift_ids) - gift_limit
 
 
-@patch("saleor.product.tasks.update_products_discounted_prices_of_promotion_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.promotion_started")
 @patch("saleor.plugins.manager.PluginsManager.promotion_created")
 def test_promotion_create_rules_without_channels_and_percentage_reward(
     promotion_created_mock,
     promotion_started_mock,
-    update_products_discounted_prices_of_promotion_task_mock,
     staff_api_client,
     permission_group_manage_discounts,
     variant,
@@ -1789,9 +1784,7 @@ def test_promotion_create_events_by_app(
     assert all(rule["id"] in rule_ids for rule in rules)
 
 
-@patch("saleor.product.tasks.update_products_discounted_prices_of_promotion_task.delay")
 def test_promotion_create_gift_promotion(
-    _,
     staff_api_client,
     permission_group_manage_discounts,
     channel_USD,

--- a/saleor/graphql/discount/tests/mutations/test_sale_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_delete.py
@@ -75,11 +75,9 @@ def test_sale_delete_mutation(
         assert listing.discounted_price_dirty is True
 
 
-@patch("saleor.product.tasks.update_discounted_prices_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.sale_deleted")
 def test_sale_delete_mutation_with_promotion_id(
     deleted_webhook_mock,
-    update_discounted_prices_task_mock,
     staff_api_client,
     promotion_converted_from_sale,
     permission_manage_discounts,
@@ -107,7 +105,6 @@ def test_sale_delete_mutation_with_promotion_id(
     )
 
     deleted_webhook_mock.assert_not_called()
-    update_discounted_prices_task_mock.assert_not_called()
 
 
 def test_sale_delete_not_found_error(staff_api_client, permission_manage_discounts):

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -1,7 +1,6 @@
 import logging
 from collections import defaultdict
 from collections.abc import Iterable
-from uuid import UUID
 
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -120,16 +119,6 @@ def update_variants_names(product_type_pk: int, saved_attributes_ids: list[int])
         _update_variants_names(instance, saved_attributes)
 
 
-@app.task
-@allow_writer()
-def update_products_discounted_prices_of_promotion_task(promotion_pk: UUID):
-    # FIXME: Should be removed in Saleor 3.21
-
-    # In case of triggering this task by old server worker, mark promotion
-    # as dirty. The reclacultion will happen in the background
-    PromotionRule.objects.filter(promotion_id=promotion_pk).update(variants_dirty=True)
-
-
 def _get_channel_to_products_map(rule_to_variant_list):
     variant_ids = {
         rule_to_variant.productvariant_id for rule_to_variant in rule_to_variant_list
@@ -236,21 +225,6 @@ def update_variant_relations_for_active_promotion_rules_task():
         update_variant_relations_for_active_promotion_rules_task.delay()
 
 
-@app.task
-@allow_writer()
-def update_products_discounted_prices_for_promotion_task(
-    product_ids: Iterable[int],
-    start_id: UUID | None = None,
-    *,
-    rule_ids: list[UUID] | None = None,
-):
-    # FIXME: Should be removed in Saleor 3.21
-
-    # In case of triggered the task by old server worker, mark all active promotions as
-    # dirty. This will make the same re-calculation as the old task.
-    PromotionRule.objects.filter(variants_dirty=False).update(variants_dirty=True)
-
-
 def _send_variant_price_updated_webhooks(
     changed_prices: list[VariantDiscountedPriceChange],
 ) -> None:
@@ -304,18 +278,6 @@ def recalculate_discounted_price_for_products_task():
                 discounted_price_dirty=False
             )
         recalculate_discounted_price_for_products_task.delay()
-
-
-@app.task
-@allow_writer()
-def update_discounted_prices_task(product_ids: Iterable[int]):
-    # FIXME: Should be removed in Saleor 3.21
-
-    # in case triggering the task by old server worker, we will just mark the products
-    # as dirty. The recalculation will happen in the background.
-    ProductChannelListing.objects.filter(product_id__in=product_ids).update(
-        discounted_price_dirty=True
-    )
 
 
 @app.task


### PR DESCRIPTION
Drop three Celery tasks in saleor/product/tasks.py that were kept only so pre-3.21 workers could enqueue them during a rolling upgrade:

- update_products_discounted_prices_of_promotion_task
- update_products_discounted_prices_for_promotion_task
- update_discounted_prices_task
