### PR TITLE
Limit metadata mutation lists to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Fixes
 
+- `updateMetadata` and `deleteMetadata` now reject list inputs exceeding 100 items.
 - Fixed `appCreate` and `appUpdate` failing with an unhandled error when `permissions` was `null` or omitted. `appCreate` now creates an app with no permissions, and `appUpdate` leaves the app's existing permissions untouched. Passing an empty list to `appUpdate` still clears them.
 
 ### Deprecations

--- a/saleor/graphql/meta/mutations/delete_metadata.py
+++ b/saleor/graphql/meta/mutations/delete_metadata.py
@@ -7,7 +7,12 @@ from ...core import ResolveInfo
 from ...core.types import MetadataError, NonNullList
 from ..permissions import PUBLIC_META_PERMISSION_MAP
 from .base import BaseMetadataMutation
-from .utils import delete_metadata_keys, get_valid_metadata_instance
+from .utils import (
+    METADATA_LIST_INPUT_LIMIT,
+    delete_metadata_keys,
+    get_valid_metadata_instance,
+    validate_metadata_list_input_limit,
+)
 
 
 class DeleteMetadata(BaseMetadataMutation):
@@ -27,7 +32,9 @@ class DeleteMetadata(BaseMetadataMutation):
         )
         keys = NonNullList(
             graphene.String,
-            description="Metadata keys to delete.",
+            description=(
+                f"Metadata keys to delete. Max {METADATA_LIST_INPUT_LIMIT} items."
+            ),
             required=True,
         )
 
@@ -35,6 +42,7 @@ class DeleteMetadata(BaseMetadataMutation):
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, id: str, keys: list[str]
     ):
+        validate_metadata_list_input_limit(keys, field_name="keys")
         instance = cast(models.ModelWithMetadata, cls.get_instance(info, id=id))
         if instance:
             meta_instance = get_valid_metadata_instance(instance)

--- a/saleor/graphql/meta/mutations/update_metadata.py
+++ b/saleor/graphql/meta/mutations/update_metadata.py
@@ -8,7 +8,12 @@ from ...core.types import MetadataError, NonNullList
 from ..inputs import MetadataInput, MetadataInputDescription
 from ..permissions import PUBLIC_META_PERMISSION_MAP
 from .base import BaseMetadataMutation
-from .utils import get_valid_metadata_instance, update_metadata
+from .utils import (
+    METADATA_LIST_INPUT_LIMIT,
+    get_valid_metadata_instance,
+    update_metadata,
+    validate_metadata_list_input_limit,
+)
 
 
 class UpdateMetadata(BaseMetadataMutation):
@@ -28,7 +33,10 @@ class UpdateMetadata(BaseMetadataMutation):
         )
         input = NonNullList(
             MetadataInput,
-            description="Fields required to update the object's metadata.",
+            description=(
+                "Fields required to update the object's metadata. "
+                f"Max {METADATA_LIST_INPUT_LIMIT} items."
+            ),
             required=True,
         )
 
@@ -36,6 +44,7 @@ class UpdateMetadata(BaseMetadataMutation):
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, id: str, input: list
     ):
+        validate_metadata_list_input_limit(input, field_name="input")
         instance = cast(models.ModelWithMetadata, cls.get_instance(info, id=id))
         if instance:
             meta_instance = get_valid_metadata_instance(instance)

--- a/saleor/graphql/meta/mutations/utils.py
+++ b/saleor/graphql/meta/mutations/utils.py
@@ -11,6 +11,20 @@ from ....core.db.connection import allow_writer
 from ....core.db.expressions import PostgresJsonConcatenate
 from ....core.error_codes import MetadataErrorCode
 from ....core.models import ModelWithMetadata
