### PR TITLE
Refresh order charge and authorize statuses when prices are recalculated

### DIFF
--- a/saleor/graphql/order/tests/integration/test_draft_order.py
+++ b/saleor/graphql/order/tests/integration/test_draft_order.py
@@ -1,10 +1,16 @@
+from decimal import Decimal
+from unittest import mock
+
 import graphene
 import pytest
 
 from .....order import OrderStatus
+from .....payment import TransactionEventType
+from .....payment.interface import TransactionSessionResult
 from ....account.tests.mutations.permission_group.test_permission_group_update import (
     PERMISSION_GROUP_UPDATE_MUTATION,
 )
+from ....order.enums import OrderChargeStatusEnum
 from ....tests.utils import assert_no_permission, get_graphql_content
 from ..mutations.test_draft_order_complete import DRAFT_ORDER_COMPLETE_MUTATION
 from ..mutations.test_draft_order_create import DRAFT_ORDER_CREATE_MUTATION
@@ -156,3 +162,231 @@ def test_user_cannot_manage_draft_order_after_losing_access_to_channel(
 
     # then
     assert_no_permission(response)
+
+
+DRAFT_ORDER_CREATE = """
+mutation draftOrderCreate($input: DraftOrderCreateInput!) {
+  draftOrderCreate(input: $input) {
+    errors { field code message }
+    order { id }
+  }
+}
+"""
+
+ORDER_LINES_CREATE = """
+mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]!) {
+  orderLinesCreate(id: $id, input: $input) {
+    errors { field code message }
+    orderLines { id }
+  }
+}
+"""
+
+ORDER_LINE_DELETE = """
+mutation orderLineDelete($id: ID!) {
+  orderLineDelete(id: $id) {
+    errors { field code message }
+  }
+}
+"""
+
+DRAFT_ORDER_UPDATE_ADDRESSES = """
+mutation draftOrderUpdate($id: ID!, $input: DraftOrderInput!) {
+  draftOrderUpdate(id: $id, input: $input) {
+    errors { field code message }
+  }
+}
+"""
+
+ORDER_UPDATE_SHIPPING = """
+mutation orderUpdateShipping($order: ID!, $input: OrderUpdateShippingInput!) {
+  orderUpdateShipping(order: $order, input: $input) {
+    errors { field code message }
+  }
+}
+"""
+
+TRANSACTION_INITIALIZE = """
+mutation transactionInitialize(
+  $id: ID!, $amount: PositiveDecimal!, $paymentGateway: PaymentGatewayToInitialize!
+) {
+  transactionInitialize(id: $id, amount: $amount, paymentGateway: $paymentGateway) {
+    errors { field code message }
+    transaction { id chargedAmount { amount } }
+  }
+}
+"""
+
+ORDER_TOTAL_QUERY = """
+query order($id: ID!) {
+  order(id: $id) {
+    total { gross { amount } }
+  }
+}
+"""
+
+ORDER_CHARGE_STATUS_QUERY = """
+query order($id: ID!) {
+  order(id: $id) {
+    chargeStatus
+  }
+}
+"""
+
+DRAFT_ORDER_COMPLETE = """
+mutation draftOrderComplete($id: ID!) {
+  draftOrderComplete(id: $id) {
+    errors { field code message }
+    order { id chargeStatus total { gross { amount } } }
+  }
+}
+"""
+
+
+def _create_order_line(api_client, order_id, variant_id, quantity):
+    response = api_client.post_graphql(
+        ORDER_LINES_CREATE,
+        {
+            "id": order_id,
+            "input": [{"variantId": variant_id, "quantity": quantity}],
+        },
+    )
+    data = get_graphql_content(response)["data"]["orderLinesCreate"]
+    assert data["errors"] == []
+    return data["orderLines"][0]["id"]
+
+
+def _set_shipping_method(api_client, order_id, shipping_method):
+    response = api_client.post_graphql(
+        ORDER_UPDATE_SHIPPING,
+        {
+            "order": order_id,
+            "input": {
+                "shippingMethod": graphene.Node.to_global_id(
+                    "ShippingMethod", shipping_method.pk
+                )
+            },
+        },
+    )
+    assert get_graphql_content(response)["data"]["orderUpdateShipping"]["errors"] == []
+
+
+def _fetch_total(api_client, order_id):
+    """Read the order total, which also persists the recalculated prices."""
+    response = api_client.post_graphql(ORDER_TOTAL_QUERY, {"id": order_id})
+    order_data = get_graphql_content(response)["data"]["order"]
+    return Decimal(str(order_data["total"]["gross"]["amount"]))
+
+
+def _fetch_charge_status(api_client, order_id):
+    response = api_client.post_graphql(ORDER_CHARGE_STATUS_QUERY, {"id": order_id})
+    return get_graphql_content(response)["data"]["order"]["chargeStatus"]
+
+
+@pytest.mark.integration
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_draft_order_charge_status_when_total_changes_after_the_order_is_charged(
+    mocked_initialize,
+    staff_api_client,
+    user_api_client,
+    permission_group_manage_orders,
+    channel_USD,
+    product,
+    shipping_method,
+    graphql_address_data,
+    webhook_app,
+    transaction_session_response,
+):
+    """Charge status calculated against a stale draft total is refreshed on complete.
+
+    A draft order is charged for the total the customer was shown, while the order
+    total stored in the database is lower, as the lines have been changed in the
+    meantime. The charge status calculated at that point is `OVERCHARGED`, and the
+    completion recalculation, which brings the total back to the charged amount, has
+    to refresh it.
+    """
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    variant_id = graphene.Node.to_global_id(
+        "ProductVariant", product.variants.first().pk
+    )
+    app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = app_identifier
+    webhook_app.save(update_fields=["identifier"])
+
+    # when
+    # create an empty draft order
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_CREATE,
+        {
+            "input": {
+                "channelId": graphene.Node.to_global_id("Channel", channel_USD.pk),
+                "userEmail": "customer@example.com",
+            }
+        },
+    )
+    data = get_graphql_content(response)["data"]["draftOrderCreate"]
+    assert data["errors"] == []
+    order_id = data["order"]["id"]
+
+    # add the lines, the addresses and the shipping method
+    line_id = _create_order_line(staff_api_client, order_id, variant_id, quantity=2)
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_UPDATE_ADDRESSES,
+        {
+            "id": order_id,
+            "input": {
+                "shippingAddress": graphql_address_data,
+                "billingAddress": graphql_address_data,
+            },
+        },
+    )
+    assert get_graphql_content(response)["data"]["draftOrderUpdate"]["errors"] == []
+    _set_shipping_method(staff_api_client, order_id, shipping_method)
+
+    # the total the customer is charged for
+    amount_to_charge = _fetch_total(staff_api_client, order_id)
+
+    # drop the line, so that the stored total no longer covers the charged amount
+    response = staff_api_client.post_graphql(ORDER_LINE_DELETE, {"id": line_id})
+    assert get_graphql_content(response)["data"]["orderLineDelete"]["errors"] == []
+    assert _fetch_total(staff_api_client, order_id) < amount_to_charge
+
+    # charge the order for the amount the customer was shown
+    gateway_response = transaction_session_response.copy()
+    gateway_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
+    gateway_response["amount"] = str(amount_to_charge)
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=app_identifier, response=gateway_response
+    )
+    response = user_api_client.post_graphql(
+        TRANSACTION_INITIALIZE,
+        {
+            "id": order_id,
+            "amount": amount_to_charge,
+            "paymentGateway": {"id": app_identifier, "data": None},
+        },
+    )
+    transaction_data = get_graphql_content(response)["data"]["transactionInitialize"]
+    assert transaction_data["errors"] == []
+    assert (
+        Decimal(str(transaction_data["transaction"]["chargedAmount"]["amount"]))
+        == amount_to_charge
+    )
+
+    assert (
+        _fetch_charge_status(staff_api_client, order_id)
+        == OrderChargeStatusEnum.OVERCHARGED.name
+    )
+
+    # bring the line and the shipping method back, so that the order total matches
+    # the charged amount again
+    _create_order_line(staff_api_client, order_id, variant_id, quantity=2)
+    _set_shipping_method(staff_api_client, order_id, shipping_method)
+
+    # then
+    response = staff_api_client.post_graphql(DRAFT_ORDER_COMPLETE, {"id": order_id})
+    data = get_graphql_content(response)["data"]["draftOrderComplete"]
+    assert data["errors"] == []
+    assert Decimal(str(data["order"]["total"]["gross"]["amount"])) == amount_to_charge
+    assert data["order"]["chargeStatus"] == OrderChargeStatusEnum.FULL.name

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -58,6 +58,7 @@ from .utils import (
     calculate_draft_order_line_price_expiration_date,
     log_address_if_validation_skipped_for_order,
     order_info_for_logs,
+    updates_amounts_for_order,
 )
 
 if TYPE_CHECKING:
