### PR TITLE
Test shipping method IDs on order responses

### DIFF
--- a/saleor/tests/e2e/orders/test_cannot_fullfill_order_with_invalid_shipping_method.py
+++ b/saleor/tests/e2e/orders/test_cannot_fullfill_order_with_invalid_shipping_method.py
@@ -106,6 +106,8 @@ def test_cannot_fullfill_order_with_invalid_shipping_method_core_0203(
     )
 
     assert draft_order["order"]["deliveryMethod"]["id"] == us_shipping_method_id
+    assert draft_order["order"]["shippingMethod"]["id"] == us_shipping_method_id
+    assert draft_order["order"]["shippingMethod"]["__typename"] == "ShippingMethod"
 
     # Step 3 - Update order's shipping address for country PL
     draft_update = draft_order_update(

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -119,6 +119,10 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
           __typename
         }
       }
+      shippingMethod {
+        id
+        __typename
+      }
     }
   }
 }


### PR DESCRIPTION
I want to merge this change because order shipping method IDs should remain stable across the current `deliveryMethod` field and the deprecated `shippingMethod` field.

Fixes #13675.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

- [ ] Link to documentation:

# Pull Request Checklist

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined