### PR TITLE
Release 3.23.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.23.29",
+  "version": "3.23.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.23.29",
+      "version": "3.23.30",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.23.29",
+  "version": "3.23.30",
   "engines": {
     "node": ">=20 <22",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "saleor"
-version = "3.23.29"
+version = "3.23.30"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 requires-python = ">=3.12,<3.13"
 readme = "README.md"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,7 +1,7 @@
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.23.29"
+__version__ = "3.23.30"
 
 
 class PatchedSubscriberExecutionContext:

--- a/uv.lock
+++ b/uv.lock
@@ -2528,7 +2528,7 @@ wheels = [
 
 [[package]]
 name = "saleor"
-version = "3.23.29"
+version = "3.23.30"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION
* Release 3.23.30 (a214d6a609)
* Delete detached FILE attribute values in object update mutations so clients no longer need the permission-restricted attributeValueDelete to clean up after replacing or clearing a file (#19709) (acb4442cae)
* Limit the number of pixels of images we decode (#19713) (4d9b44255b)
