### PR TITLE
docs(security): add guidelines about attachments

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,12 +12,14 @@ Whichever method you choose, you will be credited as the reporter once the annou
 
 ## Guidelines
 
-A report must include:
+A report must:
 
-- A clear description of the issue
-- Reproduction steps that allow us to verify the behavior
-- Affected version(s) and environment details (versions, OS, tools, configurations)
-- Let us know if you are willing to review the patches before their publication
+- Include a clear description of the issue
+- Include reproduction steps that allow us to verify the behavior
+- Include affected version(s) and environment details (versions, OS, tools, configurations)
+- Mention whether you are willing to review the patches before their publication
+- Be self-contained (no file attachments nor download links). Reports requiring to open
+  arbitrary files or links may not be accepted.
 
 Reports that lack these elements may be considered incomplete and may be closed without follow-up,
 reports may also be closed if the submitter does not engage to follow-ups.


### PR DESCRIPTION
Updated report guideline to mention reports must be self-contained as we are seeing a new trend of reports no longer containing key/critical information inside them without downloading untrusted files

Port of https://github.com/saleor/.github/pull/7



<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: irrelevant

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
