### PR TITLE
Fix draft order shipping price left at 0

### DIFF
--- a/saleor/graphql/order/mutations/utils.py
+++ b/saleor/graphql/order/mutations/utils.py
@@ -8,13 +8,15 @@ from promise import Promise
 from ....checkout.fetch import get_variant_channel_listing
 from ....core.taxes import zero_money, zero_taxed_money
 from ....core.utils import metadata_manager
-from ....discount import VoucherType
 from ....discount.interface import VariantPromotionRuleInfo, fetch_variant_rules_info
-from ....discount.utils.manual_discount import apply_discount_to_value
 from ....order import ORDER_EDITABLE_STATUS, OrderStatus, events, models
 from ....order.actions import call_order_event
 from ....order.error_codes import OrderErrorCode
-from ....order.utils import invalidate_order_prices
+from ....order.utils import (
+    apply_shipping_voucher_to_base_price,
+    get_undiscounted_base_shipping_price,
+    invalidate_order_prices,
+)
 from ....payment import PaymentError
 from ....payment import models as payment_models
 from ....product import models as product_models
@@ -150,47 +152,18 @@ class ShippingMethodUpdateMixin:
         return shipping_channel_listing
 
     @classmethod
-    def update_shipping_price(cls, order, shipping_channel_listing):
-        cls.assign_shipping_price(order, shipping_channel_listing)
-        cls.update_shipping_discount(order)
-
-    @classmethod
     def assign_shipping_price(cls, order, shipping_channel_listing):
-        if not shipping_channel_listing:
-            order.base_shipping_price = zero_money(order.currency)
-            order.undiscounted_base_shipping_price = zero_money(order.currency)
-            return
-
-        if (
-            order.shipping_method
-            and order.shipping_address
-            and order.is_shipping_required()
-        ):
-            undiscounted_shipping_price = shipping_channel_listing.price
-            order.undiscounted_base_shipping_price = undiscounted_shipping_price
-            order.base_shipping_price = undiscounted_shipping_price
-
-        else:
-            order.base_shipping_price = zero_money(order.currency)
-            order.undiscounted_base_shipping_price = zero_money(order.currency)
+        shipping_price = get_undiscounted_base_shipping_price(
+            order,
+            shipping_channel_listing,
+            shipping_required=order.is_shipping_required(),
+        )
+        order.undiscounted_base_shipping_price = shipping_price
+        order.base_shipping_price = shipping_price
 
     @classmethod
     def update_shipping_discount(cls, order: models.Order):