@@ -138,22 +139,36 @@ def process_order_prices(
                 # to avoid overwriting changes made by the other requests. Skipping the save function does not affect
                 # the query response because it returns the adjusted order and line info objects.
                 if locked_order.updated_at == order.updated_at:
-                    order.save(
-                        update_fields=[
-                            "subtotal_net_amount",
-                            "subtotal_gross_amount",
-                            "total_net_amount",
-                            "total_gross_amount",
-                            "undiscounted_total_net_amount",
-                            "undiscounted_total_gross_amount",
-                            "shipping_price_net_amount",
-                            "shipping_price_gross_amount",
-                            "base_shipping_price_amount",
-                            "shipping_tax_rate",
-                            "should_refresh_prices",
-                            "tax_error",
-                        ]
-                    )
+                    update_fields = [
+                        "subtotal_net_amount",
+                        "subtotal_gross_amount",
+                        "total_net_amount",
+                        "total_gross_amount",
+                        "undiscounted_total_net_amount",
+                        "undiscounted_total_gross_amount",
+                        "shipping_price_net_amount",
+                        "shipping_price_gross_amount",
+                        "base_shipping_price_amount",
+                        "shipping_tax_rate",
+                        "should_refresh_prices",
+                        "tax_error",
+                    ]
+                    if order.total_charged_amount or order.total_authorized_amount:
+                        # Charge and authorize statuses are derived from the order
+                        # total, so an order that has funds attached needs them
+                        # refreshed together with it. The `updated_at` check above
+                        # guarantees that the charged and authorized amounts have not
+                        # been modified by another process in the meantime.
+                        updates_amounts_for_order(order, save=False)
+                        update_fields.extend(
+                            [
+                                "total_charged_amount",
+                                "charge_status",
+                                "total_authorized_amount",
+                                "authorize_status",
+                            ]
+                        )
+                    order.save(update_fields=update_fields)
                     order.lines.bulk_update(
                         lines,
                         [


### PR DESCRIPTION
## Why this matters

A merchant reported an order stuck showing **Overcharged** even though the customer paid exactly the order total. Everything in the API agreed with itself — `total.gross == totalCharged`, `grantedRefunds: []`, `totalBalance: 0`, a single transaction with a single `pspReference` — and yet the stored `chargeStatus` said `OVERCHARGED`.

This is not cosmetic. `Order.chargeStatus` is a denormalized column, not a computed field, so a wrong value:

- shows the order as a payment discrepancy in the Dashboard (order list badge, priority marker),
- is queryable, so it silently poisons `OrderFilterInput.chargeStatus` and any staff workflow or app automation that reconciles payments,
- **never self-heals** — the status is only recomputed when a payment event arrives, and an order that is already paid gets no further events. Once the order leaves draft status it is frozen in the wrong state forever.

Staff end up investigating, or refunding, a discrepancy that does not exist.

## Root cause

`charge_status` and `authorize_status` are derived from `total_gross_amount`. For orders in `ORDER_EDITABLE_STATUS` the stored total is *deliberately allowed to be stale* — the draft mutations only flip `should_refresh_prices` (`invalidate_order_prices`), and the real total is materialized lazily on read or at completion.

`process_order_prices()` persisted the recalculated totals with an `update_fields` list that omitted both statuses:

```python
order.save(update_fields=[
    "subtotal_net_amount", ..., "total_gross_amount", ..., "tax_error",
    # charge_status / authorize_status not here
])
```

So any recalculation that moved the total left the statuses holding a verdict computed against the previous one.

The reported order hit this at `draftOrderComplete`: the draft was charged for the amount the customer was shown while the stored total was still lower, which correctly produced `OVERCHARGED` at that moment; completion then recalculated the total up to the charged amount and left the status behind. The order flipped to `UNFULFILLED` and froze.

## Reproduction (GraphQL only)

| # | Operation | Effect |
|---|---|---|
| 1 | `draftOrderCreate` (channel + userEmail) | empty draft, total `0` |
| 2 | `orderLinesCreate` | prices invalidated, stored total still stale |
| 3 | `draftOrderUpdate` (shipping + billing address) | prices invalidated |
| 4 | `orderUpdateShipping` | prices invalidated |
| 5 | query `order { total }` | client learns the amount to charge; value gets persisted |
| 6 | `orderLineDelete`, then query `total` | real total drops below the amount from step 5 |
| 7 | `transactionInitialize` → `CHARGE_SUCCESS` for the step-5 amount | charged > stored total → `chargeStatus: OVERCHARGED` |
| 8 | `orderLinesCreate` + `orderUpdateShipping` | real total is back at the charged amount; stored total still low |
| 9 | `draftOrderComplete` | total recalculated up to the charged amount |

**Actual:** `chargeStatus: OVERCHARGED`, with `total.gross == totalCharged` and no granted refunds.
**Expected:** `chargeStatus: FULL`.

The same defect fires in the other direction too (a total raised after payment keeps a stale `FULL` instead of `PARTIAL`) — it is not specific to `OVERCHARGED`.

## The fix

Recalculate both derived statuses through `updates_amounts_for_order` in the same save that writes the new totals, and add the four fields to `update_fields`.

The recalculation is **skipped when the order has neither charged nor authorized funds**, so it costs no extra queries in the overwhelmingly common case, and never-paid orders keep exactly their current behaviour (no status writes at all).

## Notes for the reviewer

- **Why the guard is on "has funds" rather than "the total changed."** The intuitive check — compare the recalculated total against the previous one — does not work here. By the time `process_order_prices` runs, the new total is *already in the database*: `process_order_promotion` → `handle_order_promotion` persists it earlier inside `fetch_order_prices_if_expired`. Neither the in-memory value nor the locked row is a usable "before" snapshot at that point. `total_charged_amount` / `total_authorized_amount` are columns the price recalculation never touches, so they are a reliable trigger.
- **Query cost.** `updates_amounts_for_order` costs 3 queries (payments, transactions, granted refunds). Applying it unconditionally pushed `saleor/order/tests/benchmark/test_fetch_order_prices.py` from 29 to 32 queries; with the guard it is back to 29. The cost only lands on orders that actually have money attached, and only when a recalculation is already happening.
- **Correctness of the recompute.** It runs inside the existing `locked_order.updated_at == order.updated_at` optimistic-lock branch, which guarantees no other process has modified the charged/authorized amounts since the order was read — so the in-memory values used for the calculation are consistent.
- **Existing bad rows are not repaired.** This change prevents new occurrences only. Orders already frozen in a wrong status need a data migration that recomputes the status for suspect rows (`charge_status = OVERCHARGED AND total_charged_amount <= total_gross_amount`), following the precedent in `saleor/order/migrations/0165_fix_order_charge_status_with_transactions.py`. Happy to add it here or as a follow-up — tell me which you prefer.
- **Test.** The regression test is a mutation-only integration test (`saleor/graphql/order/tests/integration/test_draft_order.py`) walking the table above end to end. It performs no direct model writes, and the `OVERCHARGED` precondition is produced by the server rather than set by the test. It asserts on the `Order.chargeStatus` field that actually failed. Without the fix it reports `assert 'OVERCHARGED' == 'FULL'`.
- **Suite:** `saleor/order` + `saleor/graphql/order` — 2418 passed, benchmark query counts unchanged.
- No CHANGELOG entry here — this is intended to be ported back.