### PR TITLE
Authenticate the request in the external auth mutations

### DIFF
--- a/saleor/graphql/account/mutations/authentication/external_obtain_access_tokens.py
+++ b/saleor/graphql/account/mutations/authentication/external_obtain_access_tokens.py
@@ -50,6 +50,7 @@ class ExternalObtainAccessTokens(BaseMutation):
 
         if access_tokens_response.user and access_tokens_response.user.id:
             user = access_tokens_response.user
+            info.context.user = user
             info.context._cached_user = user
             update_user_last_login_if_required(user)
 

--- a/saleor/graphql/account/mutations/authentication/external_refresh.py
+++ b/saleor/graphql/account/mutations/authentication/external_refresh.py
@@ -48,6 +48,7 @@ class ExternalRefresh(BaseMutation):
 
         if access_tokens_response.user and access_tokens_response.user.id:
             user = access_tokens_response.user
+            info.context.user = user
             info.context._cached_user = user
             update_user_last_login_if_required(user)
 

--- a/saleor/graphql/account/tests/mutations/authentication/test_external_obtain_access_tokens.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_external_obtain_access_tokens.py
@@ -165,3 +165,67 @@ def test_external_obtain_access_tokens_do_update_last_login_when_out_of_threshol
     assert customer_user.updated_at == time_out_of_threshold
     assert customer_user.last_login == time_out_of_threshold
     assert mock_refresh_token_middleware.called
+
+
+MUTATION_EXTERNAL_OBTAIN_ACCESS_TOKENS_ACCESSIBLE_CHANNELS = """
+    mutation externalObtainAccessTokens($pluginId: String!, $input: JSONString!){
+        externalObtainAccessTokens(pluginId: $pluginId, input: $input){
+            user{
+                email
+                accessibleChannels{
+                    slug
+                    isActive
+                }
+            }
+            errors{
+                field
+                message
+            }
+        }
+}
+"""
+
+
+@patch("saleor.core.middleware.jwt_decode_with_exception_handler")
+def test_external_obtain_access_tokens_resolves_staff_only_user_fields(
+    mock_refresh_token_middleware,
+    api_client,
+    staff_users,
+    permission_group_all_perms_channel_USD_only,
+    channel_USD,
+    monkeypatch,
+):
+    """The returned user must authenticate the request for the rest of the response.
+
+    `Channel.slug`/`isActive` are guarded by `AUTHENTICATED_STAFF_USER`, so without
+    `info.context.user` being set they raise `PermissionDenied` and fail the whole
+    mutation.
+    """
+    # given
+    user = staff_users[1]
+    assert user.is_staff is True
+    mocked_plugin_fun = Mock(
+        return_value=ExternalAccessTokens(token="token1", user=user)
+    )
+    monkeypatch.setattr(
+        "saleor.plugins.manager.PluginsManager.external_obtain_access_tokens",
+        mocked_plugin_fun,
+    )
+    variables = {
+        "pluginId": "pluginId1",
+        "input": json.dumps({"code": "ABCD", "state": "state-data"}),
+    }
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_EXTERNAL_OBTAIN_ACCESS_TOKENS_ACCESSIBLE_CHANNELS, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["externalObtainAccessTokens"]
+    assert data["errors"] == []
+    assert data["user"]["email"] == user.email
+    assert data["user"]["accessibleChannels"] == [
+        {"slug": channel_USD.slug, "isActive": channel_USD.is_active}
+    ]

--- a/saleor/graphql/account/tests/mutations/authentication/test_external_refresh.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_external_refresh.py
@@ -156,3 +156,63 @@ def test_external_refresh_do_update_last_login_when_out_of_threshold(
     assert customer_user.updated_at == time_out_of_threshold
     assert customer_user.last_login == time_out_of_threshold
     assert mock_refresh_token_middleware.called
+
+
+MUTATION_EXTERNAL_REFRESH_ACCESSIBLE_CHANNELS = """
+    mutation externalRefresh($pluginId: String!, $input: JSONString!){
+        externalRefresh(pluginId: $pluginId, input: $input){
+            user{
+                email
+                accessibleChannels{
+                    slug
+                    isActive
+                }
+            }
+            errors{
+                field
+                message
+            }
+        }
+}
+"""
+
+
+@patch("saleor.core.middleware.jwt_decode_with_exception_handler")
+def test_external_refresh_resolves_staff_only_user_fields(
+    mock_refresh_token_middleware,
+    api_client,
+    staff_users,
+    permission_group_all_perms_channel_USD_only,
+    channel_USD,
+    monkeypatch,
+):
+    """The returned user must authenticate the request for the rest of the response.
+
+    `Channel.slug`/`isActive` are guarded by `AUTHENTICATED_STAFF_USER`, so without
+    `info.context.user` being set they raise `PermissionDenied` and fail the whole
+    mutation.
+    """
+    # given
+    user = staff_users[1]
+    assert user.is_staff is True
+    mocked_plugin_fun = Mock(
+        return_value=ExternalAccessTokens(token="token1", user=user)
+    )
+    monkeypatch.setattr(
+        "saleor.plugins.manager.PluginsManager.external_refresh", mocked_plugin_fun
+    )
+    variables = {"pluginId": "pluginId1", "input": json.dumps({"refreshToken": "ABCD"})}
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_EXTERNAL_REFRESH_ACCESSIBLE_CHANNELS, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["externalRefresh"]
+    assert data["errors"] == []
+    assert data["user"]["email"] == user.email
+    assert data["user"]["accessibleChannels"] == [
+        {"slug": channel_USD.slug, "isActive": channel_USD.is_active}
+    ]


### PR DESCRIPTION
`externalObtainAccessTokens` and `externalRefresh` only wrote `info.context._cached_user`, but `BaseMutation.mutate` calls `setup_context_user`, which has already unwrapped the lazy `context.user` proxy to a plain `None` — so the write was dead and the request stayed unauthenticated for the rest of field resolution.

Querying the returned `user` for anything permission-guarded then failed the whole mutation with `PermissionDenied`. The Dashboard hit this via `user { accessibleChannels { isActive } }` (`AUTHENTICATED_APP`, `AUTHENTICATED_STAFF_USER`) and reported it as "You don't have permission to login".

Set `info.context.user` as well, matching `tokenCreate` (create_token.py:114), which is why password login never broke.
