### PR TITLE
Pin uv to 0.12.x via tool.uv.required-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,11 @@ dev = [
 envfile = ".env"
 
 [tool.uv]
+# Keep everyone (devs, CI, Dockerfile, uv-lock pre-commit hook) on the same uv
+# minor, so uv.lock doesn't churn between machines. Bump together with the uv
+# versions in Dockerfile and .pre-commit-config.yaml.
+required-version = "==0.12.*"
+
 environments = [
   "platform_python_implementation != 'PyPy'"
 ]


### PR DESCRIPTION
Different uv versions across developer machines produced unrelated uv.lock diffs. Setting required-version makes uv refuse to run when the local version is outside the range, so the lockfile stays stable.

The version matches the pins already in place (Dockerfile, .devcontainer/Dockerfile, uv-pre-commit hook). It also covers CI, which had no uv version pin: astral-sh/setup-uv resolves its default version from pyproject.toml.

I assume minor range is not changing diff format, if this happens too, we can lock to specific patch version