+from ...core.validators import validate_limit_of_list_input
+
+METADATA_LIST_INPUT_LIMIT = 100
+
+
+def validate_metadata_list_input_limit(items, field_name: str) -> None:
+    """Reject oversized metadata list inputs before resolving or writing."""
+    if not items:
+        return
+    try:
+        validate_limit_of_list_input(items, METADATA_LIST_INPUT_LIMIT, field_name)
+    except ValidationError as error:
+        error.code = MetadataErrorCode.INVALID.value
+        raise ValidationError({field_name: error}) from error
 
 
 def get_valid_metadata_instance(instance) -> ModelWithMetadata:

--- a/saleor/graphql/meta/tests/mutations/test_metadata_list_input_limit.py
+++ b/saleor/graphql/meta/tests/mutations/test_metadata_list_input_limit.py
@@ -1,0 +1,80 @@
+import graphene
+
+from .....core.error_codes import MetadataErrorCode
+from ....tests.utils import get_graphql_content
+
+UPDATE_METADATA_MUTATION = """
+mutation UpdatePublicMetadata($id: ID!, $input: [MetadataInput!]!) {
+    updateMetadata(id: $id, input: $input) {
+        errors {
+            field
+            code
+            message
+        }
+        item {
+            ... on Checkout {
+                id
+            }
+        }
+    }
+}
+"""
+
+DELETE_METADATA_MUTATION = """
+mutation DeletePublicMetadata($id: ID!, $keys: [String!]!) {
+    deleteMetadata(id: $id, keys: $keys) {
+        errors {
+            field
+            code
+            message
+        }
+        item {
+            ... on Checkout {
+                id
+            }
+        }
+    }
+}
+"""
+
+
+def test_update_metadata_rejects_oversized_input(api_client, checkout):
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    checkout.metadata_storage.store_value_in_metadata({"existing": "value"})
+    checkout.metadata_storage.save(update_fields=["metadata"])
+    input_items = [{"key": f"key-{index}", "value": "value"} for index in range(101)]
+
+    response = api_client.post_graphql(
+        UPDATE_METADATA_MUTATION,
+        {"id": checkout_id, "input": input_items},
+    )
+
+    content = get_graphql_content(response)
+    errors = content["data"]["updateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "input"
+    assert errors[0]["code"] == MetadataErrorCode.INVALID.name
+    assert "100" in errors[0]["message"]
+    checkout.metadata_storage.refresh_from_db()
+    assert checkout.metadata_storage.metadata == {"existing": "value"}
+
+
+def test_delete_metadata_rejects_oversized_keys(api_client, checkout):
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    checkout.metadata_storage.store_value_in_metadata({"existing": "value"})
+    checkout.metadata_storage.save(update_fields=["metadata"])
+    keys = [f"key-{index}" for index in range(101)]
+
+    response = api_client.post_graphql(
+        DELETE_METADATA_MUTATION,
+        {"id": checkout_id, "keys": keys},
+    )
+
+    content = get_graphql_content(response)
+    errors = content["data"]["deleteMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "keys"
+    assert errors[0]["code"] == MetadataErrorCode.INVALID.name
+    assert "100" in errors[0]["message"]
+    checkout.metadata_storage.refresh_from_db()
+    assert checkout.metadata_storage.metadata == {"existing": "value"}

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19997,7 +19997,7 @@ type Mutation {
     """ID or token (for Order and Checkout) of an object to update."""
     id: ID!
 
-    """Metadata keys to delete."""
+    """Metadata keys to delete. Max 100 items."""
     keys: [String!]!
   ): DeleteMetadata
 
@@ -20021,7 +20021,7 @@ type Mutation {
     """ID or token (for Order and Checkout) of an object to update."""
     id: ID!
 
-    """Fields required to update the object's metadata."""
+    """Fields required to update the object's metadata. Max 100 items."""
     input: [MetadataInput!]!
   ): UpdateMetadata
 


### PR DESCRIPTION
I want to merge this change because `updateMetadata` and `deleteMetadata` accept arbitrarily long metadata lists, allowing oversized Checkout requests to do excessive work.

The mutations now reject `input` and `keys` lists over 100 items before resolving or writing metadata.

Fixes #19210

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined