### PR TITLE
Add pricing, quantityAvailable and discountedPrice to ProductVariantC…

### DIFF
--- a/saleor/graphql/product/tests/queries/test_product_variant_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_variant_query.py
@@ -1,4 +1,7 @@
+from decimal import Decimal
+
 import graphene
+import pytest
 from django.contrib.sites.models import Site
 from measurement.measures import Weight
 
@@ -6,7 +9,11 @@ from .....attribute.utils import associate_attribute_values_to_instance
 from .....core.units import WeightUnits
 from .....warehouse import WarehouseClickAndCollectOption
 from ....core.enums import WeightUnitsEnum
-from ....tests.utils import assert_no_permission, get_graphql_content
+from ....tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 
 QUERY_VARIANT = """query ProductVariantDetails(
         $id: ID!, $address: AddressInput, $countryCode: CountryCode, $channel: String
@@ -866,3 +873,285 @@ def test_product_variant_when_assigned_attribute_is_none(
     # then
     content = get_graphql_content(response)
     assert content["data"]["productVariant"]["assignedAttribute"] is None
+
+
+CHANNEL_LISTING_PRICING_FRAGMENT = """
+    fragment ChannelListingPricing on ProductVariantChannelListing {
+        channel {
+            slug
+        }
+        price {
+            amount
+            currency
+        }
+        discountedPrice {
+            amount
+            currency
+        }
+        pricing {
+            onSale
+            price {
+                gross {
+                    amount
+                    currency
+                }
+            }
+            priceUndiscounted {
+                gross {
+                    amount
+                }
+            }
+        }
+        quantityAvailable
+    }
+"""
+
+QUERY_VARIANTS_CHANNEL_LISTING_PRICING = (
+    CHANNEL_LISTING_PRICING_FRAGMENT
+    + """
+    query VariantsChannelListingPricing($ids: [ID!]) {
+        productVariants(first: 10, ids: $ids) {
+            edges {
+                node {
+                    channelListings {
+                        ...ChannelListingPricing
+                    }
+                }
+            }
+        }
+    }
+"""
+)
+
+QUERY_VARIANT_CHANNEL_LISTING_PRICING = (
+    CHANNEL_LISTING_PRICING_FRAGMENT
+    + """
+    query VariantChannelListingPricing($id: ID!, $channel: String) {
+        productVariant(id: $id, channel: $channel) {
+            channelListings {
+                ...ChannelListingPricing
+            }
+        }
+    }
+"""
+)
+
+QUERY_VARIANT_PRICING_IN_CHANNEL = """
+    query VariantPricingInChannel($id: ID!, $channel: String!) {
+        productVariant(id: $id, channel: $channel) {
+            pricing {
+                onSale
+                price {
+                    gross {
+                        amount
+                        currency
+                    }
+                }
+                priceUndiscounted {
+                    gross {
+                        amount
+                    }
+                }
+            }
+            quantityAvailable
+        }
+    }
+"""
+
+
+def test_channel_listing_pricing_matches_channel_scoped_pricing(
+    staff_api_client,
+    product_available_in_many_channels,
+    permission_manage_products,
+):
+    """One channel-less walk returns the same pricing as one walk per channel."""
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    variant = product_available_in_many_channels.variants.get()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    channel_listings = list(variant.channel_listings.all())
+    assert len(channel_listings) == 2
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_VARIANTS_CHANNEL_LISTING_PRICING, {"ids": [variant_id]}
+    )
+    content = get_graphql_content(response)
+
+    # then
+    edges = content["data"]["productVariants"]["edges"]
+    assert len(edges) == 1
+    listings_data = edges[0]["node"]["channelListings"]
+    assert len(listings_data) == 2
+
+    data_by_slug = {data["channel"]["slug"]: data for data in listings_data}
+    for channel_listing in channel_listings:
+        data = data_by_slug[channel_listing.channel.slug]
+        assert data["price"]["amount"] == channel_listing.price_amount
+        assert data["price"]["currency"] == channel_listing.currency
+
+        channel_scoped = get_graphql_content(
+            staff_api_client.post_graphql(
+                QUERY_VARIANT_PRICING_IN_CHANNEL,
+                {"id": variant_id, "channel": channel_listing.channel.slug},
+            )
+        )["data"]["productVariant"]
+
+        assert data["pricing"] is not None
+        assert data["pricing"] == channel_scoped["pricing"]
+        assert data["quantityAvailable"] == channel_scoped["quantityAvailable"]
+
+
+def test_channel_listing_discounted_price(
+    staff_api_client,
+    product_available_in_many_channels,
+    channel_USD,
+    permission_manage_products,
+):
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    variant = product_available_in_many_channels.variants.get()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    listing = variant.channel_listings.get(channel=channel_USD)
+    undiscounted_amount = Decimal("30.00")
+    discounted_amount = Decimal("12.50")
+    listing.price_amount = undiscounted_amount
+    listing.discounted_price_amount = discounted_amount
+    listing.save(update_fields=("price_amount", "discounted_price_amount"))
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_VARIANT_CHANNEL_LISTING_PRICING,
+        {"id": variant_id, "channel": channel_USD.slug},
+    )
+    content = get_graphql_content(response)
+
+    # then
+    listings_data = content["data"]["productVariant"]["channelListings"]
+    data = next(
+        data for data in listings_data if data["channel"]["slug"] == channel_USD.slug
+    )
+    assert data["discountedPrice"]["amount"] == discounted_amount
+    assert data["discountedPrice"]["currency"] == channel_USD.currency_code
+    assert data["pricing"]["priceUndiscounted"]["gross"]["amount"] == (
+        undiscounted_amount
+    )
+    assert data["pricing"]["price"]["gross"]["amount"] == discounted_amount
+    assert data["pricing"]["onSale"] is True
+
+
+@pytest.mark.parametrize(
+    ("_case", "client_fixture", "is_allowed"),
+    [
+        ("Unauthenticated user should be rejected", "api_client", False),
+        (
+            "Authenticated unprivileged user (non-staff) should be rejected",
+            "user_api_client",
+            False,
+        ),
+        (
+            "Staff user without any permission should be allowed",
+            "staff_api_client",
+            True,
+        ),
+        ("App should be allowed", "app_api_client", True),
+    ],
+)
+def test_channel_listing_pricing_authorization(
+    _case,
+    client_fixture,
+    is_allowed,
+    request,
+    product_available_in_many_channels,
+    channel_USD,
+):
+    # given
+    client = request.getfixturevalue(client_fixture)
+    variant = product_available_in_many_channels.variants.get()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+
+    # when
+    response = client.post_graphql(QUERY_VARIANT_CHANNEL_LISTING_PRICING, variables)
+
+    # then
+    if is_allowed:
+        content = get_graphql_content(response)
+        listings_data = content["data"]["productVariant"]["channelListings"]
+        assert len(listings_data) == 2
+        for data in listings_data:
+            assert data["pricing"] is not None
+            assert data["discountedPrice"] is not None
+    else:
+        assert_no_permission(response)
+        content = get_graphql_content_from_response(response)
+        assert content["data"]["productVariant"]["channelListings"] is None
+
+
+QUERY_PRODUCT_VARIANTS_CHANNEL_LISTING_PRICING = (
+    CHANNEL_LISTING_PRICING_FRAGMENT
+    + """
+    query ProductVariantsChannelListingPricing($id: ID!, $channel: String) {
+        product(id: $id, channel: $channel) {
+            variants {
+                channelListings {
+                    ...ChannelListingPricing
+                }
+            }
+        }
+    }
+"""
+)
+
+
+def _channel_listings_by_slug(api_client, query, variables, extract):
+    content = get_graphql_content(api_client.post_graphql(query, variables))
+    return sorted(
+        extract(content["data"]), key=lambda listing: listing["channel"]["slug"]
+    )
+
+
+def test_channel_listing_pricing_is_the_same_across_queries(
+    staff_api_client,
+    product_available_in_many_channels,
+    channel_USD,
+    permission_manage_products,
+):
+    """The listing fields do not depend on the channel of the root query."""
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    product = product_available_in_many_channels
+    variant = product.variants.get()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+
+    # when
+    from_variant = _channel_listings_by_slug(
+        staff_api_client,
+        QUERY_VARIANT_CHANNEL_LISTING_PRICING,
+        {"id": variant_id, "channel": channel_USD.slug},
+        lambda data: data["productVariant"]["channelListings"],
+    )
+    from_product_in_channel = _channel_listings_by_slug(
+        staff_api_client,
+        QUERY_PRODUCT_VARIANTS_CHANNEL_LISTING_PRICING,
+        {"id": product_id, "channel": channel_USD.slug},
+        lambda data: data["product"]["variants"][0]["channelListings"],
+    )
+    from_product_without_channel = _channel_listings_by_slug(
+        staff_api_client,
+        QUERY_PRODUCT_VARIANTS_CHANNEL_LISTING_PRICING,
+        {"id": product_id},
+        lambda data: data["product"]["variants"][0]["channelListings"],
+    )
+
+    # then
+    assert len(from_variant) == 2
+    for listing_data in from_variant:
+        assert listing_data["pricing"] is not None
+        assert listing_data["discountedPrice"] is not None
+
+    assert from_product_in_channel == from_variant
+    assert from_product_without_channel == from_variant

--- a/saleor/graphql/product/tests/test_variant_pricing.py
+++ b/saleor/graphql/product/tests/test_variant_pricing.py
@@ -384,7 +384,7 @@ QUERY_GET_PRODUCT_VARIANTS_PRICING_NO_ADDRESS = """
 
 
 @patch(
-    "saleor.graphql.product.types.products.get_tax_rate_for_country",
+    "saleor.graphql.product.types.availability.get_tax_rate_for_country",
 )
 def test_product_variant_price_no_address(
     mock_get_tax_rate_for_country, user_api_client, variant, stock, channel_USD

--- a/saleor/graphql/product/types/availability.py
+++ b/saleor/graphql/product/types/availability.py
@@ -1,0 +1,307 @@
+import sys
+from dataclasses import asdict
+from decimal import Decimal
+
+import graphene
+from promise import Promise
+
+from ....core.db.connection import allow_writer_in_context
+from ....core.utils.country import get_active_country
+from ....product import models
+from ....product.utils.availability import get_variant_availability
+from ....tax.utils import (
+    get_tax_calculation_strategy,
+    get_tax_rate_for_country,
+)
+from ....warehouse.reservations import is_reservation_enabled
+from ...core.doc_category import DOC_CATEGORY_PRODUCTS
+from ...core.types import BaseObjectType, TaxedMoney, TaxedMoneyRange
+from ...tax.dataloaders import (
+    TaxClassCountryRateByTaxClassIDLoader,
+    TaxClassDefaultRateByCountryLoader,
+    TaxConfigurationByChannelId,
+    TaxConfigurationPerCountryByTaxConfigurationIDLoader,
+)
+from ...warehouse.dataloaders import (
+    AvailableQuantityByProductVariantIdAndChannelSlugLoader,
+    AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader,
+    PreorderQuantityReservedByVariantChannelListingIdLoader,
+)
+from ..dataloaders import (
+    VariantChannelListingByVariantIdAndChannelSlugLoader,
+    VariantChannelListingByVariantIdLoader,
+)
+
+
+class BasePricingInfo(BaseObjectType):
+    on_sale = graphene.Boolean(description="Whether it is in sale or not.")
+    discount = graphene.Field(
+        TaxedMoney, description="The discount amount if in sale (null otherwise)."
+    )
+    discount_prior = graphene.Field(
+        TaxedMoney,
+        description=(
+            "The discount amount compared to prior price. Null if product "
+            "is not on sale or prior price was not provided in VariantChannelListing"
+        ),
+    )
+
+    # deprecated
+    discount_local_currency = graphene.Field(
+        TaxedMoney,
+        description="The discount amount in the local currency.",
+        deprecation_reason="Always returns `null`.",
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_PRODUCTS
+        description = "Represents base type for pricing information of a product."
+
+
+class VariantPricingInfo(BasePricingInfo):
+    price = graphene.Field(
+        TaxedMoney, description="The price, with any discount subtracted."
+    )
+    price_undiscounted = graphene.Field(
+        TaxedMoney, description="The price without any discount."
+    )
+    price_prior = graphene.Field(TaxedMoney, description="The price prior to discount.")
+
+    # deprecated
+    discount_local_currency = graphene.Field(
+        TaxedMoney,
+        description="The discount amount in the local currency.",
+        deprecation_reason="Always returns `null`.",
+    )
+    price_local_currency = graphene.Field(
+        TaxedMoney,
+        description="The discounted price in the local currency.",
+        deprecation_reason="Always returns `null`.",
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_PRODUCTS
+        description = "Represents availability of a variant in the storefront."
+
+
+class ProductPricingInfo(BasePricingInfo):
+    display_gross_prices = graphene.Boolean(
+        description="Determines whether displayed prices should include taxes.",
+        required=True,
+    )
+    price_range = graphene.Field(
+        TaxedMoneyRange,
+        description="The discounted price range of the product variants.",
+    )
+    price_range_undiscounted = graphene.Field(
+        TaxedMoneyRange,
+        description="The undiscounted price range of the product variants.",
+    )
+    price_range_prior = graphene.Field(
+        TaxedMoneyRange,
+        description="The prior price range of the product variants.",
+    )
+
+    # deprecated
+    price_range_local_currency = graphene.Field(
+        TaxedMoneyRange,
+        description=(
+            "The discounted price range of the product variants in the local currency."
+        ),
+        deprecation_reason="Always returns `null`.",
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_PRODUCTS
+        description = "Represents availability of a product in the storefront."
+
+
+def get_variant_quantity_available(
+    info,
+    variant: models.ProductVariant,
+    channel_slug: str | None,
+    site,
+    country_code=None,
+):
+    """Resolve the quantity of a variant available for sale in one checkout."""
+    with allow_writer_in_context(info.context):
+        global_quantity_limit_per_checkout = site.settings.limit_quantity_per_checkout
+
+    if variant.is_preorder_active():
+        channel_listing = VariantChannelListingByVariantIdAndChannelSlugLoader(
+            info.context
+        ).load((variant.id, channel_slug))
+
+        def calculate_available_per_channel(channel_listing):
+            if (
+                channel_listing
+                and channel_listing.preorder_quantity_threshold is not None
+            ):
+                if is_reservation_enabled(site.settings):
+                    quantity_reserved = (
+                        PreorderQuantityReservedByVariantChannelListingIdLoader(
+                            info.context
+                        ).load(channel_listing.id)
+                    )
+
+                    def calculate_available_channel_quantity_with_reservations(
+                        reserved_quantity,
+                    ):
+                        return max(
+                            min(
+                                channel_listing.preorder_quantity_threshold
+                                - channel_listing.preorder_quantity_allocated
+                                - reserved_quantity,
+                                global_quantity_limit_per_checkout or sys.maxsize,
+                            ),
+                            0,
+                        )
+
+                    return quantity_reserved.then(
+                        calculate_available_channel_quantity_with_reservations
+                    )
+
+                return min(
+                    channel_listing.preorder_quantity_threshold
+                    - channel_listing.preorder_quantity_allocated,
+                    global_quantity_limit_per_checkout or sys.maxsize,
+                )
+            if variant.preorder_global_threshold is not None:
+                variant_channel_listings = VariantChannelListingByVariantIdLoader(
+                    info.context
+                ).load(variant.id)
+
+                def calculate_available_global(variant_channel_listings):
+                    if not variant_channel_listings:
+                        return global_quantity_limit_per_checkout
+                    global_sold_units = sum(
+                        channel_listing.preorder_quantity_allocated
+                        for channel_listing in variant_channel_listings
+                    )
+
+                    available_quantity = variant.preorder_global_threshold
+                    available_quantity -= global_sold_units
+
+                    if is_reservation_enabled(site.settings):
+                        quantity_reserved = (
+                            PreorderQuantityReservedByVariantChannelListingIdLoader(
+                                info.context
+                            ).load_many(
+                                [listing.id for listing in variant_channel_listings]
+                            )
+                        )
+
+                        def calculate_available_global_quantity_with_reservations(
+                            reserved_quantities,
+                        ):
+                            return max(
+                                min(
+                                    variant.preorder_global_threshold
+                                    - global_sold_units
+                                    - sum(reserved_quantities),
+                                    global_quantity_limit_per_checkout or sys.maxsize,
+                                ),
+                                0,
+                            )
+
+                        return quantity_reserved.then(
+                            calculate_available_global_quantity_with_reservations
+                        )
+
+                    return min(
+                        variant.preorder_global_threshold - global_sold_units,
+                        global_quantity_limit_per_checkout or sys.maxsize,
+                    )
+
+                return variant_channel_listings.then(calculate_available_global)
+
+            return global_quantity_limit_per_checkout
+
+        return channel_listing.then(calculate_available_per_channel)
+
+    if not variant.track_inventory:
+        return global_quantity_limit_per_checkout
+
+    include_shipping_zones = site.settings.use_legacy_shipping_zone_stock_availability
+    if include_shipping_zones:
+        return AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
+            info.context
+        ).load((variant.id, country_code, channel_slug))
+    return AvailableQuantityByProductVariantIdAndChannelSlugLoader(info.context).load(
+        (variant.id, channel_slug)
+    )
+
+
+def get_variant_pricing_info(context, data, address):
+    """Build `VariantPricingInfo` from loaded listings, channel and tax class."""
+    (
+        product_channel_listing,
+        variant_channel_listing,
+        channel,
+        tax_class_id,
+    ) = data
+
+    if not variant_channel_listing or not product_channel_listing:
+        return None
+    country_code = get_active_country(channel, address_data=address)
+
+    def load_tax_country_exceptions(tax_config):
+        def load_default_tax_rate(tax_configs_per_country):
+            def calculate_pricing_info(data):
+                country_rates, default_country_rate_obj = data
+
+                tax_config_country = next(
+                    (
+                        tc
+                        for tc in tax_configs_per_country
+                        if tc.country.code == country_code
+                    ),
+                    None,
+                )
+                tax_calculation_strategy = get_tax_calculation_strategy(
+                    tax_config, tax_config_country
+                )
+
+                default_tax_rate = (
+                    default_country_rate_obj.rate
+                    if default_country_rate_obj
+                    else Decimal(0)
+                )
+                tax_rate = get_tax_rate_for_country(
+                    country_rates, default_tax_rate, country_code
+                )
+
+                availability = get_variant_availability(
+                    variant_channel_listing=variant_channel_listing,
+                    product_channel_listing=product_channel_listing,
+                    prices_entered_with_tax=tax_config.prices_entered_with_tax,
+                    tax_calculation_strategy=tax_calculation_strategy,
+                    tax_rate=tax_rate,
+                )
+                return (
+                    VariantPricingInfo(**asdict(availability)) if availability else None
+                )
+
+            country_rates = (
+                TaxClassCountryRateByTaxClassIDLoader(context).load(tax_class_id)
+                if tax_class_id
+                else Promise.resolve([])
+            )
+            default_rate = TaxClassDefaultRateByCountryLoader(context).load(
+                country_code
+            )
+            return Promise.all([country_rates, default_rate]).then(
+                calculate_pricing_info
+            )
+
+        return (
+            TaxConfigurationPerCountryByTaxConfigurationIDLoader(context)
+            .load(tax_config.id)
+            .then(load_default_tax_rate)
+        )
+
+    return (
+        TaxConfigurationByChannelId(context)
+        .load(channel.id)
+        .then(load_tax_country_exceptions)
+    )

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -21,11 +21,13 @@ from ....tax.utils import (
 from ...account import types as account_types
 from ...channel.dataloaders.by_self import ChannelByIdLoader
 from ...channel.types import Channel
+from ...core.descriptions import ADDED_IN_323
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.fields import PermissionsField
 from ...core.scalars import Date, DateTime
 from ...core.tracing import traced_resolver
 from ...core.types import BaseObjectType, ModelObjectType
+from ...site.dataloaders import load_site_callback
 from ...tax.dataloaders import (
     TaxClassCountryRateByTaxClassIDLoader,
     TaxClassDefaultRateByCountryLoader,
@@ -33,7 +35,17 @@ from ...tax.dataloaders import (
     TaxConfigurationByChannelId,
     TaxConfigurationPerCountryByTaxConfigurationIDLoader,
 )
-from ..dataloaders.products import VariantChannelListingsByProductIdLoader
+from ..dataloaders.products import (
+    ProductChannelListingByProductIdAndChannelSlugLoader,
+    ProductVariantByIdLoader,
+    VariantChannelListingsByProductIdLoader,
+)
+from .availability import (
+    ProductPricingInfo,
+    VariantPricingInfo,
+    get_variant_pricing_info,
+    get_variant_quantity_available,
+)
 
 
 class Margin(BaseObjectType):
@@ -94,7 +106,7 @@ class ProductChannelListing(ModelObjectType[models.ProductChannelListing]):
         )
     )
     pricing = graphene.Field(
-        "saleor.graphql.product.types.products.ProductPricingInfo",
+        ProductPricingInfo,
         address=graphene.Argument(
             account_types.AddressInput,
             description=(
@@ -248,8 +260,6 @@ class ProductChannelListing(ModelObjectType[models.ProductChannelListing]):
                                 tax_calculation_strategy=tax_calculation_strategy,
                                 tax_rate=tax_rate,
                             )
-                            from .products import ProductPricingInfo
-
                             pricing_info = asdict(availability)
                             pricing_info["display_gross_prices"] = display_gross_prices
                             return ProductPricingInfo(**pricing_info)
@@ -308,10 +318,50 @@ class ProductVariantChannelListing(
         "promotion information required by customer protection laws such as EU Omnibus "
         "directive.\n\n Warning: This field is not updated automatically. Use Channel Listings mutation to update it manually.",
     )
+    discounted_price = graphene.Field(
+        Money,
+        description="The price of the variant with promotions applied." + ADDED_IN_323,
+    )
     margin = PermissionsField(
         graphene.Int,
         description="Gross margin percentage value.",
         permissions=[ProductPermissions.MANAGE_PRODUCTS],
+    )
+    pricing = graphene.Field(
+        VariantPricingInfo,
+        address=graphene.Argument(
+            account_types.AddressInput,
+            description=(
+                "Destination address used to determine the country the taxes are "
+                "calculated for. If address is empty, the channel's default country "
+                "is used."
+            ),
+        ),
+        description=(
+            "Lists the storefront variant's pricing in this channel, the current "
+            "price and discounts, only meant for displaying."
+        )
+        + ADDED_IN_323,
+    )
+    quantity_available = graphene.Int(
+        address=graphene.Argument(
+            account_types.AddressInput,
+            description=(
+                "Destination address used to find warehouses where stock availability "
+                "for this variant is checked. If address is empty, uses "
+                "`Shop.companyAddress` or fallbacks to server's "
+                "`settings.DEFAULT_COUNTRY` configuration. "
+                "When `Shop.useLegacyShippingZoneStockAvailability` is disabled, "
+                "this argument is ignored - stock availability is determined by the "
+                "direct warehouse-channel link instead of shipping zones."
+            ),
+        ),
+        description=(
+            "Quantity of a variant available for sale in one checkout in this "
+            "channel. Field value will be `null` when no `limitQuantityPerCheckout` "
+            "in global settings has been set, and the variant stocks are not tracked."
+        )
+        + ADDED_IN_323,
     )
 
     class Meta:
@@ -326,6 +376,53 @@ class ProductVariantChannelListing(
     @staticmethod
     def resolve_margin(root: models.ProductVariantChannelListing, _info):
         return get_margin_for_variant_channel_listing(root)
+
+    @staticmethod
+    def resolve_pricing(
+        root: models.ProductVariantChannelListing, info, *, address=None
+    ):
+        context = info.context
+
+        def load_pricing(data):
+            variant, channel = data
+            product_channel_listing = (
+                ProductChannelListingByProductIdAndChannelSlugLoader(context).load(
+                    (variant.product_id, channel.slug)
+                )
+            )
+            tax_class_id = TaxClassIdByProductIdLoader(context).load(variant.product_id)
+            return Promise.all([product_channel_listing, tax_class_id]).then(
+                lambda loaded: get_variant_pricing_info(
+                    context, (loaded[0], root, channel, loaded[1]), address
+                )
+            )
+
+        return Promise.all(
+            [
+                ProductVariantByIdLoader(context).load(root.variant_id),
+                ChannelByIdLoader(context).load(root.channel_id),
+            ]
+        ).then(load_pricing)
+
+    @staticmethod
+    @load_site_callback
+    def resolve_quantity_available(
+        root: models.ProductVariantChannelListing, info, site, address=None
+    ):
+        country_code = address.country if address is not None else None
+
+        def load_quantity_available(data):
+            variant, channel = data
+            return get_variant_quantity_available(
+                info, variant, channel.slug, site, country_code
+            )
+
+        return Promise.all(
+            [
+                ProductVariantByIdLoader(info.context).load(root.variant_id),
+                ChannelByIdLoader(info.context).load(root.channel_id),
+            ]
+        ).then(load_quantity_available)
 
 
 class CollectionChannelListing(ModelObjectType[models.CollectionChannelListing]):

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -1,4 +1,3 @@
-import sys
 from collections import defaultdict
 from dataclasses import asdict
 from decimal import Decimal
@@ -21,7 +20,6 @@ from ....product.models import ALL_PRODUCTS_PERMISSIONS
 from ....product.utils import calculate_revenue_for_variant
 from ....product.utils.availability import (
     get_product_availability,
-    get_variant_availability,
 )
 from ....product.utils.variants import get_variant_selection_attributes
 from ....tax.utils import (
@@ -35,7 +33,6 @@ from ....thumbnail.utils import (
     get_thumbnail_format,
     get_thumbnail_size,
 )
-from ....warehouse.reservations import is_reservation_enabled
 from ...account import types as account_types
 from ...account.enums import CountryCodeEnum
 from ...attribute.filters import (
@@ -87,7 +84,6 @@ from ...core.types import (
     ModelObjectType,
     NonNullList,
     TaxedMoney,
-    TaxedMoneyRange,
     TaxType,
     ThumbnailField,
     Weight,
@@ -122,7 +118,6 @@ from ...utils.filters import reporting_period_to_date
 from ...warehouse.dataloaders import (
     AvailableQuantityByProductVariantIdAndChannelSlugLoader,
     AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader,
-    PreorderQuantityReservedByVariantChannelListingIdLoader,
     StocksByProductVariantIdLoader,
     StocksWithAvailableQuantityByProductVariantIdAndChannelSlugLoader,
     StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader,
@@ -165,6 +160,12 @@ from ..resolvers import (
     resolve_variant_attributes,
 )
 from ..sorters import MediaSortingInput, ProductVariantSortingInput
+from .availability import (
+    ProductPricingInfo,
+    VariantPricingInfo,
+    get_variant_pricing_info,
+    get_variant_quantity_available,
+)
 from .channels import ProductChannelListing, ProductVariantChannelListing
 
 destination_address_argument = graphene.Argument(
@@ -190,89 +191,6 @@ deprecated_destination_address_argument = graphene.Argument(
         + DEPRECATED_IN_3X_INPUT
     ),
 )
-
-
-class BasePricingInfo(BaseObjectType):
-    on_sale = graphene.Boolean(description="Whether it is in sale or not.")
-    discount = graphene.Field(
-        TaxedMoney, description="The discount amount if in sale (null otherwise)."
-    )
-    discount_prior = graphene.Field(
-        TaxedMoney,
-        description=(
-            "The discount amount compared to prior price. Null if product "
-            "is not on sale or prior price was not provided in VariantChannelListing"
-        ),
-    )
-
-    # deprecated
-    discount_local_currency = graphene.Field(
-        TaxedMoney,
-        description="The discount amount in the local currency.",
-        deprecation_reason="Always returns `null`.",
-    )
-
-    class Meta:
-        doc_category = DOC_CATEGORY_PRODUCTS
-        description = "Represents base type for pricing information of a product."
-
-
-class VariantPricingInfo(BasePricingInfo):
-    price = graphene.Field(
-        TaxedMoney, description="The price, with any discount subtracted."
-    )
-    price_undiscounted = graphene.Field(
-        TaxedMoney, description="The price without any discount."
-    )
-    price_prior = graphene.Field(TaxedMoney, description="The price prior to discount.")
-
-    # deprecated
-    discount_local_currency = graphene.Field(
-        TaxedMoney,
-        description="The discount amount in the local currency.",
-        deprecation_reason="Always returns `null`.",
-    )
-    price_local_currency = graphene.Field(
-        TaxedMoney,
-        description="The discounted price in the local currency.",
-        deprecation_reason="Always returns `null`.",
-    )
-
-    class Meta:
-        doc_category = DOC_CATEGORY_PRODUCTS
-        description = "Represents availability of a variant in the storefront."
-
-
-class ProductPricingInfo(BasePricingInfo):
-    display_gross_prices = graphene.Boolean(
-        description="Determines whether displayed prices should include taxes.",
-        required=True,
-    )
-    price_range = graphene.Field(
-        TaxedMoneyRange,
-        description="The discounted price range of the product variants.",
-    )
-    price_range_undiscounted = graphene.Field(
-        TaxedMoneyRange,
-        description="The undiscounted price range of the product variants.",
-    )
-    price_range_prior = graphene.Field(
-        TaxedMoneyRange,
-        description="The prior price range of the product variants.",
-    )
-
-    # deprecated
-    price_range_local_currency = graphene.Field(
-        TaxedMoneyRange,
-        description=(
-            "The discounted price range of the product variants in the local currency."
-        ),
-        deprecation_reason="Always returns `null`.",
-    )
-
-    class Meta:
-        doc_category = DOC_CATEGORY_PRODUCTS
-        description = "Represents availability of a product in the storefront."
 
 
 @federated_entity("id channel")
@@ -488,120 +406,13 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
     ):
         if address is not None:
             country_code = address.country
-        channel_slug = str(root.channel_slug) if root.channel_slug else None
-
-        with allow_writer_in_context(info.context):
-            global_quantity_limit_per_checkout = (
-                site.settings.limit_quantity_per_checkout
-            )
-
-        if root.node.is_preorder_active():
-            variant = root.node
-            channel_listing = VariantChannelListingByVariantIdAndChannelSlugLoader(
-                info.context
-            ).load((variant.id, channel_slug))
-
-            def calculate_available_per_channel(channel_listing):
-                if (
-                    channel_listing
-                    and channel_listing.preorder_quantity_threshold is not None
-                ):
-                    if is_reservation_enabled(site.settings):
-                        quantity_reserved = (
-                            PreorderQuantityReservedByVariantChannelListingIdLoader(
-                                info.context
-                            ).load(channel_listing.id)
-                        )
-
-                        def calculate_available_channel_quantity_with_reservations(
-                            reserved_quantity,
-                        ):
-                            return max(
-                                min(
-                                    channel_listing.preorder_quantity_threshold
-                                    - channel_listing.preorder_quantity_allocated
-                                    - reserved_quantity,
-                                    global_quantity_limit_per_checkout or sys.maxsize,
-                                ),
-                                0,
-                            )
-
-                        return quantity_reserved.then(
-                            calculate_available_channel_quantity_with_reservations
-                        )
-
-                    return min(
-                        channel_listing.preorder_quantity_threshold
-                        - channel_listing.preorder_quantity_allocated,
-                        global_quantity_limit_per_checkout or sys.maxsize,
-                    )
-                if variant.preorder_global_threshold is not None:
-                    variant_channel_listings = VariantChannelListingByVariantIdLoader(
-                        info.context
-                    ).load(variant.id)
-
-                    def calculate_available_global(variant_channel_listings):
-                        if not variant_channel_listings:
-                            return global_quantity_limit_per_checkout
-                        global_sold_units = sum(
-                            channel_listing.preorder_quantity_allocated
-                            for channel_listing in variant_channel_listings
-                        )
-
-                        available_quantity = variant.preorder_global_threshold
-                        available_quantity -= global_sold_units
-
-                        if is_reservation_enabled(site.settings):
-                            quantity_reserved = (
-                                PreorderQuantityReservedByVariantChannelListingIdLoader(
-                                    info.context
-                                ).load_many(
-                                    [listing.id for listing in variant_channel_listings]
-                                )
-                            )
-
-                            def calculate_available_global_quantity_with_reservations(
-                                reserved_quantities,
-                            ):
-                                return max(
-                                    min(
-                                        variant.preorder_global_threshold
-                                        - global_sold_units
-                                        - sum(reserved_quantities),
-                                        global_quantity_limit_per_checkout
-                                        or sys.maxsize,
-                                    ),
-                                    0,
-                                )
-
-                            return quantity_reserved.then(
-                                calculate_available_global_quantity_with_reservations
-                            )
-
-                        return min(
-                            variant.preorder_global_threshold - global_sold_units,
-                            global_quantity_limit_per_checkout or sys.maxsize,
-                        )
-
-                    return variant_channel_listings.then(calculate_available_global)
-
-                return global_quantity_limit_per_checkout
-
-            return channel_listing.then(calculate_available_per_channel)
-
-        if not root.node.track_inventory:
-            return global_quantity_limit_per_checkout
-
-        include_shipping_zones = (
-            site.settings.use_legacy_shipping_zone_stock_availability
+        return get_variant_quantity_available(
+            info,
+            root.node,
+            str(root.channel_slug) if root.channel_slug else None,
+            site,
+            country_code,
         )
-        if include_shipping_zones:
-            return AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
-                info.context
-            ).load((root.node.id, country_code, channel_slug))
-        return AvailableQuantityByProductVariantIdAndChannelSlugLoader(
-            info.context
-        ).load((root.node.id, channel_slug))
 
     @classmethod
     def resolve_assigned_attribute(
@@ -651,102 +462,18 @@ class ProductVariant(ChannelContextType[models.ProductVariant]):
         channel_slug = str(root.channel_slug)
         context = info.context
 
-        product_channel_listing = ProductChannelListingByProductIdAndChannelSlugLoader(
-            context
-        ).load((root.node.product_id, channel_slug))
-        variant_channel_listing = VariantChannelListingByVariantIdAndChannelSlugLoader(
-            context
-        ).load((root.node.id, channel_slug))
-        channel = ChannelBySlugLoader(context).load(channel_slug)
-        tax_class_id_loader = TaxClassIdByProductIdLoader(context).load(
-            root.node.product_id
-        )
-
-        def load_tax_configuration(data):
-            (
-                product_channel_listing,
-                variant_channel_listing,
-                channel,
-                tax_class_id,
-            ) = data
-
-            if not variant_channel_listing or not product_channel_listing:
-                return None
-            country_code = get_active_country(channel, address_data=address)
-
-            def load_tax_country_exceptions(tax_config):
-                def load_default_tax_rate(tax_configs_per_country):
-                    def calculate_pricing_info(data):
-                        country_rates, default_country_rate_obj = data
-
-                        tax_config_country = next(
-                            (
-                                tc
-                                for tc in tax_configs_per_country
-                                if tc.country.code == country_code
-                            ),
-                            None,
-                        )
-                        tax_calculation_strategy = get_tax_calculation_strategy(
-                            tax_config, tax_config_country
-                        )
-
-                        default_tax_rate = (
-                            default_country_rate_obj.rate
-                            if default_country_rate_obj
-                            else Decimal(0)
-                        )
-                        tax_rate = get_tax_rate_for_country(
-                            country_rates, default_tax_rate, country_code
-                        )
-
-                        availability = get_variant_availability(
-                            variant_channel_listing=variant_channel_listing,
-                            product_channel_listing=product_channel_listing,
-                            prices_entered_with_tax=tax_config.prices_entered_with_tax,
-                            tax_calculation_strategy=tax_calculation_strategy,
-                            tax_rate=tax_rate,
-                        )
-                        return (
-                            VariantPricingInfo(**asdict(availability))
-                            if availability
-                            else None
-                        )
-
-                    country_rates = (
-                        TaxClassCountryRateByTaxClassIDLoader(context).load(
-                            tax_class_id
-                        )
-                        if tax_class_id
-                        else Promise.resolve([])
-                    )
-                    default_rate = TaxClassDefaultRateByCountryLoader(context).load(
-                        country_code
-                    )
-                    return Promise.all([country_rates, default_rate]).then(
-                        calculate_pricing_info
-                    )
-
-                return (
-                    TaxConfigurationPerCountryByTaxConfigurationIDLoader(context)
-                    .load(tax_config.id)
-                    .then(load_default_tax_rate)
-                )
-
-            return (
-                TaxConfigurationByChannelId(context)
-                .load(channel.id)
-                .then(load_tax_country_exceptions)
-            )
-
         return Promise.all(
             [
-                product_channel_listing,
-                variant_channel_listing,
-                channel,
-                tax_class_id_loader,
+                ProductChannelListingByProductIdAndChannelSlugLoader(context).load(
+                    (root.node.product_id, channel_slug)
+                ),
+                VariantChannelListingByVariantIdAndChannelSlugLoader(context).load(
+                    (root.node.id, channel_slug)
+                ),
+                ChannelBySlugLoader(context).load(channel_slug),
+                TaxClassIdByProductIdLoader(context).load(root.node.product_id),
             ]
-        ).then(load_tax_configuration)
+        ).then(lambda data: get_variant_pricing_info(context, data, address))
 
     @staticmethod
     def resolve_product(root: ChannelContext[models.ProductVariant], info):

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -380,6 +380,8 @@ COST_MAP = {
     },
     "ProductVariantChannelListing": {
         "channel": {"complexity": 1},
+        "pricing": {"complexity": 1},
+        "quantityAvailable": {"complexity": 1},
     },
     "Sale": {
         "categories": {"complexity": 1, "multipliers": ["first", "last"]},

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7482,11 +7482,42 @@ type ProductVariantChannelListing implements Node @doc(category: "Products") {
   priorPrice: Money
 
   """
+  The price of the variant with promotions applied.
+  
+  Added in Saleor 3.23.
+  """
+  discountedPrice: Money
+
+  """
   Gross margin percentage value.
   
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   margin: Int
+
+  """
+  Lists the storefront variant's pricing in this channel, the current price and discounts, only meant for displaying.
+  
+  Added in Saleor 3.23.
+  """
+  pricing(
+    """
+    Destination address used to determine the country the taxes are calculated for. If address is empty, the channel's default country is used.
+    """
+    address: AddressInput
+  ): VariantPricingInfo
+
+  """
+  Quantity of a variant available for sale in one checkout in this channel. Field value will be `null` when no `limitQuantityPerCheckout` in global settings has been set, and the variant stocks are not tracked.
+  
+  Added in Saleor 3.23.
+  """
+  quantityAvailable(
+    """
+    Destination address used to find warehouses where stock availability for this variant is checked. If address is empty, uses `Shop.companyAddress` or fallbacks to server's `settings.DEFAULT_COUNTRY` configuration. When `Shop.useLegacyShippingZoneStockAvailability` is disabled, this argument is ignored - stock availability is determined by the direct warehouse-channel link instead of shipping zones.
+    """
+    address: AddressInput
+  ): Int
 }
 
 """Represents channel."""


### PR DESCRIPTION
…hannelListing

ProductVariant.pricing and ProductVariant.quantityAvailable resolve from the channel of the root query, so a client that needs per-channel prices and availability for every channel — a product feed, for example — has to walk the whole catalog once per channel, even though description, media, attributes and category are identical across all of them.

The new fields resolve for the channel of the listing itself, so the same data can be read in a single channel-less walk:

    productVariants(first: 100) {
      edges { node { channelListings {
        channel { slug } discountedPrice { amount }
        pricing { price { gross { amount } } } quantityAvailable
      } } }
    }

discountedPrice was already stored in ProductVariantChannelListing.discounted_price_amount and just never exposed; ProductChannelListing.discountedPrice is its analogue. ProductChannelListing.pricing is the precedent for resolving pricing from a listing root.

To avoid duplicating the resolution logic, the tax pipeline and the stock availability logic are extracted out of ProductVariant.resolve_pricing and ProductVariant.resolve_quantity_available into get_variant_pricing_info and get_variant_quantity_available. Both the channel-scoped and the listing-scoped fields call them, so the two stay identical by construction.

Those helpers, together with BasePricingInfo, VariantPricingInfo and ProductPricingInfo, live in a new types/availability.py module. products.py imports channels.py, so keeping them in products.py would have forced channels.py to import it from inside the resolver bodies. The new module imports neither, which also removes the pre-existing local import in ProductChannelListing.resolve_pricing and lets both lazy string type references become direct ones. Moving the graphene types does not change the schema.

test_product_variant_price_no_address patched get_tax_rate_for_country on the products module; the variant pricing path no longer lives there, so it now patches types.availability. The patch in test_product_channel_listings_queries still targets products, which is correct — it exercises Product.pricing.

The new fields are not individually permission-gated: their siblings on the same type (price, costPrice, priorPrice) are not either, and the type is only reachable through ProductVariant.channelListings, which already requires AUTHENTICATED_APP or AUTHENTICATED_STAFF_USER.