-        if shipping_discount := order.discounts.filter(
-            voucher__type=VoucherType.SHIPPING
-        ).first():
-            undiscounted_shipping_price = order.undiscounted_base_shipping_price
-            shipping_price = apply_discount_to_value(
-                value=shipping_discount.value,
-                value_type=shipping_discount.value_type,
-                currency=order.currency,
-                price_to_discount=undiscounted_shipping_price,
-            )
-            order.base_shipping_price = shipping_price
-            shipping_discount_amount = undiscounted_shipping_price - shipping_price
-            if shipping_discount.amount != shipping_discount_amount:
-                shipping_discount.amount = shipping_discount_amount
-                shipping_discount.save(update_fields=["amount_value"])
+        apply_shipping_voucher_to_base_price(order)
 
     @classmethod
     def process_shipping_method(

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -4002,3 +4002,83 @@ def test_draft_order_update_with_inactive_voucher_code(
     assert len(errors) == 1
     assert errors[0]["code"] == OrderErrorCode.INVALID_VOUCHER_CODE.name
     assert errors[0]["field"] == "voucherCode"
+
+
+DRAFT_ORDER_UPDATE_SHIPPING_ADDRESS_MUTATION = """
+    mutation draftUpdate($id: ID!, $shippingAddress: AddressInput!){
+        draftOrderUpdate(
+            id: $id,
+            input: {
+                shippingAddress: $shippingAddress
+            }) {
+            errors {
+                field
+                message
+                code
+            }
+            order {
+                shippingPrice {
+                    net {
+                        amount
+                    }
+                }
+                undiscountedShippingPrice {
+                    amount
+                }
+            }
+        }
+    }
+"""
+
+
+def test_draft_order_update_shipping_price_set_when_address_added_after_method(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    shipping_method,
+    graphql_address_data,
+):
+    """Shipping price must follow a shipping address added after the method."""
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = draft_order
+    order.shipping_method = None
+    order.shipping_address = None
+    order.base_shipping_price_amount = Decimal(0)
+    order.undiscounted_base_shipping_price_amount = Decimal(0)
+    order.save(
+        update_fields=[
+            "shipping_method",
+            "shipping_address",
+            "base_shipping_price_amount",
+            "undiscounted_base_shipping_price_amount",
+        ]
+    )
+    assert order.is_shipping_required() is True
+
+    order_id = graphene.Node.to_global_id("Order", order.pk)
+    method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.pk)
+    shipping_price = shipping_method.channel_listings.get(channel=order.channel).price
+
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_UPDATE_SHIPPING_METHOD_MUTATION,
+        {"id": order_id, "shippingMethod": method_id},
+    )
+    assert get_graphql_content(response)["data"]["draftOrderUpdate"]["errors"] == []
+
+    # when
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_UPDATE_SHIPPING_ADDRESS_MUTATION,
+        {"id": order_id, "shippingAddress": graphql_address_data},
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderUpdate"]
+    assert data["errors"] == []
+    assert data["order"]["shippingPrice"]["net"]["amount"] == shipping_price.amount
+    assert data["order"]["undiscountedShippingPrice"]["amount"] == shipping_price.amount
+
+    order.refresh_from_db()
+    assert order.undiscounted_base_shipping_price == shipping_price
+    assert order.base_shipping_price == shipping_price

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -2246,3 +2246,99 @@ def test_order_lines_create_sets_product_type_id_for_order_line(
     order.refresh_from_db()
     assert len(order.lines.all()) == 1
     assert order.lines.first().product_type_id == expected_product_type_id
+
+
+ORDER_LINES_CREATE_SHIPPING_PRICE_MUTATION = """
+    mutation OrderLinesCreate($orderId: ID!, $variantId: ID!, $quantity: Int!) {
+        orderLinesCreate(
+            id: $orderId,
+            input: [{variantId: $variantId, quantity: $quantity}]
+        ) {
+            errors {
+                field
+                code
+                message
+            }
+            order {
+                shippingPrice {
+                    net {
+                        amount
+                    }
+                }
+                undiscountedShippingPrice {
+                    amount
+                }
+            }
+        }
+    }
+"""
+
+DRAFT_ORDER_UPDATE_SHIPPING_METHOD_MUTATION = """
+    mutation draftUpdate($id: ID!, $shippingMethod: ID) {
+        draftOrderUpdate(id: $id, input: {shippingMethod: $shippingMethod}) {
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+
+def test_shipping_price_set_when_line_added_after_shipping_method(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    shipping_method,
+    variant_with_many_stocks,
+):
+    """Shipping price must follow a shippable line added after the method."""
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = draft_order
+    order.lines.all().delete()
+    order.shipping_method = None
+    order.base_shipping_price_amount = Decimal(0)
+    order.undiscounted_base_shipping_price_amount = Decimal(0)
+    order.save(
+        update_fields=[
+            "shipping_method",
+            "base_shipping_price_amount",
+            "undiscounted_base_shipping_price_amount",
+        ]
+    )
+    assert order.shipping_address is not None
+
+    order_id = graphene.Node.to_global_id("Order", order.pk)
+    method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.pk)
+    variant = variant_with_many_stocks
+    assert variant.is_shipping_required() is True
+    shipping_price = shipping_method.channel_listings.get(channel=order.channel).price
+
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_UPDATE_SHIPPING_METHOD_MUTATION,
+        {"id": order_id, "shippingMethod": method_id},
+    )
+    assert get_graphql_content(response)["data"]["draftOrderUpdate"]["errors"] == []
+
+    # when
+    response = staff_api_client.post_graphql(
+        ORDER_LINES_CREATE_SHIPPING_PRICE_MUTATION,
+        {
+            "orderId": order_id,
+            "variantId": graphene.Node.to_global_id("ProductVariant", variant.pk),
+            "quantity": 1,
+        },
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderLinesCreate"]
+    assert data["errors"] == []
+    assert data["order"]["shippingPrice"]["net"]["amount"] == shipping_price.amount
+    assert data["order"]["undiscountedShippingPrice"]["amount"] == shipping_price.amount
+
+    order.refresh_from_db()
+    assert order.undiscounted_base_shipping_price == shipping_price
+    assert order.base_shipping_price == shipping_price

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -58,6 +58,7 @@ from .utils import (
     calculate_draft_order_line_price_expiration_date,
     log_address_if_validation_skipped_for_order,
     order_info_for_logs,
+    refresh_order_base_shipping_price,
 )
 
 if TYPE_CHECKING:
@@ -149,6 +150,7 @@ def process_order_prices(
                             "shipping_price_net_amount",
                             "shipping_price_gross_amount",
                             "base_shipping_price_amount",
+                            "undiscounted_base_shipping_price_amount",
                             "shipping_tax_rate",
                             "should_refresh_prices",
                             "tax_error",
@@ -171,6 +173,10 @@ def process_order_prices(
             return order, lines
 
     with allow_writer_for_default_connection(database_connection_name):
+        refresh_order_base_shipping_price(
+            order, lines, database_connection_name=database_connection_name
+        )
+
         calculate_prices(
             order,
             lines,

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -8,6 +8,7 @@ from prices import Money, TaxedMoney
 
 from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...checkout.models import Checkout
+from ...core.taxes import zero_money
 from ...discount import DiscountType, DiscountValueType
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCardEvent
@@ -27,6 +28,7 @@ from ..utils import (
     get_total_order_discount_excluding_shipping,
     match_orders_with_new_user,
     order_info_for_logs,
+    refresh_order_base_shipping_price,
     store_user_addresses_from_draft_order,
     update_order_display_gross_prices,
 )
@@ -801,3 +803,89 @@ def test_store_user_addresses_from_draft_order_only_draft_save_billing_address_t
     order.refresh_from_db()
     assert order.draft_save_shipping_address is None
     assert order.draft_save_billing_address is None
+
+
+def test_refresh_order_base_shipping_price_keeps_shipping_voucher_discount(
+    draft_order, shipping_method, voucher_shipping_type
+):
+    # given
+    order = draft_order
+    order.shipping_method = shipping_method
+    order.base_shipping_price_amount = Decimal(0)
+    order.undiscounted_base_shipping_price_amount = Decimal(0)
+    order.save(
+        update_fields=[
+            "shipping_method",
+            "base_shipping_price_amount",
+            "undiscounted_base_shipping_price_amount",
+        ]
+    )
+    shipping_price = shipping_method.channel_listings.get(channel=order.channel).price
+    discount_value = Decimal(4)
+    order.discounts.create(
+        type=DiscountType.VOUCHER,
+        value_type=DiscountValueType.FIXED,
+        value=discount_value,
+        amount_value=Decimal(0),
+        currency=order.currency,
+        voucher=voucher_shipping_type,
+    )
+
+    # when
+    refresh_order_base_shipping_price(order, order.lines.all())
+
+    # then
+    discount_amount = Money(discount_value, order.currency)
+    assert order.undiscounted_base_shipping_price == shipping_price
+    assert order.base_shipping_price == shipping_price - discount_amount
+
+    discount = order.discounts.get()
+    assert discount.amount == discount_amount
+
+
+def test_refresh_order_base_shipping_price_no_line_requires_shipping(
+    draft_order, shipping_method
+):
+    # given
+    order = draft_order
+    order.shipping_method = shipping_method
+    order.save(update_fields=["shipping_method"])
+    order.lines.update(is_shipping_required=False)
+    assert order.is_shipping_required() is False
+
+    # when
+    refresh_order_base_shipping_price(order, order.lines.all())
+
+    # then
+    assert order.undiscounted_base_shipping_price == zero_money(order.currency)
+    assert order.base_shipping_price == zero_money(order.currency)
+
+
+def test_refresh_order_base_shipping_price_skips_non_draft_order(
+    order_with_lines, shipping_method
+):
+    """An order the customer already placed keeps the price they agreed to."""
+    # given
+    order = order_with_lines
+    agreed_price = Money(Decimal("3.00"), order.currency)
+    order.status = OrderStatus.UNCONFIRMED
+    order.shipping_method = shipping_method
+    order.base_shipping_price = agreed_price
+    order.undiscounted_base_shipping_price = agreed_price
+    order.save(
+        update_fields=[
+            "status",
+            "shipping_method",
+            "base_shipping_price_amount",
+            "undiscounted_base_shipping_price_amount",
+        ]
+    )
+    listing_price = shipping_method.channel_listings.get(channel=order.channel).price
+    assert listing_price != agreed_price
+
+    # when
+    refresh_order_base_shipping_price(order, order.lines.all())
+
+    # then
+    assert order.undiscounted_base_shipping_price == agreed_price
+    assert order.base_shipping_price == agreed_price

--- a/saleor/order/tests/webhooks/subscriptions/test_order_calculate_taxes.py
+++ b/saleor/order/tests/webhooks/subscriptions/test_order_calculate_taxes.py
@@ -299,6 +299,9 @@ def test_draft_order_calculate_taxes_entire_order_voucher(
     order = draft_order_with_voucher
     webhook = subscription_order_calculate_taxes
     expected_shipping_price = Money("2.00", order.currency)
+    order.shipping_method.channel_listings.filter(channel=order.channel).update(
+        price_amount=expected_shipping_price.amount
+    )
 
     voucher = draft_order_with_voucher.voucher
     voucher.type = VoucherType.ENTIRE_ORDER
@@ -396,6 +399,9 @@ def test_draft_order_calculate_taxes_apply_once_per_order_voucher(
     order = draft_order_with_voucher
     webhook = subscription_order_calculate_taxes
     expected_shipping_price = Money("2.00", order.currency)
+    order.shipping_method.channel_listings.filter(channel=order.channel).update(
+        price_amount=expected_shipping_price.amount
+    )
 
     voucher = draft_order_with_voucher.voucher
     voucher.type = VoucherType.ENTIRE_ORDER

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -45,6 +45,7 @@ from ..giftcard.models import GiftCard
 from ..giftcard.search import mark_gift_cards_search_index_as_dirty
 from ..payment import TransactionEventType
 from ..payment.model_helpers import get_total_authorized
+from ..shipping.models import ShippingMethodChannelListing
 from ..tax.utils import get_display_gross_prices, get_tax_class_kwargs_for_order_line
 from ..warehouse.management import (
     decrease_allocations,
@@ -106,6 +107,90 @@ def invalidate_order_prices(order: Order, *, save: bool = False) -> None:
 
     if save:
         order.save(update_fields=["should_refresh_prices", "updated_at"])
+
+
+def get_undiscounted_base_shipping_price(
+    order: Order,
+    shipping_channel_listing: Optional["ShippingMethodChannelListing"],
+    shipping_required: bool,
+) -> Money:
+    """Return the shipping price implied by the shipping method assigned to the order.
+
+    The order is charged for shipping only when it has a shipping method priced in
+    its channel, an address to ship to and at least one line that requires shipping.
+    """
+    has_shipping_address = (
+        order.shipping_address_id is not None or order.shipping_address is not None
+    )
+    if (
+        shipping_channel_listing
+        and order.shipping_method_id
+        and has_shipping_address
+        and shipping_required
+    ):
+        return shipping_channel_listing.price
+    return zero_money(order.currency)
+
+
+def apply_shipping_voucher_to_base_price(order: Order) -> None:
+    """Discount the base shipping price with the shipping voucher assigned to order."""
+    shipping_discount = order.discounts.filter(
+        voucher__type=VoucherType.SHIPPING
+    ).first()
+    if not shipping_discount:
+        return
+
+    undiscounted_shipping_price = order.undiscounted_base_shipping_price
+    shipping_price = apply_discount_to_value(
+        value=shipping_discount.value,
+        value_type=shipping_discount.value_type,
+        currency=order.currency,
+        price_to_discount=undiscounted_shipping_price,
+    )
+    order.base_shipping_price = shipping_price
+    shipping_discount_amount = undiscounted_shipping_price - shipping_price
+    if shipping_discount.amount != shipping_discount_amount:
+        shipping_discount.amount = shipping_discount_amount
+        shipping_discount.save(update_fields=["amount_value"])
+
+
+def refresh_order_base_shipping_price(
+    order: Order,
+    lines: Iterable[OrderLine],
+    database_connection_name: str = settings.DATABASE_CONNECTION_DEFAULT_NAME,
+) -> None:
+    """Re-derive the base shipping price of a draft order.
+
+    The stored shipping price depends on the shipping method channel listing, the
+    shipping address and the lines that require shipping. All of them can change after
+    the shipping method has been assigned, so the price has to be re-derived whenever
+    the draft order prices are recalculated. Placed orders keep the price the customer
+    agreed to. Orders with no shipping method are left untouched - detaching the method
+    zeroes the price on its own.
+    """
+    if order.status != OrderStatus.DRAFT or not order.shipping_method_id:
+        return
+
+    shipping_channel_listing = (
+        ShippingMethodChannelListing.objects.using(database_connection_name)
+        .filter(
+            shipping_method_id=order.shipping_method_id,
+            channel_id=order.channel_id,
+        )
+        .first()
+    )
+
+    undiscounted_price = get_undiscounted_base_shipping_price(
+        order,
+        shipping_channel_listing,
+        shipping_required=any(line.is_shipping_required for line in lines),
+    )
+    if undiscounted_price == order.undiscounted_base_shipping_price:
+        return
+
+    order.undiscounted_base_shipping_price = undiscounted_price
+    order.base_shipping_price = undiscounted_price
+    apply_shipping_voucher_to_base_price(order)
 
 
 def recalculate_order_weight(order: Order, *, save: bool = False):


### PR DESCRIPTION
The shipping price stored on an order is derived from three inputs: the shipping method channel listing, the shipping address and the lines that require shipping. It was only computed when the shipping method changed, so adding the address or the first shippable line afterwards left the price at 0 forever - and the draft could then be completed with no shipping charged.

Re-derive it on every draft order price recalculation instead, in `process_order_prices` - the choke point both `fetch_order_prices_if_expired` and the price dataloader share, reached whenever any of the three inputs change. Placed orders keep the price the customer agreed to, and orders with no shipping method are left alone since detaching the method already zeroes the price.

The derivation moves from the GraphQL mutation mixin into the order domain layer so the calculation code can reuse it:
- `get_undiscounted_base_shipping_price`
- `apply_shipping_voucher_to_base_price` (was `update_shipping_discount`)
- `refresh_order_base_shipping_price`

`ShippingMethodUpdateMixin` now delegates to them; its `update_shipping_price` had no callers and is dropped.

Two tax webhook tests seeded a draft with a shipping price contradicting its shipping method listing - a state no mutation can produce - so they now set the listing price instead.
