### PR TITLE
feat: deprecate product rating API and fix attribute sorting bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ permissions.
 - Added `Order.transactionSummaries` field returning a `TransactionSummary` per payment transaction that moved any money. Unlike `Order.transactions` it requires no permission, so storefronts can show the payment history of an order; it exposes only `createdAt`, `paymentMethodDetails` and the amounts, with the card digits and expiration date stripped.
 - Deprecated the `MANAGE_OBSERVABILITY` permission (`PermissionEnum`). The observability feature is no longer supported and the permission will be removed in Saleor 3.24.
 - Added `ID` sort field to `ProductVariantSortField`. Sorting by the variant primary key gives a stable order and stable cursors, unlike `LAST_MODIFIED_AT`, whose value changes when a variant is updated during pagination.
+- Sorting products by a numeric attribute (`products(sortBy: { attributeId: ... })`) now orders by the numeric value instead of its string representation, so `10` no longer sorts before `9`.
 
 ### Webhooks
 
@@ -131,6 +132,10 @@ Validation is now performed on the frontend (Dashboard). This change increases v
 - Deprecate export mutations (`exportProducts`, `exportGiftCards`, `exportVoucherCodes`). All data can be fetched via the GraphQL API and parsed into the desired format by apps or external tools.
 - Deprecate the export webhook event types emitted by those mutations: `PRODUCT_EXPORT_COMPLETED`, `GIFT_CARD_EXPORT_COMPLETED` and `VOUCHER_CODE_EXPORT_COMPLETED` (`WebhookEventTypeEnum`, `WebhookEventTypeAsyncEnum`, `WebhookSampleEventTypeEnum`), along with the `ProductExportCompleted`, `GiftCardExportCompleted` and `VoucherCodeExportCompleted` subscription types.
 - Deprecate `voucher` input field on `DraftOrderInput` and `DraftOrderCreateInput`. Use `voucherCode` instead.
+- Deprecate the product rating API. Model ratings with a numeric attribute instead: create a numeric attribute, assign it to the relevant product types, and set the value per product. The following are deprecated:
+  - Field `Product.rating`.
+  - Input field `rating` on `ProductInput`, `ProductCreateInput` and `ProductBulkCreateInput`.
+  - Sort field `RATING` on `ProductOrderField`.
 - Deprecate the preorder API. Model pre-sales with regular stock instead: create the planned quantity in a warehouse, or set `trackInventory` to `false` to sell without a stock limit. The following are deprecated:
   - Mutation `productVariantPreorderDeactivate`.
   - Types `PreorderData` (and `ProductVariant.preorder`) and `PreorderThreshold` (and `ProductVariantChannelListing.preorderThreshold`).

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -46,6 +46,14 @@ DEPRECATED_PREORDER_TYPE_DESCRIPTION = "\n\nDEPRECATED: " + DEPRECATED_PREORDER
 # but only when the description carries the DEPRECATED_IN_3X_INPUT marker verbatim.
 DEPRECATED_PREORDER_INPUT = f"{DEPRECATED_IN_3X_INPUT} {DEPRECATED_PREORDER}"
 
+DEPRECATED_PRODUCT_RATING = (
+    "Product rating is deprecated and will be removed. Use a numeric attribute instead."
+)
+
+DEPRECATED_PRODUCT_RATING_INPUT = (
+    f"{DEPRECATED_IN_3X_INPUT} {DEPRECATED_PRODUCT_RATING}"
+)
+
 
 PREVIEW_FEATURE = (
     "\n\nNote: this API is currently in Feature Preview and can be subject to "

--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -24,7 +24,7 @@ from ....webhook.utils import get_webhooks_for_event
 from ...attribute.types import AttributeValueInput
 from ...attribute.utils.attribute_assignment import AttributeAssignmentMixin
 from ...core.context import ChannelContext
-from ...core.descriptions import RICH_CONTENT
+from ...core.descriptions import DEPRECATED_PRODUCT_RATING_INPUT, RICH_CONTENT
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.enums import ErrorPolicyEnum
 from ...core.fields import JSONString
@@ -134,7 +134,11 @@ class ProductBulkCreateInput(ProductCreateInput):
     )
     seo = SeoInput(description="Search engine optimization fields.")
     weight = WeightScalar(description="Weight of the Product.", required=False)
-    rating = graphene.Float(description="Defines the product rating value.")
+    rating = graphene.Float(
+        description=(
+            f"Defines the product rating value.{DEPRECATED_PRODUCT_RATING_INPUT}"
+        )
+    )
     metadata = NonNullList(
         MetadataInput,
         description="Fields required to update the product metadata. "

--- a/saleor/graphql/product/mutations/product/product_create.py
+++ b/saleor/graphql/product/mutations/product/product_create.py
@@ -12,6 +12,7 @@ from ....core import ResolveInfo
 from ....core.context import ChannelContext
 from ....core.descriptions import (
     DEPRECATED_IN_3X_INPUT,
+    DEPRECATED_PRODUCT_RATING_INPUT,
     RICH_CONTENT,
 )
 from ....core.doc_category import DOC_CATEGORY_PRODUCTS
@@ -63,7 +64,11 @@ class ProductInput(BaseInputObjectType):
     )
     seo = SeoInput(description="Search engine optimization fields.")
     weight = WeightScalar(description="Weight of the Product.", required=False)
-    rating = graphene.Float(description="Defines the product rating value.")
+    rating = graphene.Float(
+        description=(
+            f"Defines the product rating value.{DEPRECATED_PRODUCT_RATING_INPUT}"
+        )
+    )
     metadata = NonNullList(
         MetadataInput,
         description="Fields required to update the product metadata. "

--- a/saleor/graphql/product/sorters.py
+++ b/saleor/graphql/product/sorters.py
@@ -23,7 +23,11 @@ from ...product.models import (
     Product,
     ProductChannelListing,
 )
-from ..core.descriptions import ADDED_IN_323, CHANNEL_REQUIRED
+from ..core.descriptions import (
+    ADDED_IN_323,
+    CHANNEL_REQUIRED,
+    DEPRECATED_PRODUCT_RATING,
+)
 from ..core.doc_category import DOC_CATEGORY_PRODUCTS
 from ..core.types import BaseEnum, ChannelSortInputObjectType, SortInputObjectType
 
@@ -211,6 +215,7 @@ class ProductOrderField(BaseEnum):
             ProductOrderField.DATE.name: "Use `LAST_MODIFIED` instead.",  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
             ProductOrderField.PUBLICATION_DATE.name: "Use `PUBLISHED_AT` instead.",  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
             ProductOrderField.LAST_MODIFIED.name: "Use `LAST_MODIFIED_AT` instead.",  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
+            ProductOrderField.RATING.name: DEPRECATED_PRODUCT_RATING,  # type: ignore[attr-defined] # graphene.Enum is not typed # noqa: E501
         }
         if self.name in deprecations:
             return deprecations[self.name]

