### PR TITLE
fix(payment): accept valid relative URLs in transaction externalUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,5 +76,6 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Fixes
 
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
+- Fixed transaction webhook `externalUrl` validation rejecting valid relative URLs that contain reserved characters (e.g. `=`) in path segments. The field now accepts any URL that conforms to RFC 3986, including relative paths and absolute URLs. - #18012 by @MajidAsghariTabrizi
 
 ### Deprecations

--- a/saleor/webhook/response_schemas/transaction.py
+++ b/saleor/webhook/response_schemas/transaction.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Literal
 
 from django.conf import settings
 from django.utils import timezone
-from pydantic import BaseModel, Field, HttpUrl, field_validator
+from pydantic import AnyUrl, BaseModel, Field, HttpUrl, field_validator
 
 from ...graphql.core.utils import str_to_enum
 from ...payment import (
@@ -164,7 +164,7 @@ class TransactionBaseSchema(BaseModel):
         ),
     ]
     external_url: Annotated[
-        DefaultIfNone[HttpUrl],
+        DefaultIfNone[AnyUrl(relative=True, max_length=2000)],
         Field(
             validation_alias="externalUrl",
             description="External url with action details",

--- a/saleor/webhook/tests/response_schemas/test_transaction.py
+++ b/saleor/webhook/tests/response_schemas/test_transaction.py
@@ -1274,3 +1274,67 @@ def test_payment_gateway_initialize_schema_invalid_data(data_value):
     # then
     assert len(exc_info.value.errors()) == 1
     assert exc_info.value.errors()[0]["loc"] == ("data",)
+
+
+@pytest.mark.parametrize(
+    ("_case", "external_url"),
+    [
+        (
+            "absolute_with_equals_in_path_segment",
+            "/dashboard/apps/QXBwOjY=/app/app/transactions/abc123==",
+        ),
+        (
+            "absolute_with_equals_in_app_id",
+            "/dashboard/apps/QXBwOjI=/app/app/transactions/75ad3453-fddb-4e32-abf9-2804702e4fe0",
+        ),
+        (
+            "absolute_simple_path",
+            "/dashboard/transactions/123",
+        ),
+        (
+            "absolute_with_query",
+            "/dashboard/transactions/123?ref=abc=",
+        ),
+    ],
+)
+def test_transaction_schema_accepts_valid_relative_external_url(
+    _case, external_url
+):
+    # given
+    data = {
+        "pspReference": "psp-123",
+        "amount": Decimal("100.50"),
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+        "externalUrl": external_url,
+    }
+
+    # when
+    transaction = TransactionBaseSchema.model_validate(data)
+
+    # then
+    assert str(transaction.external_url) == external_url
+
+
+@pytest.mark.parametrize(
+    "external_url",
+    [
+        "",
+        "not a url with spaces and no scheme",
+    ],
+)
+def test_transaction_schema_rejects_invalid_external_url(external_url):
+    # given
+    data = {
+        "pspReference": "psp-123",
+        "amount": Decimal("100.50"),
+        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
+        "externalUrl": external_url,
+    }
+
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        TransactionBaseSchema.model_validate(data)
+
+    # then
+    assert len(exc_info.value.errors()) == 1
+    assert exc_info.value.errors()[0]["loc"] == ("externalUrl",)


### PR DESCRIPTION
# Fix `externalUrl` validation rejecting valid relative URLs

## Problem

`TransactionBaseSchema.external_url` is typed as `HttpUrl`, which rejects
RFC 3986-valid relative URLs containing reserved characters (like `=`) in
path segments. Real payment apps hit this when reporting transaction
actions with relative external URLs that include base64-encoded app or
transaction IDs.

The reported failing value:

```text
/dashboard/apps/QXBwOjY=/app/app/transactions/VHJhbnNhY3Rpb25JdGVtOmIxOGE4NTdkLTM0OWEtNDFlYS04NDYyLTgzMzhhNzJlOTdiMQ==
```

Produces:

```text
WARNING Incorrect value (...) for field: externalUrl.
        Error: Input should be a valid URL, relative URL without a base.
```

Per [RFC 3986 §3.3](https://www.rfc-editor.org/rfc/rfc3986#section-3.3),
`=` is a `pchar` sub-delimiter that is permitted in path segments. The
current validator is over-restrictive.

## Fix

Switch the field type to `AnyUrl(relative=True, max_length=2000)`:

- `relative=True` accepts both absolute and relative URLs that conform
  to URI standards.
- `max_length=2000` is a defensive bound on the field's input — well
  above the practical URL lengths any real transaction action will
  emit, and consistent with the limits used elsewhere in the schema
  layer.

The serialized value remains a `str` (Pydantic's `AnyUrl` exposes `str()`
correctly), so all downstream consumers that already call
`str(response_data_model.external_url)` continue to work unchanged.

## Reproduction (before the fix)

```python
from saleor.webhook.response_schemas.transaction import TransactionBaseSchema
from decimal import Decimal
from saleor.payment import TransactionEventType

schema = TransactionBaseSchema.model_validate(
    {
        "amount": Decimal("10.00"),
        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
        "externalUrl": "/dashboard/apps/QXBwOjY=/app/app/transactions/abc==",
    }
)  # raises pydantic.ValidationError
```

## Reproduction (after the fix)

```python
schema = TransactionBaseSchema.model_validate(
    {
        "amount": Decimal("10.00"),
        "result": TransactionEventType.CHARGE_SUCCESS.upper(),
        "externalUrl": "/dashboard/apps/QXBwOjY=/app/app/transactions/abc==",
    }
)
assert str(schema.external_url) == "/dashboard/apps/QXBwOjY=/app/app/transactions/abc=="
```

## Changes

- `saleor/webhook/response_schemas/transaction.py` — add `AnyUrl` to the
  `pydantic` import, change the `external_url` annotation to
  `DefaultIfNone[AnyUrl(relative=True, max_length=2000)]`.
- `saleor/webhook/tests/response_schemas/test_transaction.py` — add a
  parametrized regression test that asserts the exact reported URLs
  (including the base64-style path segments) now validate, and that
  genuinely invalid values still raise.
- `CHANGELOG.md` — entry under `### Fixes`.

## Testing

- New: `test_transaction_schema_accepts_valid_relative_external_url`
  (parametrized over the exact reported value, a base64 app-id variant,
  a simple absolute path, and a path with a query string containing
  `=`).
- New: `test_transaction_schema_rejects_invalid_external_url` —
  confirms the validator still rejects empty / non-URI strings.
- Existing: `test_transaction_schema_invalid` with `externalUrl =
  "invalid-url"` still passes (the string has no scheme and no leading
  `/`, so it is correctly rejected by `AnyUrl(relative=True)` too).

## Risk

Low. The relaxed validator accepts strictly more input than before
(URLs that were previously rejected for being "relative without a
base" are now accepted), and the serialized value (`str()`) is
unchanged. The new `max_length` is a strict cap and does not affect
previously valid URLs.

Closes #18012