--- a/saleor/graphql/product/tests/queries/test_products_query.py
+++ b/saleor/graphql/product/tests/queries/test_products_query.py
@@ -1488,5 +1488,6 @@ def test_search_product_sort_by_attribute_returns_correct_cursor(
 
     # Ref saleor.product.managers.ProductsQueryset.sort_by_attribute
     # First field stores the flag to determine if product has assigned attribute values
-    # Second is the list of attribute values as string
-    assert ["0", attr_value.name, product.name] == cursor_data
+    # Second is the numeric value, set only for attributes of numeric input type
+    # Third is the list of attribute values as string
+    assert ["0", None, attr_value.name, product.name] == cursor_data

--- a/saleor/graphql/product/tests/test_product_sorting_attributes.py
+++ b/saleor/graphql/product/tests/test_product_sorting_attributes.py
@@ -19,12 +19,19 @@ query products(
   $attributeId: ID
   $direction: OrderDirection!
   $channel: String
+  $first: Int = 100
+  $after: String
 ) {
   products(
-    first: 100,
+    first: $first,
+    after: $after,
     channel: $channel,
     sortBy: { field: $field, attributeId: $attributeId, direction: $direction }
   ) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
     edges {
       node {
         name
@@ -692,3 +699,171 @@ def test_sort_product_by_attribute_using_attribute_having_no_products(
 
     assert len(products) == product_models.Product.objects.count()
     assert products[0]["node"]["name"] == expected_first_product.name
+
+
+# Values whose numeric order differs from their lexicographic order. Fractional, so
+# that cursors have to round-trip a non-integral float.
+NUMERIC_VALUES = (2.5, 9.5, 10.25, 100.5)
+
+
+def _publish_product(name, product_type, category, channel):
+    product = product_models.Product.objects.create(
+        name=name,
+        slug=name.lower().replace(" ", "-"),
+        product_type=product_type,
+        category=category,
+    )
+    product_models.ProductChannelListing.objects.create(
+        product=product,
+        channel=channel,
+        is_published=True,
+        visible_in_listings=True,
+    )
+    variant = product_models.ProductVariant.objects.create(
+        product=product, sku=product.slug
+    )
+    product_models.ProductVariantChannelListing.objects.create(
+        variant=variant,
+        channel=channel,
+        price_amount=Decimal(10),
+        cost_price_amount=Decimal(1),
+        currency=channel.currency_code,
+    )
+    return product
+
+
+def _numeric_attribute_value(attribute, number):
+    return attribute_models.AttributeValue.objects.create(
+        attribute=attribute,
+        name=str(number),
+        slug=str(number),
+        numeric=number,
+    )
+
+
+def _sort_products_by_attribute(api_client, attribute, direction, channel):
+    variables = {
+        "attributeId": graphene.Node.to_global_id("Attribute", attribute.pk),
+        "direction": direction,
+        "channel": channel.slug,
+    }
+    response = get_graphql_content(
+        api_client.post_graphql(QUERY_SORT_PRODUCTS_BY_ATTRIBUTE, variables)
+    )
+    return [edge["node"]["name"] for edge in response["data"]["products"]["edges"]]
+
+
+@pytest.fixture
+def numeric_product_type(numeric_attribute):
+    product_type = product_models.ProductType.objects.create(
+        name="Rated", slug="rated", has_variants=False
+    )
+    product_type.product_attributes.add(numeric_attribute)
+    return product_type
+
+
+@pytest.fixture
+def products_with_numeric_attribute(
+    numeric_attribute, numeric_product_type, category, channel_USD
+):
+    for number in NUMERIC_VALUES:
+        product = _publish_product(
+            f"Product {number}", numeric_product_type, category, channel_USD
+        )
+        associate_attribute_values_to_instance(
+            product,
+            {
+                numeric_attribute.pk: [
+                    _numeric_attribute_value(numeric_attribute, number)
+                ]
+            },
+        )
+    return numeric_attribute
+
+
+@pytest.mark.parametrize("descending", [False, True])
+def test_sort_product_by_numeric_attribute(
+    api_client, products_with_numeric_attribute, descending, channel_USD
+):
+    # given
+    attribute = products_with_numeric_attribute
+    expected_names = [
+        f"Product {number}" for number in sorted(NUMERIC_VALUES, reverse=descending)
+    ]
+
+    # when
+    names = _sort_products_by_attribute(
+        api_client, attribute, "DESC" if descending else "ASC", channel_USD
+    )
+
+    # then
+    assert names == expected_names
+
+
+@pytest.mark.parametrize("descending", [False, True])
+def test_sort_product_by_numeric_attribute_without_assigned_values(
+    api_client,
+    numeric_attribute,
+    numeric_product_type,
+    category,
+    channel_USD,
+    descending,
+):
+    """Rank products with a value first, then valueless, then unrelated types."""
+    # given
+    other_product_type = product_models.ProductType.objects.create(
+        name="Unrated", slug="unrated", has_variants=False
+    )
+
+    with_value = _publish_product(
+        "With value", numeric_product_type, category, channel_USD
+    )
+    associate_attribute_values_to_instance(
+        with_value,
+        {numeric_attribute.pk: [_numeric_attribute_value(numeric_attribute, 7)]},
+    )
+    _publish_product("Without value", numeric_product_type, category, channel_USD)
+    _publish_product("Other type", other_product_type, category, channel_USD)
+
+    expected_names = ["With value", "Without value", "Other type"]
+    if descending:
+        expected_names.reverse()
+
+    # when
+    names = _sort_products_by_attribute(
+        api_client, numeric_attribute, "DESC" if descending else "ASC", channel_USD
+    )
+
+    # then
+    assert names == expected_names
+
+
+def test_sort_product_by_numeric_attribute_paginates_in_numeric_order(
+    api_client, products_with_numeric_attribute, channel_USD
+):
+    """Ensure the float sort value survives the cursor round-trip."""
+    # given
+    attribute = products_with_numeric_attribute
+    page_size = 2
+    expected_names = [f"Product {number}" for number in sorted(NUMERIC_VALUES)]
+    variables = {
+        "attributeId": graphene.Node.to_global_id("Attribute", attribute.pk),
+        "direction": "ASC",
+        "channel": channel_USD.slug,
+        "first": page_size,
+        "after": None,
+    }
+
+    # when
+    collected_names = []
+    for _ in range(len(NUMERIC_VALUES) // page_size):
+        response = get_graphql_content(
+            api_client.post_graphql(QUERY_SORT_PRODUCTS_BY_ATTRIBUTE, variables)
+        )
+        products = response["data"]["products"]
+        collected_names += [edge["node"]["name"] for edge in products["edges"]]
+        variables["after"] = products["pageInfo"]["endCursor"]
+
+    # then
+    assert collected_names == expected_names
+    assert products["pageInfo"]["hasNextPage"] is False

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -71,6 +71,7 @@ from ...core.descriptions import (
     DEPRECATED_IN_3X_INPUT,
     DEPRECATED_PREORDER,
     DEPRECATED_PREORDER_TYPE_DESCRIPTION,
+    DEPRECATED_PRODUCT_RATING,
     RICH_CONTENT,
 )
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
@@ -958,7 +959,10 @@ class Product(ChannelContextType[models.Product]):
     default_variant = graphene.Field(
         ProductVariant, description="Default variant of the product."
     )
-    rating = graphene.Float(description="Rating of the product.")
+    rating = graphene.Float(
+        description="Rating of the product.",
+        deprecation_reason=DEPRECATED_PRODUCT_RATING,
+    )
     channel = graphene.String(
         description=(
             "Channel given to retrieve this product. Also used by federation "

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4140,7 +4140,7 @@ type Product implements Node & ObjectWithMetadata & ObjectWithAttributes @doc(ca
   defaultVariant: ProductVariant
 
   """Rating of the product."""
-  rating: Float
+  rating: Float @deprecated(reason: "Product rating is deprecated and will be removed. Use a numeric attribute instead.")
 
   """
   Channel given to retrieve this product. Also used by federation gateway to resolve this object in a federated query.
@@ -4914,7 +4914,7 @@ enum ProductOrderField @doc(category: "Products") {
   COLLECTION
 
   """Sort products by rating."""
-  RATING
+  RATING @deprecated(reason: "Product rating is deprecated and will be removed. Use a numeric attribute instead.")
 
   """Sort products by creation date."""
   CREATED_AT
@@ -25159,7 +25159,7 @@ input ProductCreateInput @doc(category: "Products") {
   weight: WeightScalar
 
   """Defines the product rating value."""
-  rating: Float
+  rating: Float @deprecated(reason: "Product rating is deprecated and will be removed. Use a numeric attribute instead.")
 
   """
   Fields required to update the product metadata. Can be read by any API client authorized to read the object it's attached to.
@@ -25376,7 +25376,7 @@ input ProductBulkCreateInput @doc(category: "Products") {
   weight: WeightScalar
 
   """Defines the product rating value."""
-  rating: Float
+  rating: Float @deprecated(reason: "Product rating is deprecated and will be removed. Use a numeric attribute instead.")
 
   """
   Fields required to update the product metadata. Can be read by any API client authorized to read the object it's attached to.
@@ -25659,7 +25659,7 @@ input ProductInput @doc(category: "Products") {
   weight: WeightScalar
 
   """Defines the product rating value."""
-  rating: Float
+  rating: Float @deprecated(reason: "Product rating is deprecated and will be removed. Use a numeric attribute instead.")
 
   """
   Fields required to update the product metadata. Can be read by any API client authorized to read the object it's attached to.

--- a/saleor/product/managers.py
+++ b/saleor/product/managers.py
@@ -11,6 +11,7 @@ from django.db.models import (
     Exists,
     ExpressionWrapper,
     F,
+    Min,
     OuterRef,
     Q,
     Subquery,
@@ -175,12 +176,21 @@ class ProductsQueryset(models.QuerySet):
                 concatenated_values_order=Value(
                     None, output_field=models.IntegerField()
                 ),
+                numeric_value=Value(None, output_field=models.FloatField()),
                 concatenated_values=Value(None, output_field=models.CharField()),
             )
 
         qs = qs.annotate(
             # Implicit `GROUP BY` required for the `StringAgg` aggregation
             grouped_ids=Count("id"),
+            # Numeric attributes must sort by their value, not by its string
+            # representation, otherwise "10" would come before "9". The aggregate
+            # reuses the join `concatenated_values` already needs and stays `NULL`
+            # for every other input type, making it a no-op for them.
+            numeric_value=Min(
+                "attributevalues__value__numeric",
+                filter=Q(attributevalues__value__attribute_id=attribute_pk),
+            ),
             # String aggregation of the attribute's values to efficiently sort them
             concatenated_values=Case(
                 # If the product has no association data but has
@@ -232,6 +242,7 @@ class ProductsQueryset(models.QuerySet):
         ordering = "-" if descending else ""
         return qs.order_by(
             f"{ordering}concatenated_values_order",
+            f"{ordering}numeric_value",
             f"{ordering}concatenated_values",
             f"{ordering}name",
         )

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -266,7 +266,12 @@ class Product(SeoModel, ModelWithMetadata, ModelWithExternalReference):
 
     @staticmethod
     def sort_by_attribute_fields() -> list:
-        return ["concatenated_values_order", "concatenated_values", "name"]
+        return [
+            "concatenated_values_order",
+            "numeric_value",
+            "concatenated_values",
+            "name",
+        ]
 
 
 class ProductTranslation(SeoModelTranslationWithSlug):


### PR DESCRIPTION
When asked by merchant about product rating, I recommended to use numeric attribute instead - product rating is rather legacy thing and can be easily replaced.

Once I did that I realized there is a bug in numeric attribute sorting (lexical sorting is incorrect for numbers) - so I fixed that 

I decided to keep it in a single PR because bug fix is a few lines of code

